### PR TITLE
Changed random seeding and function arguments

### DIFF
--- a/gen_acme_dataset.py
+++ b/gen_acme_dataset.py
@@ -1,9 +1,42 @@
-
-
-# Dev mode warnings
+#!/usr/bin/env python
+"""Script to generate Altered and Corrupted Midi Exerpt (ACME) datasets"""
 import sys
+from mdtk import degradations
 
+# For dev mode warnings...
 if not sys.warnoptions:
-    import os, warnings
+    import os
+    import warnings
     warnings.simplefilter("always") # Change the filter in this process
     os.environ["PYTHONWARNINGS"] = "always" # Also affect subprocesses
+
+
+
+def parse_degradation_kwargs(kwarg_dict):
+    """Convenience function to parse a dictionary of keyword arguments for
+    the functions within the degradations module. All keys in the kwarg_dict
+    supplied should start with the function name and be followed by a double
+    underscore.
+
+    Parameters
+    ----------
+    kwarg_dict : dict
+        Dict containing keyword arguments to parse
+
+    Returns
+    -------
+    func_kwargs : dict
+        Dict with keys matching the names of the functions. The corresponding
+        value is a dictionary of the keyword arguments for the function.
+    """
+    func_names = degradations.DEGRADATIONS.keys()
+    func_kwargs = {name: {} for name in func_names}
+    for kk, kwarg_value in kwarg_dict.items():
+        try:
+            func_name, kwarg_name = kk.split('__', 1)
+        except ValueError:
+            raise ValueError(f"Supplied keyword [{kk}] must have a double "
+                              "underscore")
+        assert func_name in func_names, f"{func_name} not in {func_names}"
+        func_kwargs[func_name][kwarg_name] = kwarg_value
+    return func_kwargs

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -1,11 +1,38 @@
 """Code to perform the degradations i.e. edits to the midi data"""
 import numpy as np
+from numpy.random import randint, uniform, choice
 
 from mdtk.data_structures import Composition
 
 
 
-def pitch_shift(excerpt, rand, params):
+def set_random_seed(func, seed=None):
+    """This is a function decorator which just adds the keyword argument `seed`
+    to the end of the supplied function that it decorates. It seeds numpy's
+    random state with the provided value before the call of the function.
+
+    Parameters
+    ----------
+    func : function
+        function to be decorated
+    seed : int
+        integer value to seed
+
+    Returns
+    -------
+    seeded_func : function
+        The originally supplied function, but now with an aditional optional
+        seed keyword argument.
+    """
+    def seeded_func(*args, seed=seed, **kwargs):
+        np.random.seed(seed)
+        return func(*args, **kwargs)
+    return seeded_func
+
+
+
+@set_random_seed
+def pitch_shift(excerpt, params):
     """
     Shift the pitch of one note from the given excerpt.
 
@@ -13,9 +40,6 @@ def pitch_shift(excerpt, rand, params):
     ----------
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
-
-    rand : numpy.random
-        A seeded numpy random object.
 
     params : dict
         A dictionary containing parameters for the pitch shift. All used
@@ -26,6 +50,9 @@ def pitch_shift(excerpt, rand, params):
             max_pitch : int
                 One greater than the maximum pitch to which a note may be
                 shifted. Defaults to 127.
+
+    seed : int
+        A seed to be supplied to np.random.seed(), defaults to None
 
     Returns
     -------
@@ -40,18 +67,21 @@ def pitch_shift(excerpt, rand, params):
     degraded = excerpt.copy()
 
     # Sample a random note
-    note_index = rand.randint(0, degraded.note_df.shape[0])
+    note_index = randint(0, degraded.note_df.shape[0])
 
     # Shift its pitch (to something new)
+    # TODO: I reckon this may update in place so the while loop will go forever
     original_pitch = degraded.note_df.loc[note_index, 'pitch']
     while degraded.note_df.loc[note_index, 'pitch'] == original_pitch:
-        degraded.note_df.loc[note_index, 'pitch'] = rand.randint(min_pitch, max_pitch)
+        degraded.note_df.loc[note_index, 'pitch'] = randint(min_pitch,
+                                                            max_pitch)
 
     return degraded
 
 
 
-def time_shift(excerpt, rand, params):
+@set_random_seed
+def time_shift(excerpt, params):
     """
     Shift the onset and offset times of one note from the given excerpt,
     leaving its duration unchanged.
