### PR TITLE
Use data structures

### DIFF
--- a/mdtk/data_structures.py
+++ b/mdtk/data_structures.py
@@ -21,7 +21,7 @@ NR_MIDINOTES = 128
 
 
 
-def read_note_csv(path, onset='onset', pitch='pitch', dur='dur', track='ch',
+def read_note_csv(path, onset='onset', track='track', pitch='pitch', dur='dur',
                   sort=True, header='infer', monophonic_tracks=None,
                   max_note_len=None):
     """Read a csv and create a standard note event DataFrame - a `note_df`.

--- a/mdtk/midi.py
+++ b/mdtk/midi.py
@@ -7,7 +7,8 @@ import pandas as pd
 
 import pretty_midi
 
-from data_structures import NOTE_DF_SORT_ORDER, check_note_df
+from mdtk.data_structures import NOTE_DF_SORT_ORDER, check_note_df
+
 
 
 COLNAMES = NOTE_DF_SORT_ORDER

--- a/mdtk/midi.py
+++ b/mdtk/midi.py
@@ -7,9 +7,10 @@ import pandas as pd
 
 import pretty_midi
 
+from data_structures import NOTE_DF_SORT_ORDER, check_note_df
 
 
-COLNAMES = ['onset', 'track', 'pitch', 'dur']
+COLNAMES = NOTE_DF_SORT_ORDER
 
 
 
@@ -54,7 +55,6 @@ def midi_to_csv(midi_path, csv_path):
     df_to_csv(midi_to_df(midi_path), csv_path)
 
 
-
 def midi_to_df(midi_path):
     """
     Get the data from a MIDI file and load it into a pandas DataFrame.
@@ -87,8 +87,9 @@ def midi_to_df(midi_path):
 
     df = pd.DataFrame(notes)[COLNAMES]
     df = df.sort_values(COLNAMES)
-    return df.reset_index(drop=True)
-
+    df = df.reset_index(drop=True)
+    check_note_df(df)
+    return df
 
 
 def df_to_csv(df, csv_path):

--- a/mdtk/tests/test_data_structures.py
+++ b/mdtk/tests/test_data_structures.py
@@ -74,6 +74,12 @@ note_df_with_silence = pd.DataFrame({
     'pitch': [60, 61, 60, 60, 60, 60],
     'dur': [1, 3.75, 1, 0.5, 0.5, 2]
 })
+note_df_odd_names = pd.DataFrame({
+    'note_on': [0, 0, 1, 2, 3, 4],
+    'midinote': [60, 61, 60, 60, 60, 60],
+    'duration': [1, 3.75, 1, 0.5, 0.5, 2],
+    'ch' :[0, 1, 0, 0, 0, 0]
+})
 # midinote keyboard range from 0 to 127 inclusive
 all_midinotes = list(range(0, 128))
 # All pitches played simultaneously for 1 quantum
@@ -132,12 +138,18 @@ df_all_poly = pd.DataFrame({
     'pitch': [60, 61, 62, 63, 70, 71, 72, 73, 80, 81, 82, 83],
     'dur': [2, 1, 1, 1, 4, 1, 1, 1, 3, 1, 1, 1]
 }).sort_values(by=NOTE_DF_SORT_ORDER).reset_index(drop=True)
-
+note_df_with_silence = pd.DataFrame({
+    'onset': [0, 0, 1, 2, 3, 4],
+    'track' :[0, 1, 0, 0, 0, 0],
+    'pitch': [60, 61, 60, 60, 60, 60],
+    'dur': [1, 3.75, 1, 0.5, 0.5, 2]
+})
 
 ALL_DF = {
     'note_df_overlapping_pitch': note_df_overlapping_pitch,
     'note_df_overlapping_note': note_df_overlapping_note,
     'note_df_2pitch_aligned': note_df_2pitch_aligned,
+    'note_df_odd_names': note_df_odd_names,
     'note_df_2pitch_weird_times': note_df_2pitch_weird_times,
     'note_df_2pitch_weird_times_quant': note_df_2pitch_weird_times_quant,
     'note_df_with_silence': note_df_with_silence,
@@ -169,6 +181,7 @@ ASSERTION_ERRORS = {
     'note_df_2pitch_weird_times': None,
     'note_df_2pitch_weird_times_quant': None,
     'note_df_with_silence': None,
+    'note_df_odd_names': missing_col_err,
     'all_pitch_df_notrack': missing_col_err,
     'all_pitch_df_wrongorder': col_order_err,
     'all_pitch_df': None,
@@ -195,6 +208,7 @@ ALL_VALID_DF = {
     'note_df_2pitch_weird_times': note_df_2pitch_weird_times,
     'note_df_2pitch_weird_times_quant': note_df_2pitch_weird_times_quant,
     'note_df_with_silence': note_df_with_silence,
+    'note_df_odd_names': note_df_with_silence,
     'all_pitch_df_notrack': all_pitch_df,
     'all_pitch_df_wrongorder': all_pitch_df,
     'all_pitch_df': all_pitch_df,
@@ -236,14 +250,13 @@ def test_read_note_csv():
     assert df.equals(all_pitch_df_track_name_change)
     df = read_note_csv('./all_pitch_df.csv', track='track')
     assert df.equals(all_pitch_df)
-    df = read_note_csv('./all_pitch_df_tracks.csv', track='track', sort=False)
+    df = read_note_csv('./all_pitch_df_tracks.csv', sort=False)
     assert df.equals(all_pitch_df_tracks[NOTE_DF_SORT_ORDER]), (
             f"{df}\n\n\n{all_pitch_df_tracks[NOTE_DF_SORT_ORDER]}")
-    df = read_note_csv('./all_pitch_df_tracks_sparecol.csv', track='track',
-                       sort=False)
+    df = read_note_csv('./all_pitch_df_tracks_sparecol.csv', sort=False)
     comp_df = all_pitch_df_tracks_sparecol[NOTE_DF_SORT_ORDER + ['sparecol']]
     assert df.equals(comp_df.drop('sparecol', axis=1))
-    df = read_note_csv('./all_pitch_df_tracks_sparecol.csv', track='track')
+    df = read_note_csv('./all_pitch_df_tracks_sparecol.csv')
     assert not df.equals(comp_df.drop('sparecol', axis=1))  # sorting
     assert df.equals(
             (comp_df
@@ -252,8 +265,13 @@ def test_read_note_csv():
                  .reset_index(drop=True)
             )[NOTE_DF_SORT_ORDER])  # sorting
     df = read_note_csv('./all_pitch_df_tracks_sparecol_weirdorder.csv',
-                       track='track', sort=False)
+                       sort=False)
     assert df.equals(comp_df.drop('sparecol', axis=1))
+    assert (
+        read_note_csv('./note_df_with_silence.csv').equals(
+            read_note_csv('./note_df_odd_names.csv', onset='note_on',
+                          track='ch', pitch='midinote', dur='duration'))
+        )
     
 
 def test_check_overlap():


### PR DESCRIPTION
Simple change. As expected, don't need to use read_note_csv in midi (since you're importing from midi!), but I've changed the default values expected for import because we agreed that csvs should be in the expected format post download.

Main change of interest for you is the addition of the check: `check_note_df`. From the commit msg:
> If we find that many imported midi files present issue, we can implement fix_note_df() in data_structures such that this doesn't bomb out with an assertion error (we chan set the `raise_error` argument in `check_note_df` to false and fix if required).