### PR TITLE
fix column order :bug:

### DIFF
--- a/mdtk/midi.py
+++ b/mdtk/midi.py
@@ -85,7 +85,7 @@ def midi_to_df(midi_path):
                           'pitch': note.pitch,
                           'dur': (note.end - note.start) * 1000})
 
-    df = pd.DataFrame(notes)
+    df = pd.DataFrame(notes)[COLNAMES]
     df = df.sort_values(COLNAMES)
     return df.reset_index(drop=True)
 

--- a/mdtk/midi.py
+++ b/mdtk/midi.py
@@ -9,6 +9,9 @@ import pretty_midi
 
 
 
+COLNAMES = ['onset', 'track', 'pitch', 'dur']
+
+
 
 def midi_dir_to_csv(midi_dir_path, csv_dir_path):
     """
@@ -17,14 +20,14 @@ def midi_dir_to_csv(midi_dir_path, csv_dir_path):
     It will create any necessary directories for the csv files, and will
     create one csv per MIDI file, where the 'mid' extension is replaced with
     'csv'.
-    
+
     Parameters
     ----------
     midi_dir_path : string
         The path of a directory which contains any number of MIDI files with
         extension 'mid'. The directory is not searched recursively, and any
         files with a different extension are ignored.
-        
+
     csv_dir_path : string
         The path of the directory to write out each csv to. If it does not
         exist, it will be created.
@@ -35,34 +38,32 @@ def midi_dir_to_csv(midi_dir_path, csv_dir_path):
         midi_to_csv(midi_path, csv_path)
 
 
-
 def midi_to_csv(midi_path, csv_path):
     """
     Convert a MIDI file into a csv file.
-    
+
     Parameters
     ----------
     midi_path : string
         The filename of the MIDI file to parse.
-        
+
     csv_path : string
         The filename of the csv to write out to. Any nested directories will be
         created by df_to_csv(df, csv_path).
     """
     df_to_csv(midi_to_df(midi_path), csv_path)
-    
-    
-    
-    
+
+
+
 def midi_to_df(midi_path):
     """
     Get the data from a MIDI file and load it into a pandas DataFrame.
-    
+
     Parameters
     ----------
     midi_path : string
         The filename of the MIDI file to parse.
-        
+
     Returns
     -------
     df : DataFrame
@@ -75,7 +76,7 @@ def midi_to_df(midi_path):
         Sorting will be first by onset, then track, then pitch, then duration.
     """
     midi = pretty_midi.PrettyMIDI(midi_path)
-    
+
     notes = []
     for index, instrument in enumerate(midi.instruments):
         for note in instrument.notes:
@@ -83,9 +84,9 @@ def midi_to_df(midi_path):
                           'track': index,
                           'pitch': note.pitch,
                           'dur': (note.end - note.start) * 1000})
-            
+
     df = pd.DataFrame(notes)
-    df = df.sort_values(['onset', 'track', 'pitch', 'dur'])
+    df = df.sort_values(COLNAMES)
     return df.reset_index(drop=True)
 
 
@@ -94,7 +95,7 @@ def df_to_csv(df, csv_path):
     """
     Print the data from the given pandas DataFrame into a csv in the correct
     format.
-    
+
     Parameters
     ----------
     df : DataFrame
@@ -104,11 +105,12 @@ def df_to_csv(df, csv_path):
             track: The track number of the instrument the note is from.
             pitch: The MIDI pitch number for the note.
             dur: The duration of the note (offset - onset), in milliseconds.
-        
+
     csv_path : string
         The filename of the csv to which to print the data. No header or index
         will be printed, and the rows will be printed in the current order of the
         DataFrame. Any nested directories will be created.
     """
     os.makedirs(os.path.dirname(csv_path), exist_ok=True)
-    df.to_csv(csv_path, index=None, header=False)
+    # Enforce column order
+    df[COLNAMES].to_csv(csv_path, index=None, header=False)


### PR DESCRIPTION
When I ran pytest, mine failed. This is becuase the dataframe created
in test_df_to_csv put the columns in a weird order. I've fixed
midi.df_to_csv to select columns in a specific order fixed at the
top of the file.

Also just did pep8 shit.