@@ -61,13 +91,13 @@ def time_shift(excerpt, rand, params):
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
 
-    rand : numpy.random
-        A seeded numpy random object.
-
     params : dict
         A dictionary containing parameters for the time shift. All used
         parameters keys will begin with 'time_shift_'. They include:
             None
+
+    seed : int
+        A seed to be supplied to np.random.seed(), defaults to None
 
     Returns
     -------
@@ -78,7 +108,8 @@ def time_shift(excerpt, rand, params):
 
 
 
-def onset_shift(excerpt, rand, params):
+@set_random_seed
+def onset_shift(excerpt, params):
     """
     Shift the onset time of one note from the given excerpt.
 
@@ -87,13 +118,13 @@ def onset_shift(excerpt, rand, params):
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
 
-    rand : numpy.random
-        A seeded numpy random object.
-
     params : dict
         A dictionary containing parameters for the onset shift. All used
         parameters keys will begin with 'onset_shift_'. They include:
             None
+
+    seed : int
+        A seed to be supplied to np.random.seed(), defaults to None
 
     Returns
     -------
@@ -104,7 +135,8 @@ def onset_shift(excerpt, rand, params):
 
 
 
-def offset_shift(excerpt, rand, params):
+@set_random_seed
+def offset_shift(excerpt, params):
     """
     Shift the offset time of one note from the given excerpt.
 
@@ -113,13 +145,14 @@ def offset_shift(excerpt, rand, params):
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
 
-    rand : numpy.random
-        A seeded numpy random object.
-
     params : dict
         A dictionary containing parameters for the offset shift. All used
         parameters keys will begin with 'offset_shift_'. They include:
             None
+
+    seed : int
+        A seed to be supplied to np.random.seed(), defaults to None
+
 
     Returns
     -------
@@ -129,7 +162,9 @@ def offset_shift(excerpt, rand, params):
     raise NotImplementedError()
 
 
-def remove_note(excerpt, rand, params):
+
+@set_random_seed
+def remove_note(excerpt, params):
     """
     Remove one note from the given excerpt.
 
@@ -138,13 +173,14 @@ def remove_note(excerpt, rand, params):
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
 
-    rand : numpy.random
-        A seeded numpy random object.
-
     params : dict
         A dictionary containing parameters for the note removal. All used
         parameters keys will begin with 'remove_note_'. They include:
             None
+
+    seed : int
+        A seed to be supplied to np.random.seed(), defaults to None
+
 
     Returns
     -------
@@ -154,7 +190,7 @@ def remove_note(excerpt, rand, params):
     degraded = excerpt.copy()
 
     # Sample a random note
-    note_index = rand.randint(0, degraded.note_df.shape[0])
+    note_index = randint(0, degraded.note_df.shape[0])
 
     # Remove that note
     (degraded.note_df
@@ -166,7 +202,8 @@ def remove_note(excerpt, rand, params):
 
 
 
-def add_note(excerpt, rand, params):
+@set_random_seed
+def add_note(excerpt, params):
     """
     Add one note to the given excerpt.
 
@@ -174,9 +211,6 @@ def add_note(excerpt, rand, params):
     ----------
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
-
-    rand : numpy.random
-        A seeded numpy random object.
 
     params : dict
         A dictionary containing parameters for the note addition. All used
@@ -193,6 +227,10 @@ def add_note(excerpt, rand, params):
                 The maximum duration for the added note. Defaults to infinity.
                 (The offset time will never go beyond the current last offset
                 in the excerpt.)
+
+    seed : int
+        A seed to be supplied to np.random.seed(), defaults to None
+
 
     Returns
     -------
@@ -212,13 +250,13 @@ def add_note(excerpt, rand, params):
 
     end_time = degraded.note_df[['onset', 'dur']].sum(axis=1).max()
 
-    pitch = rand.randint(min_pitch, max_pitch)
+    pitch = randint(min_pitch, max_pitch)
 
-    onset = rand.uniform(degraded.note_df['onset'].min(), end_time - min_duration)
-    duration = rand.uniform(onset + min_duration, max(end_time - onset, max_duration))
+    onset = uniform(degraded.note_df['onset'].min(), end_time - min_duration)
+    duration = uniform(onset + min_duration, max(end_time - onset, max_duration))
 
     # Track is random one of existing tracks
