### PR TITLE
Degradation optimizations

### DIFF
--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -218,16 +218,16 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf):
     end_time = offset.max()
     
     # Shift earlier
-    earliest_earlier_onset = (onset - max_shift + 1).clip(lower=0)
-    latest_earlier_onset = ((onset - min_shift + 1)
+    earliest_earlier_onset = (onset - (max_shift - 1)).clip(lower=0)
+    latest_earlier_onset = ((onset - (min_shift - 1))
                                 .clip(lower=earliest_earlier_onset,
                                       upper=onset))
     
     # Shift later
-    latest_later_onset = onset + ((end_time - offset + 1)
+    latest_later_onset = onset + (((end_time + 1) - offset)
                                       .clip(upper=max_shift))
     earliest_later_onset = ((onset + min_shift)
-                                .clip(lower=onset+1,
+                                .clip(lower=onset + 1,
                                       upper=latest_later_onset))
     
     # Find valid notes
@@ -298,13 +298,13 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
     earliest_lengthened_onset = ((offset - max_duration)
                                      .clip(lower=onset - max_shift)
                                      .clip(lower=0))
-    latest_lengthened_onset = ((((onset - max(min_shift, 1))
-                                     .clip(upper=offset - min_duration)) + 1)
-                               .clip(lower=earliest_lengthened_onset))
+    latest_lengthened_onset = ((onset - max(min_shift - 1, 0))
+                                   .clip(upper=offset - (min_duration - 1),
+                                         lower=earliest_lengthened_onset))
     
     # Shorten bounds (increase onset)
-    latest_shortened_onset = ((offset - min_duration)
-                                  .clip(upper=onset + max_shift)) + 1
+    latest_shortened_onset = ((offset - (min_duration - 1))
+                                  .clip(upper=onset + (max_shift + 1)))
     earliest_shortened_onset = ((onset + max(min_shift, 1))
                                     .clip(lower=offset - max_duration,
                                           upper=latest_shortened_onset))

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -84,7 +84,8 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
     Parameters
     ----------
     excerpt : pd.DataFrame
-        An excerpt from a piece of music.
+        An excerpt from a piece of music. If inplace=True, this object
+        will be changed in place if the degradation is possible.
 
     min_pitch : int
         The minimum pitch to which a note may be shifted.
@@ -101,8 +102,8 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         pitch. Defaults to None, which implies a uniform distribution.
         
     inplace : boolean
-        True to edit the given DataFrame in place. False to create a copy.
-        The result is returned either way.
+        True to edit the given excerpt in place. False to create and return
+        a copy.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -201,7 +202,8 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf, inplace=False):
     Parameters
     ----------
     excerpt : pd.DataFrame
-        A Composition object of an excerpt from a piece of music.
+        An excerpt from a piece of music. If inplace=True, this object
+        will be changed in place if the degradation is possible.
 
     min_shift : int
         The minimum amount by which the note will be shifted. Defaults to 50.
@@ -211,8 +213,8 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf, inplace=False):
         infinity.
         
     inplace : boolean
-        True to edit the given DataFrame in place. False to create a copy.
-        The result is returned either way.
+        True to edit the given excerpt in place. False to create and return
+        a copy.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -281,8 +283,9 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
     Parameters
     ----------
-    excerpt : Composition
-        A Composition object of an excerpt from a piece of music.
+    excerpt : df.DataFrame
+        An excerpt from a piece of music. If inplace=True, this object
+        will be changed in place if the degradation is possible.
         
     min_shift : int
         The minimum amount by which the onset time will be changed. Defaults
@@ -301,8 +304,8 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
         in the excerpt.)
         
     inplace : boolean
-        True to edit the given DataFrame in place. False to create a copy.
-        The result is returned either way.
+        True to edit the given excerpt in place. False to create and return
+        a copy.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -310,8 +313,9 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
     Returns
     -------
-    degraded : Composition
-        A degradation of the excerpt, with the onset time of one note changed.
+    degraded : df.DataFrame
+        A degradation of the excerpt, with the onset time of one note changed,
+        or None if inplace=True or no notes can be onset shifted.
     """
     min_shift = max(min_shift, 1)
     min_duration -= 1
@@ -373,8 +377,9 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
     Parameters
     ----------
-    excerpt : Composition
-        A Composition object of an excerpt from a piece of music.
+    excerpt : df.DataFrame
+        An excerpt from a piece of music. If inplace=True, this object
+        will be changed in place if the degradation is possible.
         
     min_shift : int
         The minimum amount by which the offset time will be changed. Defaults
@@ -393,8 +398,8 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
         in the excerpt.)
         
     inplace : boolean
-        True to edit the given DataFrame in place. False to create a copy.
-        The result is returned either way.
+        True to edit the given excerpt in place. False to create and return
+        a copy.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -403,8 +408,9 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
     Returns
     -------
-    degraded : Composition
-        A degradation of the excerpt, with the offset time of one note changed.
+    degraded : df.DataFrame
+        A degradation of the excerpt, with the offset time of one note changed,
+        or None if inplace=True or no notes can be offset shifted.
     """
     min_shift = max(min_shift, 1)
     max_duration += 1
@@ -463,22 +469,23 @@ def remove_note(excerpt, inplace=False):
 
     Parameters
     ----------
-    excerpt : Composition
-        A Composition object of an excerpt from a piece of music.
+    excerpt : df.DataFrame
+        An excerpt from a piece of music. If inplace=True, this object
+        will be changed in place if the degradation is possible.
         
     inplace : boolean
-        True to edit the given DataFrame in place. False to create a copy.
-        The result is returned either way.
+        True to edit the given excerpt in place. False to create and return
+        a copy.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
         leaves numpy's random state unchanged.
 
-
     Returns
     -------
-    degraded : Composition
-        A degradation of the excerpt, with one note removed.
+    degraded : df.DataFrame
+        A degradation of the excerpt, with one note removed, or None if
+        inplace=True or no notes are in the excerpt.
     """
     if excerpt.shape[0] == 0:
         warnings.warn('WARNING: No notes to remove. Returning None.',
@@ -510,8 +517,9 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
     Parameters
     ----------
-    excerpt : Composition
-        A Composition object of an excerpt from a piece of music.
+    excerpt : df.DataFrame
+        An excerpt from a piece of music. If inplace=True, this object
+        will be changed in place.
     min_pitch : int
         The minimum pitch at which a note may be added.
     max_pitch : int
@@ -523,8 +531,9 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         (The offset time will never go beyond the current last offset
         in the excerpt.)
     inplace : boolean
-        True to edit the given DataFrame in place. False to create a copy.
-        The result is returned either way.
+        True to edit the given excerpt in place. False to create and return
+        a copy. Note that inplace=True will potentially make this method
+        less efficient.
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
         leaves numpy's random state unchanged.
@@ -532,8 +541,9 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
     Returns
     -------
-    degraded : Composition
-        A degradation of the excerpt, with one note added.
+    degraded : df.DataFrame
+        A degradation of the excerpt, with one note added, or None if
+        inplace=True.
     """
     end_time = excerpt[['onset', 'dur']].sum(axis=1).max()
 
@@ -567,16 +577,16 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         else:
             index = 0
         degraded.loc[index] = {'pitch': pitch,
-                                       'onset': onset,
-                                       'dur': duration,
-                                       'track': track}
+                               'onset': onset,
+                               'dur': duration,
+                               'track': track}
     else:
         degraded = excerpt.copy()
         degraded = degraded.append({'pitch': pitch,
-                                                    'onset': onset,
-                                                    'dur': duration,
-                                                    'track': track},
-                                                   ignore_index=True)
+                                    'onset': onset,
+                                    'dur': duration,
+                                    'track': track},
+                                   ignore_index=True)
         
     if not inplace:
         return degraded
@@ -591,8 +601,9 @@ def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
     
     Parameters
     ----------
-    excerpt : Composition
-        A Composition object of an excerpt from a piece of music.
+    excerpt : df.DataFrame
+        An excerpt from a piece of music. If inplace=True, this object
+        will be changed in place if the degradation is possible.
         
     min_duration : int
         The minimum length for any of the resulting notes.
@@ -602,8 +613,9 @@ def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
         be split into (num_splits+1) shorter notes.
         
     inplace : boolean
-        True to edit the given DataFrame in place. False to create a copy.
-        The result is returned either way.
+        True to edit the given excerpt in place. False to create and return
+        a copy. Note that inplace=True will potentially make this method
+        less efficient because rows must be appended to the data frame.
         
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -611,8 +623,9 @@ def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
         
     Returns
     -------
-    degraded : Composition
-        A degradation of the excerpt, with one note split.
+    degraded : df.DataFrame
+        A degradation of the excerpt, with one note split, or None if
+        inplace=True or no notes can be split.
     """
     if excerpt.shape[0] == 0:
         warnings.warn('WARNING: No notes to split. Returning None.',
@@ -658,9 +671,9 @@ def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
         
         for note_idx, df_idx in enumerate(range(start, start + num_splits)):
             degraded.loc[df_idx] = {'onset': onsets[note_idx],
-                                            'track': tracks[note_idx],
-                                            'pitch': pitches[note_idx],
-                                            'dur': durs[note_idx]}
+                                    'track': tracks[note_idx],
+                                    'pitch': pitches[note_idx],
+                                    'dur': durs[note_idx]}
     else:
         degraded = excerpt.copy()
         new_df = pd.DataFrame({'onset': onsets,
@@ -684,16 +697,17 @@ def join_notes(excerpt, max_gap=50, inplace=False):
     
     Parameters
     ----------
-    excerpt : Composition
-        A Composition object of an excerpt from a piece of music.
+    excerpt : df.DataFrame
+        An excerpt from a piece of music. If inplace=True, this object
+        will be changed in place if the degradation is possible.
         
     max_gap : int
         The maximum gap length, in ms, for 2 notes to be able to be joined.
         (They must always share the same pitch and track).
         
     inplace : boolean
-        True to edit the given DataFrame in place. False to create a copy.
-        The result is returned either way.
+        True to edit the given excerpt in place. False to create and return
+        a copy.
         
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -701,8 +715,9 @@ def join_notes(excerpt, max_gap=50, inplace=False):
         
     Returns
     -------
-    degraded : Composition
-        A degradation of the excerpt, with one note split.
+    degraded : df.DataFrame
+        A degradation of the excerpt, with one note split, or None
+        if inplace=True or no notes can be joined.
     """
     if excerpt.shape[0] < 2:
         warnings.warn('WARNING: No notes to join. Returning None.',
@@ -745,8 +760,8 @@ def join_notes(excerpt, max_gap=50, inplace=False):
     
     # Extend first note
     degraded.loc[prev_i]['dur'] = (degraded.loc[next_i]['onset'] +
-                                           degraded.loc[next_i]['dur'] -
-                                           degraded.loc[prev_i]['onset'])
+                                   degraded.loc[next_i]['dur'] -
+                                   degraded.loc[prev_i]['onset'])
     
     # Drop 2nd note
     degraded.drop(next_i, inplace=True)

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -214,7 +214,7 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf):
         parameters.
     """
     onset = excerpt.note_df['onset']
-    offset = excerpt.note_df[['onset', 'dur']].sum(axis=1)
+    offset = onset + excerpt.note_df['dur']
     end_time = offset.max()
     
     # Shift earlier

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -76,7 +76,7 @@ def split_range_sample(split_range, p=None):
 
 @set_random_seed
 def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
-                distribution=None):
+                distribution=None, inplace=False):
     """
     Shift the pitch of one note from the given excerpt.
 
