### PR TITLE
Fix `fix_overlapping_notes` changing dtype

### DIFF
--- a/mdtk/data_structures.py
+++ b/mdtk/data_structures.py
@@ -211,20 +211,18 @@ def fix_overlapping_notes(df, drop_new_cols=True):
 #    df = df.copy()
     if df.shape[0] <= 1:
         return df
-#    dtypes = dict(zip(df.columns, df.dtypes))  # See comment below
+    dtypes = dict(zip(df.columns, df.dtypes))
     df['note_off'] = df['onset'] + df['dur']
     df['next_note_on'] = df['onset'].shift(-1)
-    df.loc[df.index[-1], 'next_note_on'] = np.inf
+    df.loc[df.index[-1], 'next_note_on'] = np.iinfo(np.int32).max
+    if np.issubdtype(dtypes['onset'], np.integer):
+        df['next_note_on'] = df['next_note_on'].astype('int')
     df['bad_note'] = df['note_off'] > df['next_note_on']  # equal is fine
     df.loc[df['bad_note'], 'dur'] = (df.loc[df['bad_note'], 'next_note_on']
                                      - df.loc[df['bad_note'], 'onset'])
     if drop_new_cols:
         new_cols = ['note_off', 'next_note_on', 'bad_note']
         df.drop(new_cols, axis=1, inplace=True)
-#    df = df.astype(dtypes)  # This broke the function when used with a groupby
-                             # it made track always return as the same value
-    df['dur'] = df['dur'].astype('int')
-    df['onset'] = df['onset'].astype('int')
     # TODO: add an assertion to catch dur==0 and add a test
     return df
 

--- a/mdtk/tests/test_data_structures.py
+++ b/mdtk/tests/test_data_structures.py
@@ -307,6 +307,8 @@ def test_fix_overlapping_notes():
     assert note_df_overlapping_pitch_fix.equals(
             fix_overlapping_notes(note_df_overlapping_pitch.copy())
         )
+    assert all(note_df_2pitch_weird_times.dtypes == 
+               fix_overlapping_notes(note_df_2pitch_weird_times.copy()).dtypes)
 
 
 def test_get_monophonic_tracks():


### PR DESCRIPTION
Agree with your suggestion logic should be simpler in this function. I tried:
```
for ii in range(df.shape[0]-1):
        note = df.loc[df.index[ii]]
        next_note = df.loc[df.index[ii+1]]
        note_off = min(note['onset'] + note['dur'], next_note['onset'])
        note['dur'] = note_off - note['onset']
```
But it returns the classic pandas 'copy' warning on tests (seems something to do with floats...I don't want to try and fix this just now if the function works as expected!):
```
mdtk/tests/test_data_structures.py::test_fix_overlapping_notes
  /home/james/git/midi_degradation_toolkit/mdtk/data_structures.py:218: SettingWithCopyWarning: 
  A value is trying to be set on a copy of a slice from a DataFrame
  
  See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
    note['dur'] = note_off - note['onset']

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```