-    track = rand.choice(degraded.note_df['track'].unique())
+    track = choice(degraded.note_df['track'].unique())
 
     degraded.note_df = degraded.note_df.append({'pitch': pitch,
                                                 'onset': onset,
@@ -229,12 +267,16 @@ def add_note(excerpt, rand, params):
 
 
 
-def split_note(excerpt, rand, params):
+@set_random_seed
+def split_note(excerpt, params):
+    """Split a note into two notes."""
     raise NotImplementedError()
-    
 
 
-def join_notes(excerpt, rand, params):
+
+@set_random_seed
+def join_notes(excerpt, params):
+    """Combine two notes into one note."""
     raise NotImplementedError()
 
 

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -6,6 +6,11 @@ from mdtk.data_structures import Composition
 
 
 
+MIN_PITCH = 0
+MAX_PITCH = 127
+
+
+
 def set_random_seed(func, seed=None):
     """This is a function decorator which just adds the keyword argument `seed`
     to the end of the supplied function that it decorates. It seeds numpy's
@@ -33,7 +38,7 @@ def set_random_seed(func, seed=None):
 
 
 @set_random_seed
-def pitch_shift(excerpt, params):
+def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH):
     """
     Shift the pitch of one note from the given excerpt.
 
@@ -41,17 +46,10 @@ def pitch_shift(excerpt, params):
     ----------
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
-
-    params : dict
-        A dictionary containing parameters for the pitch shift. All used
-        parameters keys will begin with 'pitch_shift_'. They include:
-            min_pitch : int
-                The minimum pitch to which a note may be shifted.
-                Defaults to 0.
-            max_pitch : int
-                One greater than the maximum pitch to which a note may be
-                shifted. Defaults to 127.
-
+    min_pitch : int
+        The minimum pitch to which a note may be shifted.
+    max_pitch : int
+        One greater than the maximum pitch to which a note may be shifted.
     seed : int
         A seed to be supplied to np.random.seed(), defaults to None
 
@@ -60,11 +58,6 @@ def pitch_shift(excerpt, params):
     degraded : Composition
         A copy of the given excerpt, with the pitch of one note changed.
     """
-    min_pitch = (0 if 'pitch_shift_min_pitch' not in params
-                 else params['pitch_shift_min_pitch'])
-    max_pitch = (127 if 'pitch_shift_max_pitch' not in params
-                 else params['pitch_shift_max_pitch'])
-
     degraded = excerpt.copy()
 
     # Sample a random note
@@ -110,7 +103,7 @@ def time_shift(excerpt, params):
 
 
 @set_random_seed
-def onset_shift(excerpt, params):
+def onset_shift(excerpt):
     """
     Shift the onset time of one note from the given excerpt.
 
@@ -118,11 +111,6 @@ def onset_shift(excerpt, params):
     ----------
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
-
-    params : dict
-        A dictionary containing parameters for the onset shift. All used
-        parameters keys will begin with 'onset_shift_'. They include:
-            None
 
     seed : int
         A seed to be supplied to np.random.seed(), defaults to None
@@ -137,7 +125,7 @@ def onset_shift(excerpt, params):
 
 
 @set_random_seed
-def offset_shift(excerpt, params):
+def offset_shift(excerpt):
     """
     Shift the offset time of one note from the given excerpt.
 
@@ -145,11 +133,6 @@ def offset_shift(excerpt, params):
     ----------
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
-
-    params : dict
-        A dictionary containing parameters for the offset shift. All used
-        parameters keys will begin with 'offset_shift_'. They include:
-            None
 
     seed : int
         A seed to be supplied to np.random.seed(), defaults to None
@@ -165,7 +148,7 @@ def offset_shift(excerpt, params):
 
 
 @set_random_seed
-def remove_note(excerpt, params):
+def remove_note(excerpt):
     """
     Remove one note from the given excerpt.
 
@@ -173,11 +156,6 @@ def remove_note(excerpt, params):
     ----------
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
-
-    params : dict
-        A dictionary containing parameters for the note removal. All used
-        parameters keys will begin with 'remove_note_'. They include:
-            None
 
     seed : int
         A seed to be supplied to np.random.seed(), defaults to None
@@ -204,7 +182,8 @@ def remove_note(excerpt, params):
 
 
 @set_random_seed
-def add_note(excerpt, params):
+def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
+             min_duration=50, max_duration=np.inf):
     """
     Add one note to the given excerpt.
 
@@ -212,23 +191,16 @@ def add_note(excerpt, params):
     ----------
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
-
-    params : dict
-        A dictionary containing parameters for the note addition. All used
-        parameters keys will begin with 'add_note_'. They include:
-            min_pitch : int
-                The minimum pitch at which a note may be added.
-                Defaults to 0.
-            max_pitch : int
-                One greater than the maximum pitch at which a note may be
-                added. Defaults to 88.
-            min_duration : float
-                The minimum duration for the note to be added. Defaults to 50.
-            max_duration : float
-                The maximum duration for the added note. Defaults to infinity.
-                (The offset time will never go beyond the current last offset
-                in the excerpt.)
-
+    min_pitch : int
+        The minimum pitch at which a note may be added.
+    max_pitch : int
+        One greater than the maximum pitch at which a note may be added.
+    min_duration : float
+        The minimum duration for the note to be added. Defaults to 50.
+    max_duration : float
+        The maximum duration for the added note. Defaults to infinity.
+        (The offset time will never go beyond the current last offset
+        in the excerpt.)
     seed : int
         A seed to be supplied to np.random.seed(), defaults to None
 
@@ -238,15 +210,6 @@ def add_note(excerpt, params):
     degraded : Composition
         A copy of the given excerpt, with one note added.
     """
-    min_pitch = (0 if 'add_note_min_pitch' not in params
-                 else params['add_note_min_pitch'])
-    max_pitch = (88 if 'add_note_max_pitch' not in params
-                 else params['add_note_max_pitch'])
-    min_duration = (50 if 'add_note_min_duration' not in params
-                    else params['add_note_min_duration'])
-    max_duration = (np.inf if 'add_note_max_duration' not in params
-                    else params['add_note_max_duration'])
-
     degraded = excerpt.copy()
 
     end_time = degraded.note_df[['onset', 'dur']].sum(axis=1).max()
@@ -254,7 +217,8 @@ def add_note(excerpt, params):
     pitch = randint(min_pitch, max_pitch)
 
     onset = uniform(degraded.note_df['onset'].min(), end_time - min_duration)
-    duration = uniform(onset + min_duration, max(end_time - onset, max_duration))
+    duration = uniform(onset + min_duration,
+                       max(end_time - onset, max_duration))
 
     # Track is random one of existing tracks
     track = choice(degraded.note_df['track'].unique())
@@ -262,8 +226,8 @@ def add_note(excerpt, params):
     degraded.note_df = degraded.note_df.append({'pitch': pitch,
                                                 'onset': onset,
                                                 'dur': duration,
-                                                'track': track}, ignore_index=True)
-
+                                                'track': track},
+                                               ignore_index=True)
     return degraded
 
 

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -15,8 +15,8 @@ def set_random_seed(func, seed=None):
     ----------
     func : function
         function to be decorated
-    seed : int
-        integer value to seed
+    seed : int or None
+        integer value to use for seed, if None leaves the random state as is
 
     Returns
     -------
@@ -25,7 +25,8 @@ def set_random_seed(func, seed=None):
         seed keyword argument.
     """
     def seeded_func(*args, seed=seed, **kwargs):
-        np.random.seed(seed)
+        if seed is not None:
+            np.random.seed(seed)
         return func(*args, **kwargs)
     return seeded_func
 


### PR DESCRIPTION
Function arguments
===============
We decided that supplying a dictionary was not as good if people want to use these functions in other contexts. I also said:
* explicit arg parsing at the top of each function to set defaults isn't as nice to read; now we set default values for kwargs in the function definition at the top
* kwarg names now don't need to include the function name
* The actual parsing of args supplied to the main script can happen in the script - see the main script where I've written a function to do the parsing.

Seeding
======
Each function now gets the argument `seed` when decorated with `set_random_seed`. The random number generator is not touched unless a seed is set. I imagine we wont use this seed argument very often unless we are testing...but you never know.