@@ -98,6 +98,10 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         range [min_pitch, max_pitch] will also be set to 0. The distribution
         will then be normalized to sum to 1, and used to generate a new
         pitch. Defaults to None, which implies a uniform distribution.
+        
+    inplace : boolean
+        True to edit the given DataFrame in place. False to create a copy.
+        The result is returned either way.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -107,7 +111,7 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
     Returns
     -------
     degraded : Composition
-        A copy of the given excerpt, with the pitch of one note changed.
+        A degradation of the excerpt, with the pitch of one note changed.
     """
     if excerpt.note_df.shape[0] == 0:
         warnings.warn('WARNING: No notes to pitch shift. Returning None.',
@@ -156,7 +160,10 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
                           'distribution[zero_idx] to 0). Returning None.')
             return None
         
-    degraded = excerpt.copy()
+    if inplace:
+        degraded = excerpt
+    else:
+        degraded = excerpt.copy()
 
     # Sample a random note
     note_index = valid_notes[randint(len(valid_notes))]
@@ -184,7 +191,7 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
 
 @set_random_seed
-def time_shift(excerpt, min_shift=50, max_shift=np.inf):
+def time_shift(excerpt, min_shift=50, max_shift=np.inf, inplace=False):
     """
     Shift the onset and offset times of one note from the given excerpt,
     leaving its duration unchanged.
@@ -200,6 +207,10 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf):
     max_shift : int
         The maximum amount by which the note will be shifted. Defaults to
         infinity.
+        
+    inplace : boolean
+        True to edit the given DataFrame in place. False to create a copy.
+        The result is returned either way.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -209,7 +220,7 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf):
     Returns
     -------
     degraded : Composition
-        A copy of the given excerpt, with the timing of one note changed,
+        A degradation of the excerpt, with the timing of one note changed,
         or None if there are no notes that can be changed given the
         parameters.
     """
@@ -248,7 +259,10 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf):
     
     onset = split_range_sample([(eeo, leo), (elo, llo)])
     
-    degraded = excerpt.copy()
+    if inplace:
+        degraded = excerpt
+    else:
+        degraded = excerpt.copy()
     
     degraded.note_df.loc[index, 'onset'] = onset
     
@@ -258,7 +272,7 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf):
 
 @set_random_seed
 def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
-                max_duration=np.inf):
+                max_duration=np.inf, inplace=False):
     """
     Shift the onset time of one note from the given excerpt.
 
@@ -282,6 +296,10 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
         The maximum duration for the resulting note. Defaults to infinity.
         (The offset time will never go beyond the current last offset
         in the excerpt.)
+        
+    inplace : boolean
+        True to edit the given DataFrame in place. False to create a copy.
+        The result is returned either way.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -290,7 +308,7 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
     Returns
     -------
     degraded : Composition
-        A copy of the given excerpt, with the onset time of one note changed.
+        A degradation of the excerpt, with the onset time of one note changed.
     """
     min_shift = max(min_shift, 1)
     min_duration -= 1
@@ -331,7 +349,10 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
     
     onset = split_range_sample([(elo, llo), (eso, lso)])
     
-    degraded = excerpt.copy()
+    if inplace:
+        degraded = excerpt
+    else:
+        degraded = excerpt.copy()
     
     degraded.note_df.loc[index, 'onset'] = onset
     degraded.note_df.loc[index, 'dur'] = offset[index] - onset
@@ -342,7 +363,7 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
 @set_random_seed
 def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
-                 max_duration=np.inf):
+                 max_duration=np.inf, inplace=False):
     """
     Shift the offset time of one note from the given excerpt.
 
@@ -366,6 +387,10 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
         The maximum duration for the resulting note. Defaults to infinity.
         (The offset time will never go beyond the current last offset
         in the excerpt.)
+        
+    inplace : boolean
+        True to edit the given DataFrame in place. False to create a copy.
+        The result is returned either way.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -375,7 +400,7 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
     Returns
     -------
     degraded : Composition
-        A copy of the given excerpt, with the offset time of one note changed.
+        A degradation of the excerpt, with the offset time of one note changed.
     """
     min_shift = max(min_shift, 1)
     max_duration += 1
@@ -415,7 +440,10 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
     
     duration = split_range_sample([(ssd, lsd), (sld, lld)])
         
-    degraded = excerpt.copy()
+    if inplace:
+        degraded = excerpt
+    else:
+        degraded = excerpt.copy()
     
     degraded.note_df.loc[index, 'dur'] = duration
     
@@ -424,7 +452,7 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
 
 @set_random_seed
-def remove_note(excerpt):
+def remove_note(excerpt, inplace=False):
     """
     Remove one note from the given excerpt.
 
@@ -432,6 +460,10 @@ def remove_note(excerpt):
     ----------
     excerpt : Composition
         A Composition object of an excerpt from a piece of music.
+        
+    inplace : boolean
+        True to edit the given DataFrame in place. False to create a copy.
+        The result is returned either way.
 
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
@@ -441,14 +473,17 @@ def remove_note(excerpt):
     Returns
     -------
     degraded : Composition
-        A copy of the given excerpt, with one note removed.
+        A degradation of the excerpt, with one note removed.
     """
     if excerpt.note_df.shape[0] == 0:
         warnings.warn('WARNING: No notes to remove. Returning None.',
                       category=UserWarning)
         return None
         
-    degraded = excerpt.copy()
+    if inplace:
+        degraded = excerpt
+    else:
+        degraded = excerpt.copy()
 
     # Sample a random note
     note_index = choice(list(degraded.note_df.index))
@@ -463,7 +498,7 @@ def remove_note(excerpt):
 
 @set_random_seed
 def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
-             min_duration=50, max_duration=np.inf):
+             min_duration=50, max_duration=np.inf, inplace=False):
     """
     Add one note to the given excerpt.
 
@@ -481,6 +516,9 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         The maximum duration for the added note. Defaults to infinity.
         (The offset time will never go beyond the current last offset
         in the excerpt.)
+    inplace : boolean
+        True to edit the given DataFrame in place. False to create a copy.
+        The result is returned either way.
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
         leaves numpy's random state unchanged.
@@ -489,9 +527,12 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
     Returns
     -------
     degraded : Composition
-        A copy of the given excerpt, with one note added.
+        A degradation of the excerpt, with one note added.
     """
-    degraded = excerpt.copy()
+    if inplace:
+        degraded = excerpt
+    else:
+        degraded = excerpt.copy()
 
     end_time = degraded.note_df[['onset', 'dur']].sum(axis=1).max()
 
@@ -528,7 +569,7 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
 
 @set_random_seed
-def split_note(excerpt, min_duration=50, num_splits=1):
+def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
     """
     Split one note from the excerpt into two or more notes of equal
     duration.
@@ -545,6 +586,10 @@ def split_note(excerpt, min_duration=50, num_splits=1):
         The number of splits to make in the chosen note. The note will
         be split into (num_splits+1) shorter notes.
         
+    inplace : boolean
+        True to edit the given DataFrame in place. False to create a copy.
+        The result is returned either way.
+        
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
         leaves numpy's random state unchanged.
@@ -552,7 +597,7 @@ def split_note(excerpt, min_duration=50, num_splits=1):
     Returns
     -------
     degraded : Composition
-        A copy of the given excerpt, with one note split.
+        A degradation of the excerpt, with one note split.
     """
     if excerpt.note_df.shape[0] == 0:
         warnings.warn('WARNING: No notes to split. Returning None.',
@@ -570,7 +615,10 @@ def split_note(excerpt, min_duration=50, num_splits=1):
     
     note_index = choice(valid_notes)
     
-    degraded = excerpt.copy()
+    if inplace:
+        degraded = excerpt
+    else:
+        degraded = excerpt.copy()
     
     short_duration_float = (degraded.note_df.loc[note_index, 'dur'] /
                             (num_splits + 1))
@@ -601,7 +649,7 @@ def split_note(excerpt, min_duration=50, num_splits=1):
 
 
 @set_random_seed
-def join_notes(excerpt, max_gap=50):
+def join_notes(excerpt, max_gap=50, inplace=False):
     """
     Combine two notes of the same pitch and track into one.
     
@@ -614,6 +662,10 @@ def join_notes(excerpt, max_gap=50):
         The maximum gap length, in ms, for 2 notes to be able to be joined.
         (They must always share the same pitch and track).
         
+    inplace : boolean
+        True to edit the given DataFrame in place. False to create a copy.
+        The result is returned either way.
+        
     seed : int
         A seed to be supplied to np.random.seed(). Defaults to None, which
         leaves numpy's random state unchanged.
@@ -621,7 +673,7 @@ def join_notes(excerpt, max_gap=50):
     Returns
     -------
     degraded : Composition
-        A copy of the given excerpt, with one note split.
+        A degradation of the excerpt, with one note split.
     """
     if excerpt.note_df.shape[0] < 2:
         warnings.warn('WARNING: No notes to join. Returning None.',
@@ -657,7 +709,10 @@ def join_notes(excerpt, max_gap=50):
     prev_i = valid_prev[index]
     next_i = valid_next[index]
     
-    degraded = excerpt.copy()
+    if inplace:
+        degraded = excerpt
+    else:
+        degraded = excerpt.copy()
     
     # Extend first note
     degraded.note_df.loc[prev_i]['dur'] = (degraded.note_df.loc[next_i]['onset'] +

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -597,20 +597,15 @@ def split_note(excerpt, min_duration=50, num_splits=1):
         return None
     
     # Find all splitable notes
-    valid_notes = []
-    
-    # Use indices because saving the df.loc objects creates copies
-    for note_index in range(excerpt.note_df.shape[0]):
-        if (excerpt.note_df.loc[note_index]['dur'] >=
-                (min_duration * (num_splits + 1))):
-            valid_notes.append(note_index)
+    long_enough = excerpt.note_df['dur'] >= min_duration * (num_splits + 1)
+    valid_notes = list(long_enough.index[long_enough])
     
     if not valid_notes:
         warnings.warn('WARNING: No valid notes to split. Returning ' +
                       'None.', category=UserWarning)
         return None
     
-    note_index = valid_notes[randint(len(valid_notes))]
+    note_index = choice(valid_notes)
     
     degraded = excerpt.copy()
     

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -120,7 +120,7 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         return None
     
     # Assume all notes can be shifted initially
-    valid_notes = list(range(excerpt.note_df.shape[0]))
+    valid_notes = list(excerpt.note_df.index)
     
     # If distribution is being used, some notes may not be possible to pitch
     # shift. This is because the distribution supplied would only allow them

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -488,7 +488,7 @@ def remove_note(excerpt):
     degraded = excerpt.copy()
 
     # Sample a random note
-    note_index = randint(0, degraded.note_df.shape[0])
+    note_index = choice(list(degraded.note_df.index))
 
     # Remove that note
     degraded.note_df.drop(note_index, inplace=True)

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -27,10 +27,11 @@ def test_pitch_shift():
         assert deg.pitch_shift(comp) == None, ("Pitch shifting with empty data "
                                                "frame did not return None.")
     
-    comp = ds.Composition(BASIC_DF)
-    
-    # Deterministic testing
+    # In place testing
     for i in range(2):
+        copy = BASIC_DF.copy()
+        comp = ds.Composition(copy)
+        
         comp2 = deg.pitch_shift(comp, seed=1, inplace=True)
     
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
@@ -43,8 +44,10 @@ def test_pitch_shift():
             f"instead of \n{basic_res}"
         )
         
-        changed = (comp == comp2) and BASIC_DF.equals(comp2.note_df)
-        assert changed, "Composition or note_df was not cloned."
+        inplace = (comp == comp2) and (copy.equals(comp2.note_df))
+        assert inplace, "Excerpt was not changed in place."
+    
+    comp = ds.Composition(BASIC_DF)
     
     # Deterministic testing
     for i in range(2):
@@ -149,6 +152,26 @@ def test_time_shift():
         assert deg.time_shift(comp) == None, ("Time shifting with empty data "
                                               "frame did not return None.")
     
+    # In place testing
+    for i in range(2):
+        copy = BASIC_DF.copy()
+        comp = ds.Composition(copy)
+        
+        comp2 = deg.time_shift(comp, seed=1, inplace=True)
+    
+        basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
+                                  'track': [0, 1, 0, 1],
+                                  'pitch': [10, 20, 30, 40],
+                                  'dur': [100, 100, 100, 100]})
+        
+        assert comp2.note_df.equals(basic_res), (
+            f"Time shifting \n{BASIC_DF}\nresulted in \n{comp2.note_df}\n"
+            f"instead of \n{basic_res}"
+        )
+        
+        inplace = (comp == comp2) and (copy.equals(comp2.note_df))
+        assert inplace, "Excerpt was not changed in place."
+    
     comp = ds.Composition(BASIC_DF)
     
     # Deterministic testing
@@ -160,11 +183,12 @@ def test_time_shift():
                                   'pitch': [10, 20, 30, 40],
                                   'dur': [100, 100, 100, 100]})
         
-        assert (comp2.note_df == basic_res).all().all(), (f"Time shifting \n{BASIC_DF}\n"
-                                                          f"resulted in \n{comp2.note_df}\n"
-                                                          f"instead of \n{basic_res}")
+        assert comp2.note_df.equals(basic_res), (
+            f"Time shifting \n{BASIC_DF}\nresulted in \n{comp2.note_df}\n"
+            f"instead of \n{basic_res}"
+        )
         
-        changed = comp != comp2 and BASIC_DF is not comp2.note_df
+        changed = (comp != comp2) and (not BASIC_DF.equals(comp2.note_df))
         assert changed, "Composition or note_df was not cloned."
         
     # Truly random testing
@@ -237,6 +261,26 @@ def test_onset_shift():
         assert deg.onset_shift(comp) == None, ("Onset shifting with empty data "
                                                "frame did not return None.")
     
+    # In place testing
+    for i in range(2):
+        copy = BASIC_DF.copy()
+        comp = ds.Composition(copy)
+        
+        comp2 = deg.onset_shift(comp, seed=1, inplace=True)
+    
+        basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
+                                  'track': [0, 1, 0, 1],
+                                  'pitch': [10, 20, 30, 40],
+                                  'dur': [100, 50, 100, 100]})
+        
+        assert comp2.note_df.equals(basic_res), (
+            f"Onset shifting \n{BASIC_DF}\nresulted in \n{comp2.note_df}\n"
+            f"instead of \n{basic_res}"
+        )
+        
+        inplace = (comp == comp2) and copy.equals(comp2.note_df)
+        assert inplace, f"Excerpt was not changed in place."
+    
     comp = ds.Composition(BASIC_DF)
     
     # Deterministic testing
@@ -248,11 +292,12 @@ def test_onset_shift():
                                   'pitch': [10, 20, 30, 40],
                                   'dur': [100, 50, 100, 100]})
         
-        assert (comp2.note_df == basic_res).all().all(), (f"Onset shifting \n{BASIC_DF}\n"
-                                                          f"resulted in \n{comp2.note_df}\n"
-                                                          f"instead of \n{basic_res}")
+        assert comp2.note_df.equals(basic_res), (
+            f"Onset shifting \n{BASIC_DF}\nresulted in \n{comp2.note_df}\n"
+            f"instead of \n{basic_res}"
+        )
         
-        changed = comp != comp2 and BASIC_DF is not comp2.note_df
+        changed = (comp != comp2) and (not BASIC_DF.equals(comp2.note_df))
         assert changed, "Composition or note_df was not cloned."
         
     # Random testing
@@ -372,6 +417,26 @@ def test_offset_shift():
         assert deg.offset_shift(comp) == None, ("Offset shifting with empty data "
                                                 "frame did not return None.")
     
+    # In place testing
+    for i in range(2):
+        copy = BASIC_DF.copy()
+        comp = ds.Composition(copy)
+        
+        comp2 = deg.offset_shift(comp, seed=1, inplace=True)
+    
+        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
+                                  'track': [0, 1, 0, 1],
+                                  'pitch': [10, 20, 30, 40],
+                                  'dur': [100, 158, 100, 100]})
+        
+        assert comp2.note_df.equals(basic_res), (
+            f"Offset shifting \n{BASIC_DF}\nresulted in \n{comp2.note_df}\n"
+            f"instead of \n{basic_res}"
+        )
+        
+        inplace = comp == comp2 and copy.equals(comp2.note_df)
+        assert inplace, "Excerpt was not changed in place."
+    
     comp = ds.Composition(BASIC_DF)
     
     # Deterministic testing
@@ -383,11 +448,12 @@ def test_offset_shift():
                                   'pitch': [10, 20, 30, 40],
                                   'dur': [100, 158, 100, 100]})
         
-        assert (comp2.note_df == basic_res).all().all(), (f"Offset shifting \n{BASIC_DF}\n"
-                                                          f"resulted in \n{comp2.note_df}\n"
-                                                          f"instead of \n{basic_res}")
+        assert comp2.note_df.equals(basic_res), (
+            f"Offset shifting \n{BASIC_DF}\nresulted in \n{comp2.note_df}\n"
+            f"instead of \n{basic_res}"
+        )
         
-        changed = comp != comp2 and BASIC_DF is not comp2.note_df
+        changed = (comp != comp2) and (not BASIC_DF.equals(comp2.note_df))
         assert changed, "Composition or note_df was not cloned."
         
     # Random testing
@@ -480,7 +546,27 @@ def test_remove_note():
                                                    "remove. Returning None.")):
         assert deg.remove_note(comp) == None, ("Remove note with empty data "
                                                "frame did not return None.")
+    
+    # In place testing
+    for i in range(2):
+        copy = BASIC_DF.copy()
+        comp = ds.Composition(copy)
         
+        comp2 = deg.remove_note(comp, seed=1, inplace=True)
+    
+        basic_res = pd.DataFrame({'onset': [0, 200, 200],
+                                  'track': [0, 0, 1],
+                                  'pitch': [10, 30, 40],
+                                  'dur': [100, 100, 100]})
+        
+        assert comp2.note_df.equals(basic_res), (
+            f"Removing note from \n{BASIC_DF}\n resulted in "
+            f"\n{comp2.note_df}\ninstead of \n{basic_res}"
+        )
+        
+        inplace = comp == comp2 and copy.equals(comp2.note_df)
+        assert inplace, "Excerpt was not changed in place."
+    
     comp = ds.Composition(BASIC_DF)
         
     # Deterministic testing
@@ -492,12 +578,12 @@ def test_remove_note():
                                   'pitch': [10, 30, 40],
                                   'dur': [100, 100, 100]})
         
-        assert (comp2.note_df == basic_res).all().all(), (f"Removing note from \n"
-                                                          f"{BASIC_DF}\n resulted"
-                                                          f" in \n{comp2.note_df}\n"
-                                                          f"instead of \n{basic_res}")
+        assert comp2.note_df.equals(basic_res), (
+            f"Removing note from \n{BASIC_DF}\n resulted in "
+            f"\n{comp2.note_df}\ninstead of \n{basic_res}"
+        )
         
-        changed = comp != comp2 and BASIC_DF is not comp2.note_df
+        changed = (comp != comp2) and (not BASIC_DF.equals(comp2.note_df))
         assert changed, "Composition or note_df was not cloned."
         
     # Random testing
@@ -517,6 +603,26 @@ def test_add_note():
     assert deg.add_note(comp) is not None, ("Add note to empty data "
                                             "frame returned None.")
     
+    # In place testing
+    for i in range(2):
+        copy = BASIC_DF.copy()
+        comp = ds.Composition(copy)
+        
+        comp2 = deg.add_note(comp, seed=1, inplace=True)
+    
+        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 235],
+                                  'track': [0, 1, 0, 1, 0],
+                                  'pitch': [10, 20, 30, 40, 37],
+                                  'dur': [100, 100, 100, 100, 62]})
+        
+        assert comp2.note_df.equals(basic_res), (
+            f"Adding note to \n{BASIC_DF}\n resulted in "
+            f"\n{comp2.note_df}\ninstead of \n{basic_res}"
+        )
+        
+        inplace = comp == comp2 and copy.equals(comp2.note_df)
+        assert inplace, f"Excerpt was not changed in place."
+    
     comp = ds.Composition(BASIC_DF)
     
     # Deterministic testing
@@ -528,10 +634,13 @@ def test_add_note():
                                   'pitch': [10, 20, 30, 40, 37],
                                   'dur': [100, 100, 100, 100, 62]})
         
-        assert (comp2.note_df == basic_res).all().all(), (f"Adding note to \n"
-                                                          f"{BASIC_DF}\n resulted"
-                                                          f" in \n{comp2.note_df}\n"
-                                                          f"instead of \n{basic_res}")
+        assert comp2.note_df.equals(basic_res), (
+            f"Adding note to \n{BASIC_DF}\n resulted in "
+            f"\n{comp2.note_df}\ninstead of \n{basic_res}"
+        )
+        
+        changed = (comp != comp2) and (not BASIC_DF.equals(comp2.note_df))
+        assert changed, "Composition or note_df was not cloned."
         
     # Random testing
     for i in range(10):
@@ -581,6 +690,26 @@ def test_split_note():
         assert deg.split_note(comp) == None, ("Split note with empty data "
                                               "frame did not return None.")
     
+    # In place testing
+    for i in range(2):
+        copy = BASIC_DF.copy()
+        comp = ds.Composition(copy)
+        
+        comp2 = deg.split_note(comp, seed=1, inplace=True)
+    
+        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 150],
+                                  'track': [0, 1, 0, 1, 1],
+                                  'pitch': [10, 20, 30, 40, 20],
+                                  'dur': [100, 50, 100, 100, 50]})
+        
+        assert comp2.note_df.equals(basic_res), (
+            f"Splitting note in \n{BASIC_DF}\n resulted in "
+            f"\n{comp2.note_df}\ninstead of \n{basic_res}"
+        )
+        
+        inplace = comp == comp2 and copy.equals(comp2.note_df)
+        assert inplace, "Excerpt was not changed in place."
+    
     comp = ds.Composition(BASIC_DF)
     
     # Deterministic testing
@@ -592,10 +721,13 @@ def test_split_note():
                                   'pitch': [10, 20, 30, 40, 20],
                                   'dur': [100, 50, 100, 100, 50]})
         
-        assert (comp2.note_df == basic_res).all().all(), (f"Splitting note in \n"
-                                                          f"{BASIC_DF}\n resulted"
-                                                          f" in \n{comp2.note_df}\n"
-                                                          f"instead of \n{basic_res}")
+        assert comp2.note_df.equals(basic_res), (
+            f"Splitting note in \n{BASIC_DF}\n resulted in "
+            f"\n{comp2.note_df}\ninstead of \n{basic_res}"
+        )
+        
+        changed = (comp != comp2) and (not BASIC_DF.equals(comp2.note_df))
+        assert changed, "Composition or note_df was not cloned."
         
     # Random testing
     for i in range(8):
@@ -674,6 +806,29 @@ def test_join_notes():
         'pitch': [10, 10, 10, 40],
         'dur': [100, 100, 100, 100]
     })
+    
+    # In place testing
+    for i in range(2):
+        copy = join_df.copy()
+        comp = ds.Composition(copy)
+        
+        comp2 = deg.join_notes(comp, seed=1, inplace=True)
+        
+        join_res = pd.DataFrame({
+            'onset': [0, 100, 200],
+            'track': [0, 0, 1],
+            'pitch': [10, 10, 40],
+            'dur': [100, 200, 100]
+        })
+        
+        assert comp2.note_df.equals(join_res), (
+            f"Joining \n{join_df}\nresulted in \n{comp2.note_df}\n"
+            f"instead of \n{join_res}"
+        )
+        
+        inplace = comp == comp2 and copy.equals(comp2.note_df)
+        assert inplace, "Excerpt was not changed in place."
+    
     comp = ds.Composition(join_df)
     
     # Deterministic testing
@@ -687,11 +842,12 @@ def test_join_notes():
             'dur': [100, 200, 100]
         })
         
-        assert (comp2.note_df == join_res).all().all(), (f"Joining \n{join_df}\n"
-                                                         f"resulted in \n{comp2.note_df}\n"
-                                                         f"instead of \n{join_res}")
+        assert comp2.note_df.equals(join_res), (
+            f"Joining \n{join_df}\nresulted in \n{comp2.note_df}\n"
+            f"instead of \n{join_res}"
+        )
         
-        changed = comp != comp2 and join_df is not comp2.note_df
+        changed = (comp != comp2) and (not join_df.equals(comp2.note_df))
         assert changed, "Composition or note_df was not cloned."
         
     # Check different pitch and track

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -7,7 +7,7 @@ import mdtk.degradations as deg
 
 EMPTY_DF = pd.DataFrame({
     'onset': [],
-    'track' : [],
+    'track': [],
     'pitch': [],
     'dur': []
 })
@@ -19,69 +19,74 @@ BASIC_DF = pd.DataFrame({
     'dur': [100, 100, 100, 100]
 })
 
+
 def test_pitch_shift():
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to pitch "
-                                                   "shift. Returning None.")):
-        assert deg.pitch_shift(EMPTY_DF) == None, (
+    with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to pitch"
+                                                   " shift. Returning None.")):
+        assert deg.pitch_shift(EMPTY_DF) is None, (
             "Pitch shifting with empty data frame did not return None."
         )
-    
+
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
         res = deg.pitch_shift(copy, seed=1, inplace=True)
-        
-        assert res is None, "Pitch shift with inplace=True returned something."
-    
+
+        assert res is None, (
+            "Pitch shift with inplace=True returned something."
+        )
+
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
                                   'track': [0, 1, 0, 1],
                                   'pitch': [10, 107, 30, 40],
                                   'dur': [100, 100, 100, 100]})
-        
+
         assert copy.equals(basic_res), (
             f"Pitch shifting \n{BASIC_DF}\n resulted in \n{copy}\n"
             f"instead of \n{basic_res}"
         )
-    
+
     # Deterministic testing
     for i in range(2):
         res = deg.pitch_shift(BASIC_DF, seed=1)
-    
+
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
                                   'track': [0, 1, 0, 1],
                                   'pitch': [10, 107, 30, 40],
                                   'dur': [100, 100, 100, 100]})
-        
+
         assert res.equals(basic_res), (
             f"Pitch shifting \n{BASIC_DF}\n resulted in \n{res}\n"
             f"instead of \n{basic_res}"
         )
-        
+
         assert not BASIC_DF.equals(res), "Note_df was not copied."
-        
-    
+
     # Truly random testing
     for i in range(10):
         np.random.seed()
-        
-        res = deg.pitch_shift(BASIC_DF, min_pitch=100 * i, max_pitch=100 * (i + 1))
-        
+
+        res = deg.pitch_shift(BASIC_DF, min_pitch=100 * i,
+                              max_pitch=100 * (i + 1))
+
         equal = (res == BASIC_DF)
-        
+
         # Check that only things that should have changed have changed
         assert equal['onset'].all(), "Pitch shift changed some onset time."
         assert equal['track'].all(), "Pitch shift changed some track."
         assert equal['dur'].all(), "Pitch shift changed some duration."
-        assert (1 - equal['pitch']).sum() == 1, ("Pitch shift did not change "
-                                                 "exactly one pitch.")
-        
+        assert (1 - equal['pitch']).sum() == 1, (
+            "Pitch shift did not change exactly one pitch."
+        )
+
         # Check that changed pitch is within given range
         changed_pitch = res[(res['pitch'] !=
-                                       BASIC_DF['pitch'])]['pitch'].iloc[0]
-        assert 100 * i <= changed_pitch <= 100 * (i + 1), (f"Pitch {changed_pitch} "
-                                                           f"outside of range [{100 * i}"
-                                                           f", {100 * (i + 1)}]")
-        
+                             BASIC_DF['pitch'])]['pitch'].iloc[0]
+        assert 100 * i <= changed_pitch <= 100 * (i + 1), (
+            f"Pitch {changed_pitch} outside of range "
+            f"[{100 * i}, {100 * (i + 1)}]"
+        )
+
         # Check a simple setting of the distribution parameter
         distribution = np.zeros(3)
         sample = np.random.randint(3)
@@ -89,763 +94,841 @@ def test_pitch_shift():
             sample = 2
         distribution[sample] = 1
         correct_diff = 1 - sample
-        
+
         res = deg.pitch_shift(BASIC_DF, distribution=distribution)
-        
+
         not_equal = (res['pitch'] != BASIC_DF['pitch'])
         changed_pitch = res[not_equal]['pitch'].iloc[0]
         original_pitch = BASIC_DF[not_equal]['pitch'].iloc[0]
         diff = original_pitch - changed_pitch
-        
-        assert diff == correct_diff, (f"Pitch difference {diff} is not equal to correct "
-                                      f" difference {correct_diff} with distribution = "
-                                      f"length 50 list of 0's with 1 at index {sample}.")
-        
+
+        assert diff == correct_diff, (
+            f"Pitch difference {diff} is not equal to correct difference "
+            f"{correct_diff} with distribution = length 50 list of 0's with "
+            f"1 at index {sample}."
+        )
+
     # Check for distribution warnings
     with pytest.warns(
-                UserWarning,
-                match=re.escape('WARNING: distribution contains only 0s after '
-                                'setting distribution[zero_idx] value to 0. '
-                                'Returning None.')
-            ):
+        UserWarning,
+        match=re.escape('WARNING: distribution contains only 0s after '
+                        'setting distribution[zero_idx] value to 0. '
+                        'Returning None.')
+    ):
         res = deg.pitch_shift(BASIC_DF, distribution=[0, 1, 0])
-        assert res == None, "Pitch shifting with distribution of 0s returned something."
-        
-    with pytest.warns(UserWarning, match=re.escape('WARNING: No valid pitches to shift '
-                                                   'given min_pitch')):
-        res = deg.pitch_shift(BASIC_DF, min_pitch=-50, max_pitch=-20, distribution=[1, 0, 1])
-        assert res == None, "Pitch shifting with invalid distribution returned something."
-        
+        assert res is None, (
+            "Pitch shifting with distribution of 0s returned something."
+        )
+
+    with pytest.warns(UserWarning, match=re.escape('WARNING: No valid pitches '
+                                                   'to shift given min_pitch')):
+        res = deg.pitch_shift(BASIC_DF, min_pitch=-50,
+                              max_pitch=-20, distribution=[1, 0, 1])
+        assert res is None, (
+            "Pitch shifting with invalid distribution returned something."
+        )
+
     res = deg.pitch_shift(BASIC_DF, min_pitch=BASIC_DF['pitch'].min() - 1,
-                            max_pitch=BASIC_DF['pitch'].min() - 1, distribution=[1, 0, 0])
+                          max_pitch=BASIC_DF['pitch'].min() - 1,
+                          distribution=[1, 0, 0])
     assert res is not None, "Valid shift down of 1 pitch returned None."
-    
+
     with pytest.warns(UserWarning, match=re.escape('WARNING: No valid pitches to shift '
                                                    'given min_pitch')):
         res = deg.pitch_shift(BASIC_DF, min_pitch=BASIC_DF['pitch'].min() - 2,
-                                max_pitch=BASIC_DF['pitch'].min() - 2, distribution=[1, 0, 0])
+                              max_pitch=BASIC_DF['pitch'].min() - 2,
+                              distribution=[1, 0, 0])
         assert res is None, "Invalid shift down of 2 pitch returned something."
-    
+
     res = deg.pitch_shift(BASIC_DF, min_pitch=BASIC_DF['pitch'].max() + 1,
-                            max_pitch=BASIC_DF['pitch'].max() + 1, distribution=[0, 0, 1])
+                          max_pitch=BASIC_DF['pitch'].max() + 1,
+                          distribution=[0, 0, 1])
     assert res is not None, "Valid shift up of 1 pitch returned None."
-    
+
     with pytest.warns(UserWarning, match=re.escape('WARNING: No valid pitches to shift '
                                                    'given min_pitch')):
         res = deg.pitch_shift(BASIC_DF, min_pitch=BASIC_DF['pitch'].max() + 2,
-                                max_pitch=BASIC_DF['pitch'].max() + 2, distribution=[0, 0, 1])
+                              max_pitch=BASIC_DF['pitch'].max() + 2,
+                              distribution=[0, 0, 1])
         assert res is None, "Invalid shift up of 2 pitch returned something."
-
 
 
 def test_time_shift():
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to time "
                                                    "shift. Returning None.")):
-        assert deg.time_shift(EMPTY_DF) == None, ("Time shifting with empty data "
+        assert deg.time_shift(EMPTY_DF) is None, ("Time shifting with empty data "
                                                   "frame did not return None.")
-    
+
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
         res = deg.time_shift(copy, seed=1, inplace=True)
-        
-        assert res is None, "Time shift with inplace=True returned something."
-    
+
+        assert res is None, (
+            "Time shift with inplace=True returned something."
+        )
+
         basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
                                   'track': [0, 1, 0, 1],
                                   'pitch': [10, 20, 30, 40],
                                   'dur': [100, 100, 100, 100]})
-        
+
         assert copy.equals(basic_res), (
             f"Time shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
             f"instead of \n{basic_res}"
         )
-    
+
     # Deterministic testing
     for i in range(2):
         res = deg.time_shift(BASIC_DF, seed=1)
-    
+
         basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
                                   'track': [0, 1, 0, 1],
                                   'pitch': [10, 20, 30, 40],
                                   'dur': [100, 100, 100, 100]})
-        
+
         assert res.equals(basic_res), (
             f"Time shifting \n{BASIC_DF}\nresulted in \n{res}\n"
             f"instead of \n{basic_res}"
         )
-        
+
         assert not BASIC_DF.equals(res), "Note_df was not copied."
-        
+
     # Truly random testing
     for i in range(10):
         np.random.seed()
-        
-        res = deg.time_shift(BASIC_DF, min_shift=10 * i, max_shift=10 * (i + 1))
-        
+
+        res = deg.time_shift(BASIC_DF, min_shift=10 * i,
+                             max_shift=10 * (i + 1))
+
         equal = (res == BASIC_DF)
-        
+
         # Check that only things that should have changed have changed
         assert equal['track'].all(), "Time shift changed some track."
         assert equal['pitch'].all(), "Time shift changed some pitch."
         assert equal['dur'].all(), "Time shift changed some duration."
-        assert (1 - equal['onset']).sum() == 1, ("Time shift did not change "
-                                                 "exactly one onset.")
-        
+        assert (1 - equal['onset']).sum() == 1, (
+            "Time shift did not change exactly one onset."
+        )
+
         # Check that changed onset is within given range
         changed_onset = res[(res['onset'] !=
-                                       BASIC_DF['onset'])]['onset'].iloc[0]
+                             BASIC_DF['onset'])]['onset'].iloc[0]
         original_onset = BASIC_DF[(res['onset'] !=
                                    BASIC_DF['onset'])]['onset'].iloc[0]
         shift = abs(changed_onset - original_onset)
-        assert 10 * i <= shift <= 10 * (i + 1), (f"Shift {shift} outside of range"
-                                                 f" [{10 * i}, {10 * (i + 1)}].")
-        
+        assert 10 * i <= shift <= 10 * (i + 1), (
+            f"Shift {shift} outside of range [{10 * i}, {10 * (i + 1)}]."
+        )
+
     # Check for range too large warning
     with pytest.warns(UserWarning, match=re.escape('WARNING: No valid notes to '
                                                    'time shift.')):
         res = deg.time_shift(BASIC_DF, min_shift=201, max_shift=202)
         assert res is None, "Invalid time shift of 201 returned something."
-    
+
     res = deg.time_shift(BASIC_DF, min_shift=200, max_shift=201)
     assert res is not None, "Valid time shift of 200 returned None."
-    
 
-    
+
 def test_onset_shift():
-    def check_onset_shift_result(df, res, min_shift, max_shift, min_duration,
-                                 max_duration):
+    def check_onset_shift_result(df, res, min_shift, max_shift,
+                                 min_duration, max_duration):
         diff = pd.concat([res, df]).drop_duplicates(keep=False)
         new_note = pd.merge(diff, res).reset_index()
         changed_note = pd.merge(diff, df).reset_index()
         unchanged_notes = pd.merge(res, df).reset_index()
-        
-        assert unchanged_notes.shape[0] == df.shape[0] - 1, ("More or less than 1 note"
-                                                                   " changed when shifting"
-                                                                   " onset.")
-        assert changed_note.shape[0] == 1, "More than 1 note changed when shifting onset."
-        assert new_note.shape[0] == 1, "More than 1 new note added when shifting onset."
-        assert min_duration <= new_note.loc[0]['dur'] <= max_duration, ("Note duration not"
-                                                                        " within bounds "
-                                                                        "when onset shifting.")
+
+        assert unchanged_notes.shape[0] == df.shape[0] - 1, (
+            "More or less than 1 note changed when shifting onset."
+        )
+        assert changed_note.shape[0] == 1, (
+            "More than 1 note changed when shifting onset."
+        )
+        assert new_note.shape[0] == 1, (
+            "More than 1 new note added when shifting onset."
+        )
+        assert min_duration <= new_note.loc[0]['dur'] <= max_duration, (
+            "Note duration not within bounds when onset shifting."
+        )
         assert (min_shift <=
-                abs(new_note.loc[0]['onset'] - changed_note.loc[0]['onset']) <=
-                max_shift), "Note shifted outside of bounds when onset shifting."
-        assert new_note.loc[0]['pitch'] == changed_note.loc[0]['pitch'], ("Pitch changed when"
-                                                                          " onset shifting.")
-        assert new_note.loc[0]['track'] == changed_note.loc[0]['track'], ("Track changed when"
-                                                                          " onset shifting.")
-        assert (changed_note.loc[0]['onset'] + changed_note.loc[0]['dur'] ==
-                new_note.loc[0]['onset'] + new_note.loc[0]['dur']), ("Offset changed when "
-                                                                     "onset shifting.")
-        assert changed_note.loc[0]['onset'] >= 0, "Changed note given negative onset time."
-        
+                abs(new_note.loc[0]['onset'] - changed_note.loc[0]['onset'])
+                <= max_shift), (
+            "Note shifted outside of bounds when onset shifting."
+        )
+        assert new_note.loc[0]['pitch'] == changed_note.loc[0]['pitch'], (
+            "Pitch changed when onset shifting."
+        )
+        assert new_note.loc[0]['track'] == changed_note.loc[0]['track'], (
+            "Track changed when onset shifting."
+        )
+        assert (changed_note.loc[0]['onset'] + changed_note.loc[0]['dur']
+                == new_note.loc[0]['onset'] + new_note.loc[0]['dur']), (
+            "Offset changed when onset shifting."
+        )
+        assert changed_note.loc[0]['onset'] >= 0, (
+            "Changed note given negative onset time."
+        )
+
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " onset shift. Returning "
                                                    "None.")):
-        assert deg.onset_shift(EMPTY_DF) == None, ("Onset shifting with empty data "
-                                               "frame did not return None.")
-    
+        assert deg.onset_shift(EMPTY_DF) is None, (
+            "Onset shifting with empty data frame did not return None."
+        )
+
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
         res = deg.onset_shift(copy, seed=1, inplace=True)
-        
-        assert res is None, "Onset shift with inplace=True returned something."
-    
+
+        assert res is None, (
+            "Onset shift with inplace=True returned something."
+        )
+
         basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
                                   'track': [0, 1, 0, 1],
                                   'pitch': [10, 20, 30, 40],
                                   'dur': [100, 50, 100, 100]})
-        
+
         assert copy.equals(basic_res), (
             f"Onset shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
             f"instead of \n{basic_res}"
         )
-        
+
     # Deterministic testing
     for i in range(2):
         res = deg.onset_shift(BASIC_DF, seed=1)
-    
+
         basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
                                   'track': [0, 1, 0, 1],
                                   'pitch': [10, 20, 30, 40],
                                   'dur': [100, 50, 100, 100]})
-        
+
         assert res.equals(basic_res), (
             f"Onset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
             f"instead of \n{basic_res}"
         )
-        
+
         assert not BASIC_DF.equals(res), "Note_df was not copied."
-        
+
     # Random testing
     for i in range(10):
         np.random.seed()
-        
+
         min_shift = i * 10
         max_shift = (i + 1) * 10
-        
+
         # Cut min/max shift in half towards less shift
         min_duration = 100 - min_shift - 5
         max_duration = 100 + min_shift + 5
         res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                min_duration=min_duration, max_duration=max_duration)
+                              min_duration=min_duration, max_duration=max_duration)
         check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
                                  max_duration)
-        
+
         # Duration is too short
         min_duration = 0
         max_duration = 100 - max_shift - 1
-        
+
         with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                        " onset shift. Returning "
                                                        "None.")):
             res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                min_duration=min_duration, max_duration=max_duration)
-            assert res is None, ("Onset shift with max_duration too short didn't "
-                                   "return None.")
-        
+                                  min_duration=min_duration, max_duration=max_duration)
+            assert res is None, (
+                "Onset shift with max_duration too short didn't return None."
+            )
+
         # Duration is barely short enough
         min_duration = 0
         max_duration = 100 - max_shift
         res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                min_duration=min_duration, max_duration=max_duration)
+                              min_duration=min_duration, max_duration=max_duration)
         check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
                                  max_duration)
-        
+
         # Duration is too long
         min_duration = 100 + max_shift + 1
         max_duration = np.inf
-        
+
         with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                        " onset shift. Returning "
                                                        "None.")):
             res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                min_duration=min_duration, max_duration=max_duration)
-            assert res is None, ("Onset shift with min_duration too long didn't "
-                                   "return None.")
-        
+                                  min_duration=min_duration, max_duration=max_duration)
+            assert res is None, (
+                "Onset shift with min_duration too long didn't return None."
+            )
+
         # Duration is barely short enough
         min_duration = 100 + max_shift
         max_duration = np.inf
         res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                min_duration=min_duration, max_duration=max_duration)
+                              min_duration=min_duration, max_duration=max_duration)
         check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
                                  max_duration)
-        
+
         # Duration is shortest half of shift
         min_duration = 0
         max_duration = 100 - min_shift - 5
         res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                min_duration=min_duration, max_duration=max_duration)
+                              min_duration=min_duration, max_duration=max_duration)
         check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
                                  max_duration)
-        
+
         # Duration is longest half of shift
         min_duration = 100 + min_shift + 5
         max_duration = np.inf
         res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                min_duration=min_duration, max_duration=max_duration)
+                              min_duration=min_duration, max_duration=max_duration)
         check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
                                  max_duration)
-        
+
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " onset shift. Returning "
                                                    "None.")):
         res = deg.onset_shift(BASIC_DF, min_shift=300)
-        assert res == None, ("Onset shifting with empty data min_shift greater "
-                               "than possible additional duration did not return "
-                               "None.")
-
+        assert res is None, (
+            "Onset shifting with empty data min_shift greater than "
+            "possible additional duration did not return None."
+        )
 
 
 def test_offset_shift():
-    def check_offset_shift_result(df, res, min_shift, max_shift, min_duration,
-                                  max_duration):
+    def check_offset_shift_result(df, res, min_shift, max_shift,
+                                  min_duration, max_duration):
         diff = pd.concat([res, df]).drop_duplicates(keep=False)
         new_note = pd.merge(diff, res).reset_index()
         changed_note = pd.merge(diff, df).reset_index()
         unchanged_notes = pd.merge(res, df).reset_index()
-        
-        assert unchanged_notes.shape[0] == df.shape[0] - 1, ("More or less than 1 note"
-                                                             " changed when shifting"
-                                                             " offset.")
-        assert changed_note.shape[0] == 1, "More than 1 note changed when shifting offset."
-        assert new_note.shape[0] == 1, "More than 1 new note added when shifting offset."
-        assert min_duration <= new_note.loc[0]['dur'] <= max_duration, ("Note duration not"
-                                                                        " within bounds "
-                                                                        "when offset shifting.")
+
+        assert unchanged_notes.shape[0] == df.shape[0] - 1, (
+            "More or less than 1 note changed when shifting offset."
+        )
+        assert changed_note.shape[0] == 1, (
+            "More than 1 note changed when shifting offset."
+        )
+        assert new_note.shape[0] == 1, (
+            "More than 1 new note added when shifting offset."
+        )
+        assert min_duration <= new_note.loc[0]['dur'] <= max_duration, (
+            "Note duration not within bounds when offset shifting."
+        )
         assert (min_shift <=
-                abs(new_note.loc[0]['dur'] - changed_note.loc[0]['dur']) <=
-                max_shift), "Note offset shifted outside of bounds when onset shifting."
-        assert new_note.loc[0]['pitch'] == changed_note.loc[0]['pitch'], ("Pitch changed when"
-                                                                          " offset shifting.")
-        assert new_note.loc[0]['track'] == changed_note.loc[0]['track'], ("Track changed when"
-                                                                          " offset shifting.")
-        assert (changed_note.loc[0]['onset'] == new_note.loc[0]['onset']), ("Onset changed when"
-                                                                            " offset shifting.")
-        assert (changed_note.loc[0]['onset'] + changed_note.loc[0]['dur'] <=
-                df[['onset', 'dur']].sum(axis=1).max()), ("Changed note offset shifted"
-                                                          " past previous last offset.")
-        
+                abs(new_note.loc[0]['dur'] - changed_note.loc[0]['dur'])
+                <= max_shift), (
+            "Note offset shifted outside of bounds when onset shifting."
+        )
+        assert new_note.loc[0]['pitch'] == changed_note.loc[0]['pitch'], (
+            "Pitch changed when offset shifting."
+        )
+        assert new_note.loc[0]['track'] == changed_note.loc[0]['track'], (
+            "Track changed when offset shifting."
+        )
+        assert changed_note.loc[0]['onset'] == new_note.loc[0]['onset'], (
+            "Onset changed when offset shifting."
+        )
+        assert (changed_note.loc[0]['onset'] + changed_note.loc[0]['dur']
+                <= df[['onset', 'dur']].sum(axis=1).max()), (
+            "Changed note offset shifted past previous last offset."
+        )
+
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " offset shift. Returning "
                                                    "None.")):
-        assert deg.offset_shift(EMPTY_DF) == None, ("Offset shifting with empty data "
-                                                "frame did not return None.")
-    
+        assert deg.offset_shift(EMPTY_DF) is None, (
+            "Offset shifting with empty data frame did not return None."
+        )
+
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
         res = deg.offset_shift(copy, seed=1, inplace=True)
-        
-        assert res is None, "Offset shift with inplace=True returned something."
-    
+
+        assert res is None, (
+            "Offset shift with inplace=True returned something."
+        )
+
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
                                   'track': [0, 1, 0, 1],
                                   'pitch': [10, 20, 30, 40],
                                   'dur': [100, 158, 100, 100]})
-        
+
         assert copy.equals(basic_res), (
             f"Offset shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
             f"instead of \n{basic_res}"
         )
-    
+
     # Deterministic testing
     for i in range(2):
         res = deg.offset_shift(BASIC_DF, seed=1)
-    
+
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
                                   'track': [0, 1, 0, 1],
                                   'pitch': [10, 20, 30, 40],
                                   'dur': [100, 158, 100, 100]})
-        
+
         assert res.equals(basic_res), (
             f"Offset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
             f"instead of \n{basic_res}"
         )
-        
+
         assert not BASIC_DF.equals(res), "Note_df was not copied."
-        
+
     # Random testing
     for i in range(10):
         np.random.seed()
-        
+
         min_shift = i * 10
         max_shift = (i + 1) * 10
-        
+
         # Cut min/max shift in half towards less shift
         min_duration = 100 - min_shift - 5
         max_duration = 100 + min_shift + 5
         res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                 min_duration=min_duration, max_duration=max_duration)
+                               min_duration=min_duration, max_duration=max_duration)
         check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
                                   max_duration)
-        
+
         # Duration is too short
         min_duration = 0
         max_duration = 100 - max_shift - 1
-        
+
         with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                        " offset shift. Returning "
                                                        "None.")):
-            res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                     min_duration=min_duration,
-                                     max_duration=max_duration)
-            assert res is None, ("Offset shift with max_duration too short didn't "
-                                   "return None.")
-        
+            res = deg.offset_shift(BASIC_DF, min_shift=min_shift,
+                                   max_shift=max_shift, min_duration=min_duration,
+                                   max_duration=max_duration)
+            assert res is None, (
+                "Offset shift with max_duration too short didn't return None."
+            )
+
         # Duration is barely short enough
         min_duration = 0
         max_duration = 100 - max_shift
         res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                 min_duration=min_duration, max_duration=max_duration)
+                               min_duration=min_duration, max_duration=max_duration)
         check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                 max_duration)
-        
+                                  max_duration)
+
         # Duration is too long
         min_duration = 100 + max_shift + 1
         max_duration = np.inf
-        
+
         with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                        " offset shift. Returning "
                                                        "None.")):
-            res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                     min_duration=min_duration,
-                                     max_duration=max_duration)
-            assert res is None, ("Offset shift with min_duration too long didn't "
-                                   "return None.")
-        
+            res = deg.offset_shift(BASIC_DF, min_shift=min_shift,
+                                   max_shift=max_shift, min_duration=min_duration,
+                                   max_duration=max_duration)
+            assert res is None, (
+                "Offset shift with min_duration too long didn't return None."
+            )
+
         # Duration is barely short enough
         min_duration = 100 + max_shift
         max_duration = np.inf
         res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                 min_duration=min_duration, max_duration=max_duration)
+                               min_duration=min_duration, max_duration=max_duration)
         check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
                                   max_duration)
-        
+
         # Duration is shortest half of shift
         min_duration = 0
         max_duration = 100 - min_shift - 5
-        res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                 min_duration=min_duration, max_duration=max_duration)
+        res = deg.offset_shift(BASIC_DF, min_shift=min_shift,max_shift=max_shift,
+                               min_duration=min_duration, max_duration=max_duration)
         check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
                                   max_duration)
-        
+
         # Duration is longest half of shift
         min_duration = 100 + min_shift + 5
         max_duration = np.inf
         res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                 min_duration=min_duration, max_duration=max_duration)
+                               min_duration=min_duration, max_duration=max_duration)
         check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
                                   max_duration)
-        
+
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " offset shift. Returning "
                                                    "None.")):
         res = deg.offset_shift(BASIC_DF, min_shift=300)
-        assert res == None, ("Offset shifting with empty data min_shift greater "
-                               "than possible additional note duration did not "
-                               "return None.")
-
+        assert res is None, (
+            "Offset shifting with empty data min_shift greater than "
+            "possible additional note duration did not return None."
+        )
 
 
 def test_remove_note():
     with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to "
                                                    "remove. Returning None.")):
-        assert deg.remove_note(EMPTY_DF) == None, ("Remove note with empty data "
-                                                   "frame did not return None.")
-    
+        assert deg.remove_note(EMPTY_DF) is None, (
+            "Remove note with empty data frame did not return None."
+        )
+
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
         res = deg.remove_note(copy, seed=1, inplace=True)
-        
-        assert res is None, "Removing note with inplace=True returned something."
-    
+
+        assert res is None, (
+            "Removing note with inplace=True returned something."
+        )
+
         basic_res = pd.DataFrame({'onset': [0, 200, 200],
                                   'track': [0, 0, 1],
                                   'pitch': [10, 30, 40],
                                   'dur': [100, 100, 100]})
-        
+
         assert copy.equals(basic_res), (
             f"Removing note from \n{BASIC_DF}\n resulted in "
             f"\n{copy}\ninstead of \n{basic_res}"
         )
-        
+
     # Deterministic testing
     for i in range(2):
         res = deg.remove_note(BASIC_DF, seed=1)
-    
+
         basic_res = pd.DataFrame({'onset': [0, 200, 200],
                                   'track': [0, 0, 1],
                                   'pitch': [10, 30, 40],
                                   'dur': [100, 100, 100]})
-        
+
         assert res.equals(basic_res), (
             f"Removing note from \n{BASIC_DF}\n resulted in "
             f"\n{res}\ninstead of \n{basic_res}"
         )
-        
+
         assert not BASIC_DF.equals(res), "Note_df was not copied."
-        
+
     # Random testing
     for i in range(10):
         np.random.seed()
-        
+
         res = deg.remove_note(BASIC_DF)
         merged = pd.merge(BASIC_DF, res)
-        
-        assert merged.shape[0] == BASIC_DF.shape[0] - 1, ("Remove note did not remove"
-                                                          " exactly 1 note.")
 
+        assert merged.shape[0] == BASIC_DF.shape[0] - 1, (
+            "Remove note did not remove exactly 1 note."
+        )
 
 
 def test_add_note():
-    assert deg.add_note(EMPTY_DF) is not None, ("Add note to empty data "
-                                                "frame returned None.")
-    
+    assert deg.add_note(EMPTY_DF) is not None, (
+        "Add note to empty data frame returned None."
+    )
+
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
         res = deg.add_note(copy, seed=1, inplace=True)
-        
-        assert res is None, "Adding note with inplace=True returned something."
-    
+
+        assert res is None, (
+            "Adding note with inplace=True returned something."
+        )
+
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 235],
                                   'track': [0, 1, 0, 1, 0],
                                   'pitch': [10, 20, 30, 40, 37],
                                   'dur': [100, 100, 100, 100, 62]})
-        
+
         assert copy.equals(basic_res), (
             f"Adding note to \n{BASIC_DF}\n resulted in "
             f"\n{copy}\ninstead of \n{basic_res}"
         )
-        
+
     # Deterministic testing
     for i in range(2):
         res = deg.add_note(BASIC_DF, seed=1)
-    
+
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 235],
                                   'track': [0, 1, 0, 1, 0],
                                   'pitch': [10, 20, 30, 40, 37],
                                   'dur': [100, 100, 100, 100, 62]})
-        
+
         assert res.equals(basic_res), (
             f"Adding note to \n{BASIC_DF}\n resulted in "
             f"\n{res}\ninstead of \n{basic_res}"
         )
-        
+
         assert not BASIC_DF.equals(res), "Note_df was not copied."
-        
+
     # Random testing
     for i in range(10):
         np.random.seed()
-        
+
         min_pitch = i * 10
         max_pitch = (i + 1) * 10
         min_duration = i * 10
         max_duration = (i + 1) * 10
-        
+
         res = deg.add_note(BASIC_DF, min_pitch=min_pitch, max_pitch=max_pitch,
-                             min_duration=min_duration, max_duration=max_duration)
-        
-        assert (res[:BASIC_DF.shape[0]] == BASIC_DF).all().all(), ("Adding a note"
-                                                                             "changed an "
-                                                                             "existing note.")
+                           min_duration=min_duration, max_duration=max_duration)
+
+        assert (res[:BASIC_DF.shape[0]] == BASIC_DF).all().all(), (
+            "Adding a note changed an existing note."
+        )
         assert res.shape[0] == BASIC_DF.shape[0] + 1, "No note was added."
-        
+
         note = res.loc[BASIC_DF.shape[0]]
-        assert min_pitch <= note['pitch'] <= max_pitch, (f"Added note's pitch ({note.pitch})"
-                                                         f" not within range "
-                                                         f" [{min_pitch}, {max_pitch}].")
-        assert min_duration <= note['dur'] <= max_duration, (f"Added note's duration "
-                                                             f"({note.pitch}) not within"
-                                                             f" range [{min_duration}, "
-                                                             f"{max_duration}].")
+        assert min_pitch <= note['pitch'] <= max_pitch, (
+            f"Added note's pitch ({note.pitch}) not within range "
+            f"[{min_pitch}, {max_pitch}]."
+        )
+        assert min_duration <= note['dur'] <= max_duration, (
+            f"Added note's duration ({note.pitch}) not within range "
+            f"[{min_duration}, {max_duration}]."
+        )
         assert (note['onset'] >= 0 and note['onset'] + note['dur'] <=
-                BASIC_DF[['onset', 'dur']].sum(axis=1).max()), ("Added note's onset and "
-                                                                "duration do not lie within"
-                                                                " bounds of given dataframe.")
-        
+                BASIC_DF[['onset', 'dur']].sum(axis=1).max()), (
+            "Added note's onset and duration do not lie within "
+            "bounds of given dataframe."
+        )
+
     # Test min_duration too large
     res = deg.add_note(BASIC_DF, min_duration=500)
     assert (res.loc[BASIC_DF.shape[0]]['onset'] == 0 and
-            res.loc[BASIC_DF.shape[0]]['dur'] == 500), ("Adding note with large "
-                                                                  "min_duration does not set"
-                                                                  " to full dataframe length.")
-        
-
+            res.loc[BASIC_DF.shape[0]]['dur'] == 500), (
+        "Adding note with large min_duration does not set duration "
+        "to full dataframe length."
+    )
 
 
 def test_split_note():
     with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to "
                                                    "split. Returning None.")):
-        assert deg.split_note(EMPTY_DF) == None, ("Split note with empty data "
-                                              "frame did not return None.")
-    
+        assert deg.split_note(EMPTY_DF) is None, (
+            "Split note with empty data frame did not return None."
+        )
+
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
         res = deg.split_note(copy, seed=1, inplace=True)
-        
-        assert res is None, "Splitting with inplace=True returned something."
-    
+
+        assert res is None, (
+            "Splitting with inplace=True returned something."
+        )
+
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 150],
                                   'track': [0, 1, 0, 1, 1],
                                   'pitch': [10, 20, 30, 40, 20],
                                   'dur': [100, 50, 100, 100, 50]})
-        
+
         assert copy.equals(basic_res), (
             f"Splitting note in \n{BASIC_DF}\n resulted in "
             f"\n{res}\ninstead of \n{basic_res}"
         )
-    
+
     # Deterministic testing
     for i in range(2):
         res = deg.split_note(BASIC_DF, seed=1)
-    
+
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 150],
                                   'track': [0, 1, 0, 1, 1],
                                   'pitch': [10, 20, 30, 40, 20],
                                   'dur': [100, 50, 100, 100, 50]})
-        
+
         assert res.equals(basic_res), (
             f"Splitting note in \n{BASIC_DF}\n resulted in "
             f"\n{res}\ninstead of \n{basic_res}"
         )
-        
+
         assert not BASIC_DF.equals(res), "Note_df was not copied."
-        
+
     # Random testing
     for i in range(8):
         np.random.seed()
-        
+
         num_splits = i + 1
         num_notes = num_splits + 1
-        
+
         res = deg.split_note(BASIC_DF, min_duration=10, num_splits=num_splits)
-        
+
         diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
         new_notes = pd.merge(diff, res).reset_index()
         changed_notes = pd.merge(diff, BASIC_DF).reset_index()
         unchanged_notes = pd.merge(res, BASIC_DF).reset_index()
-        
-        assert changed_notes.shape[0] == 1, "More than 1 note changed when splitting."
-        assert unchanged_notes.shape[0] == BASIC_DF.shape[0] - 1, ("More than 1 note "
-                                                                   "changed when "
-                                                                   "splitting.")
-        assert new_notes.shape[0] == num_notes, f"Did not split into {num_notes} notes."
-        
+
+        assert changed_notes.shape[0] == 1, (
+            "More than 1 note changed when splitting."
+        )
+        assert unchanged_notes.shape[0] == BASIC_DF.shape[0] - 1, (
+            "More than 1 note changed when splitting."
+        )
+        assert new_notes.shape[0] == num_notes, (
+            f"Did not split into {num_notes} notes."
+        )
+
         # Check first new note
-        assert (new_notes.loc[0]['pitch'] ==
-                changed_notes.loc[0]['pitch']), "Pitch changed when splitting."
-        assert (new_notes.loc[0]['track'] ==
-                changed_notes.loc[0]['track']), "Track changed when splitting."
-        assert (new_notes.loc[0]['onset'] ==
-                changed_notes.loc[0]['onset']), "Onset changed when splitting."
-        
+        assert new_notes.loc[0]['pitch'] == changed_notes.loc[0]['pitch'], (
+            "Pitch changed when splitting."
+        )
+        assert new_notes.loc[0]['track'] == changed_notes.loc[0]['track'], (
+            "Track changed when splitting."
+        )
+        assert new_notes.loc[0]['onset'] == changed_notes.loc[0]['onset'], (
+            "Onset changed when splitting."
+        )
+
         # Check duration and remainder of notes
         total_duration = new_notes.loc[0]['dur']
-        
+
         notes = list(new_notes.iterrows())
         for prev_note, next_note in zip(notes[:-1], notes[1:]):
             total_duration += next_note[1]['dur']
-            
-            assert prev_note[1]['pitch'] == next_note[1]['pitch'], ("Pitch changed "
-                                                                    "when splitting.")
-            assert prev_note[1]['track'] == next_note[1]['track'], ("Track changed "
-                                                                    "when splitting.")
+
+            assert prev_note[1]['pitch'] == next_note[1]['pitch'], (
+                "Pitch changed when splitting."
+            )
+            assert prev_note[1]['track'] == next_note[1]['track'], (
+                "Track changed when splitting."
+            )
             assert (prev_note[1]['onset'] + prev_note[1]['dur']
-                    == next_note[1]['onset']), ("Offset/onset times of split notes "
-                                                "not aligned.")
-            
-            
-        assert total_duration == changed_notes.loc[0]['dur'], ("Duration changed "
-                                                               "when splitting.")
-        
+                    == next_note[1]['onset']), (
+                "Offset/onset times of split notes not aligned."
+            )
+
+        assert total_duration == changed_notes.loc[0]['dur'], (
+            "Duration changed when splitting."
+        )
+
     # Test min_duration too large for num_splits
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " split. Returning None.")):
-        assert deg.split_note(BASIC_DF,
-                              min_duration=10,
-                              num_splits=10) == None, ("Splitting note into "
-                                                       "too many pieces didn't"
-                                                       " return None.")
-
+        assert deg.split_note(BASIC_DF, min_duration=10,
+                              num_splits=10) is None, (
+            "Splitting note into too many pieces didn't return None."
+        )
 
 
 def test_join_notes():
     with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to "
                                                    "join. Returning None.")):
-        assert deg.join_notes(EMPTY_DF) == None, ("Join notes with empty data "
-                                              "frame did not return None.")
-    
+        assert deg.join_notes(EMPTY_DF) is None, (
+            "Join notes with empty data frame did not return None."
+        )
+
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " join. Returning None.")):
-        assert deg.join_notes(BASIC_DF) == None, ("Joining notes with none back-to"
-                                                  "back didn't return None.")
-    
+        assert deg.join_notes(BASIC_DF) is None, (
+            "Joining notes with none back-to-back didn't return None."
+        )
+
     join_df = pd.DataFrame({
         'onset': [0, 100, 200, 200],
         'track': [0, 0, 0, 1],
         'pitch': [10, 10, 10, 40],
         'dur': [100, 100, 100, 100]
     })
-    
+
     # In place testing
     for i in range(2):
         copy = join_df.copy()
         res = deg.join_notes(copy, seed=1, inplace=True)
-        
-        assert res is None, "Joining with inplace=True returned something."
-        
+
+        assert res is None, (
+            "Joining with inplace=True returned something."
+        )
+
         join_res = pd.DataFrame({
             'onset': [0, 100, 200],
             'track': [0, 0, 1],
             'pitch': [10, 10, 40],
             'dur': [100, 200, 100]
         })
-        
+
         assert copy.equals(join_res), (
             f"Joining \n{join_df}\nresulted in \n{copy}\n"
             f"instead of \n{join_res}"
         )
-    
+
     # Deterministic testing
     for i in range(2):
         res = deg.join_notes(join_df, seed=1)
-        
+
         join_res = pd.DataFrame({
             'onset': [0, 100, 200],
             'track': [0, 0, 1],
             'pitch': [10, 10, 40],
             'dur': [100, 200, 100]
         })
-        
+
         assert res.equals(join_res), (
             f"Joining \n{join_df}\nresulted in \n{res}\n"
             f"instead of \n{join_res}"
         )
-        
+
         assert not join_df.equals(res), "Note_df was not copied."
-        
+
     # Check different pitch and track
     join_df.loc[1]['pitch'] = 20
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " join. Returning None.")):
-        assert deg.join_notes(join_df) == None, ("Joining notes with different "
-                                              "pitches didn't return None.")
-    
+        assert deg.join_notes(join_df) is None, (
+            "Joining notes with different pitches didn't return None."
+        )
+
     join_df.loc[1]['pitch'] = 10
     join_df.loc[1]['track'] = 1
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " join. Returning None.")):
-        assert deg.join_notes(join_df) == None, ("Joining notes with different "
-                                              "tracks didn't return None.")
-        
+        assert deg.join_notes(join_df) is None, (
+            "Joining notes with different tracks didn't return None."
+        )
+
     # Check some with different max_gaps
     join_df.loc[1]['track'] = 0
     for i in range(10):
         np.random.seed()
-        
+
         max_gap = i * 10
-        
-        join_df.loc[0]['dur'] = join_df.loc[1]['onset'] - max_gap - join_df.loc[0]['onset']
-        join_df.loc[1]['dur'] = join_df.loc[2]['onset'] - max_gap - join_df.loc[1]['onset']
-        
+
+        join_df.loc[0]['dur'] = join_df.loc[1]['onset'] - \
+            max_gap - join_df.loc[0]['onset']
+        join_df.loc[1]['dur'] = join_df.loc[2]['onset'] - \
+            max_gap - join_df.loc[1]['onset']
+
         res = deg.join_notes(join_df, max_gap=max_gap)
-        
+
         # Gap should work
         diff = pd.concat([res, join_df]).drop_duplicates(keep=False)
         new_note = pd.merge(diff, res).reset_index()
         joined_notes = pd.merge(diff, join_df).reset_index()
         unchanged_notes = pd.merge(res, join_df).reset_index()
-        
-        assert unchanged_notes.shape[0] == join_df.shape[0] - 2, ("Joining notes changed "
-                                                                  "too many notes.")
-        assert new_note.shape[0] == 1, ("Joining notes resulted in more than 1 new note.")
-        assert joined_notes.shape[0] == 2, "Joining notes changed too many notes."
-        
-        assert (new_note.loc[0]['onset'] ==
-                joined_notes.loc[0]['onset']), "Joined onset not equal to original onset."
-        assert (new_note.loc[0]['pitch'] ==
-                joined_notes.loc[0]['pitch']), "Joined pitch not equal to original pitch."
-        assert (new_note.loc[0]['track'] ==
-                joined_notes.loc[0]['track']), "Joined track not equal to original pitch."
+
+        assert unchanged_notes.shape[0] == join_df.shape[0] - 2, (
+            "Joining notes changed too many notes."
+        )
+        assert new_note.shape[0] == 1, (
+            "Joining notes resulted in more than 1 new note."
+        )
+        assert joined_notes.shape[0] == 2, (
+            "Joining notes changed too many notes."
+        )
+        assert new_note.loc[0]['onset'] == joined_notes.loc[0]['onset'], (
+            "Joined onset not equal to original onset."
+        )
+        assert new_note.loc[0]['pitch'] == joined_notes.loc[0]['pitch'], (
+            "Joined pitch not equal to original pitch."
+        )
+        assert new_note.loc[0]['track'] == joined_notes.loc[0]['track'], (
+            "Joined track not equal to original pitch."
+        )
         assert (new_note.loc[0]['dur'] ==
                 joined_notes.loc[1]['dur'] + joined_notes.loc[1]['onset'] -
-                joined_notes.loc[0]['onset']), ("Joined duration not equal to original "
-                                                "durations plus gap.")
-        
+                joined_notes.loc[0]['onset']), (
+            "Joined duration not equal to original durations plus gap."
+        )
+
         join_df.loc[0]['dur'] -= 1
         join_df.loc[1]['dur'] -= 1
-        
+
         # Gap too large
         with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                        " join. Returning None.")):
-            assert deg.join_notes(join_df, max_gap=max_gap) == None, ("Joining notes with too"
-                                                                   "large of a gap didn't "
-                                                                   "return None.")
-
+            assert deg.join_notes(join_df, max_gap=max_gap) is None, (
+                "Joining notes with too large of a gap didn't return None."
+            )

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -31,6 +31,23 @@ def test_pitch_shift():
     
     # Deterministic testing
     for i in range(2):
+        comp2 = deg.pitch_shift(comp, seed=1, inplace=True)
+    
+        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
+                                  'track': [0, 1, 0, 1],
+                                  'pitch': [10, 107, 30, 40],
+                                  'dur': [100, 100, 100, 100]})
+        
+        assert comp2.note_df.equals(basic_res), (
+            f"Pitch shifting \n{BASIC_DF}\n resulted in \n{comp2.note_df}\n"
+            f"instead of \n{basic_res}"
+        )
+        
+        changed = (comp == comp2) and BASIC_DF.equals(comp2.note_df)
+        assert changed, "Composition or note_df was not cloned."
+    
+    # Deterministic testing
+    for i in range(2):
         comp2 = deg.pitch_shift(comp, seed=1)
     
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -29,7 +29,9 @@ def test_pitch_shift():
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
-        deg.pitch_shift(copy, seed=1, inplace=True)
+        res = deg.pitch_shift(copy, seed=1, inplace=True)
+        
+        assert res is None, "Pitch shift with inplace=True returned something."
     
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
                                   'track': [0, 1, 0, 1],
@@ -145,7 +147,9 @@ def test_time_shift():
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
-        deg.time_shift(copy, seed=1, inplace=True)
+        res = deg.time_shift(copy, seed=1, inplace=True)
+        
+        assert res is None, "Time shift with inplace=True returned something."
     
         basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
                                   'track': [0, 1, 0, 1],
@@ -246,6 +250,8 @@ def test_onset_shift():
     for i in range(2):
         copy = BASIC_DF.copy()
         res = deg.onset_shift(copy, seed=1, inplace=True)
+        
+        assert res is None, "Onset shift with inplace=True returned something."
     
         basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
                                   'track': [0, 1, 0, 1],
@@ -392,7 +398,9 @@ def test_offset_shift():
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
-        deg.offset_shift(copy, seed=1, inplace=True)
+        res = deg.offset_shift(copy, seed=1, inplace=True)
+        
+        assert res is None, "Offset shift with inplace=True returned something."
     
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
                                   'track': [0, 1, 0, 1],
@@ -512,7 +520,9 @@ def test_remove_note():
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
-        deg.remove_note(copy, seed=1, inplace=True)
+        res = deg.remove_note(copy, seed=1, inplace=True)
+        
+        assert res is None, "Removing note with inplace=True returned something."
     
         basic_res = pd.DataFrame({'onset': [0, 200, 200],
                                   'track': [0, 0, 1],
@@ -559,7 +569,9 @@ def test_add_note():
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
-        deg.add_note(copy, seed=1, inplace=True)
+        res = deg.add_note(copy, seed=1, inplace=True)
+        
+        assert res is None, "Adding note with inplace=True returned something."
     
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 235],
                                   'track': [0, 1, 0, 1, 0],
@@ -636,7 +648,9 @@ def test_split_note():
     # In place testing
     for i in range(2):
         copy = BASIC_DF.copy()
-        deg.split_note(copy, seed=1, inplace=True)
+        res = deg.split_note(copy, seed=1, inplace=True)
+        
+        assert res is None, "Splitting with inplace=True returned something."
     
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 150],
                                   'track': [0, 1, 0, 1, 1],
@@ -743,7 +757,9 @@ def test_join_notes():
     # In place testing
     for i in range(2):
         copy = join_df.copy()
-        deg.join_notes(copy, seed=1, inplace=True)
+        res = deg.join_notes(copy, seed=1, inplace=True)
+        
+        assert res is None, "Joining with inplace=True returned something."
         
         join_res = pd.DataFrame({
             'onset': [0, 100, 200],


### PR DESCRIPTION
This makes and tests 3 performance changes to the degradations:

1. Converts the input format from Compositions to pd.DataFrames. This is in regards to #25, which I will leave open for now in case we want to reconsider this format again (into, e.g., dicts, arrays...)
2. Adds an inplace parameter to each degradation. inplace=False is the default, and performs exactly as before. inplace=True changes the given excerpt parameter in place, and returns None. This is noted in the docs under inplace, excerpt, and the return value. It is also noted under inplace for add_note and split_note that this can make performance worse. Overall, we see little if any improvement, but it is worth including so people can use the degradations this way if they wish. This fixes #35. Tests were added for the inplace param and return values.
3. Vectorizes all of the operations. There is no more looping over indices (and I fixed a few bugs that would've cropped up with non-consecutive indices, though they shouldn't now--TODO: we may want to add tests for this). There is still the nested groupby in join_notes, but I'm not sure how to fix this. This leads to a significant performance improvement. This fixes #34.