### PR TITLE
Degradations

### DIFF
--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -789,7 +789,7 @@ def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
 
 
 @set_random_seed
-def join_notes(excerpt, max_gap=50, max_notes=2, only_first=False,
+def join_notes(excerpt, max_gap=50, max_notes=20, only_first=False,
                inplace=False):
     """
     Combine two notes of the same pitch and track into one.
@@ -858,7 +858,7 @@ def join_notes(excerpt, max_gap=50, max_notes=2, only_first=False,
 
             # Get valid notes to start joining from
             if only_first:
-                valid = gap_after <= max_gap and gap_before > max_gap
+                valid = (gap_after <= max_gap) & (gap_before > max_gap)
             else:
                 valid = gap_after <= max_gap
             valid_starts.extend(list(valid.index[valid]))

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -23,7 +23,7 @@ def set_random_seed(func, seed=None):
         function to be decorated
     seed : int or None
         A seed to be supplied to np.random.seed(). None leaves numpy's
-        leaves numpy's random state unchanged.
+        random state unchanged.
 
     Returns
     -------
@@ -150,7 +150,7 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
-        leaves numpy's random state unchanged.
+        random state unchanged.
 
 
     Returns
@@ -257,7 +257,7 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf, align_onset=False):
 
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
-        leaves numpy's random state unchanged.
+        random state unchanged.
 
 
     Returns
@@ -393,7 +393,7 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
-        leaves numpy's random state unchanged.
+        random state unchanged.
 
     Returns
     -------
@@ -559,7 +559,7 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
-        leaves numpy's random state unchanged.
+        random state unchanged.
 
 
     Returns
@@ -654,7 +654,7 @@ def remove_note(excerpt):
 
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
-        leaves numpy's random state unchanged.
+        random state unchanged.
 
     Returns
     -------
@@ -719,7 +719,7 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
-        leaves numpy's random state unchanged.
+        random state unchanged.
 
 
     Returns
@@ -831,7 +831,7 @@ def split_note(excerpt, min_duration=50, num_splits=1):
 
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
-        leaves numpy's random state unchanged.
+        random state unchanged.
 
     Returns
     -------
@@ -915,7 +915,7 @@ def join_notes(excerpt, max_gap=50, max_notes=20, only_first=False):
 
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
-        leaves numpy's random state unchanged.
+        random state unchanged.
 
     Returns
     -------

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -725,11 +725,22 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
         # Find onset and duration
         if align_time:
-            # TODO: Keep in correct ranges
-            onset = choice(excerpt['onset'].unique())
-            dur_unique = excerpt['dur'].unique()
-            dur_in_range = dur_unique[dur_unique <= end_time - onset]
-            duration = choice(dur_in_range)
+            if (min_duration > excerpt['dur'].max() or
+                max_duration < excerpt['dur'].min()):
+                warnings.warn("WARNING: No valid aligned duration in "
+                              "given range.", category=UserWarning)
+                return None
+
+            durations = excerpt['dur'].between(min_duration, max_duration,
+                                               inclusive=True)
+            durations = excerpt['dur'][durations]
+            min_dur = durations.min()
+            onset = excerpt['onset'].between(0, end_time - min_dur,
+                                             inclusive=True)
+            onset = choice(excerpt['onset'][onset].unique())
+            dur_unique = durations[durations.between(
+                min_dur, end_time - onset, inclusive=True)].unique()
+            duration = choice(dur_unique)
         elif min_duration > end_time:
             onset = 0
             duration = min_duration

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -700,6 +700,7 @@ def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
 
     if inplace:
         degraded = excerpt
+        degraded.loc[note_index]['dur'] = int(round(short_duration_float))
         if len(degraded) > 0:
             start = max(degraded.index) + 1
         else:
@@ -712,14 +713,12 @@ def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
                                     'dur': durs[note_idx]}
     else:
         degraded = excerpt.copy()
+        degraded.loc[note_index]['dur'] = int(round(short_duration_float))
         new_df = pd.DataFrame({'onset': onsets,
                                'track': tracks,
                                'pitch': pitches,
                                'dur': durs})
         degraded = degraded.append(new_df, ignore_index=True)
-
-    # Shorten original note
-    degraded.loc[note_index]['dur'] = int(round(short_duration_float))
 
     degraded = post_process(degraded, inplace=inplace)
 

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -22,7 +22,7 @@ def set_random_seed(func, seed=None):
     func : function
         function to be decorated
     seed : int or None
-        A seed to be supplied to np.random.seed(). Defaults to None, which
+        A seed to be supplied to np.random.seed(). None leaves numpy's
         leaves numpy's random state unchanged.
 
     Returns
@@ -114,7 +114,7 @@ def split_range_sample(split_range, p=None):
     p : list(float)
         If given, should be a list the same length as split_range, and
         contains the probability of sampling from each range. p will be
-        normalized before use. Defaults to None.
+        normalized before use.
 
     Returns
     -------
@@ -156,14 +156,14 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         pitch, and will be set to 0. Additionally, pitches outside of the
         range [min_pitch, max_pitch] will also be set to 0. The distribution
         will then be normalized to sum to 1, and used to generate a new
-        pitch. Defaults to None, which implies a uniform distribution.
+        pitch. None implies a uniform distribution.
 
     inplace : boolean
         True to edit the given excerpt in place. False to create and return
         a copy.
 
     seed : int
-        A seed to be supplied to np.random.seed(). Defaults to None, which
+        A seed to be supplied to np.random.seed(). None leaves numpy's
         leaves numpy's random state unchanged.
 
 
@@ -269,18 +269,17 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf, inplace=False):
         will be changed in place if the degradation is possible.
 
     min_shift : int
-        The minimum amount by which the note will be shifted. Defaults to 50.
+        The minimum amount by which the note will be shifted.
 
     max_shift : int
-        The maximum amount by which the note will be shifted. Defaults to
-        infinity.
+        The maximum amount by which the note will be shifted.
 
     inplace : boolean
-        True to edit the given excerpt in place. False to create and return
-        a copy.
+        True to edit the given excerpt in place. False to create and
+        return a copy.
 
     seed : int
-        A seed to be supplied to np.random.seed(). Defaults to None, which
+        A seed to be supplied to np.random.seed(). None leaves numpy's
         leaves numpy's random state unchanged.
 
 
@@ -357,18 +356,16 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
         will be changed in place if the degradation is possible.
 
     min_shift : int
-        The minimum amount by which the onset time will be changed. Defaults
-        to 50.
+        The minimum amount by which the onset time will be changed.
 
     max_shift : int
-        The maximum amount by which the onset time will be changed. Defaults
-        to infinity.
+        The maximum amount by which the onset time will be changed.
 
     min_duration : int
-        The minimum duration for the resulting note. Defaults to 50.
+        The minimum duration for the resulting note.
 
     max_duration : int
-        The maximum duration for the resulting note. Defaults to infinity.
+        The maximum duration for the resulting note.
         (The offset time will never go beyond the current last offset
         in the excerpt.)
 
@@ -377,7 +374,7 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
         a copy.
 
     seed : int
-        A seed to be supplied to np.random.seed(). Defaults to None, which
+        A seed to be supplied to np.random.seed(). None leaves numpy's
         leaves numpy's random state unchanged.
 
     Returns
@@ -457,18 +454,16 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
         will be changed in place if the degradation is possible.
 
     min_shift : int
-        The minimum amount by which the offset time will be changed. Defaults
-        to 50.
+        The minimum amount by which the offset time will be changed.
 
     max_shift : int
-        The maximum amount by which the offset time will be changed. Defaults
-        to infinity.
+        The maximum amount by which the offset time will be changed.
 
     min_duration : int
-        The minimum duration for the resulting note. Defaults to 50.
+        The minimum duration for the resulting note.
 
     max_duration : int
-        The maximum duration for the resulting note. Defaults to infinity.
+        The maximum duration for the resulting note.
         (The offset time will never go beyond the current last offset
         in the excerpt.)
 
@@ -477,7 +472,7 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
         a copy.
 
     seed : int
-        A seed to be supplied to np.random.seed(). Defaults to None, which
+        A seed to be supplied to np.random.seed(). None leaves numpy's
         leaves numpy's random state unchanged.
 
 
@@ -559,7 +554,7 @@ def remove_note(excerpt, inplace=False):
         a copy.
 
     seed : int
-        A seed to be supplied to np.random.seed(). Defaults to None, which
+        A seed to be supplied to np.random.seed(). None leaves numpy's
         leaves numpy's random state unchanged.
 
     Returns
@@ -616,10 +611,10 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         The maximum pitch at which a note may be added.
 
     min_duration : int
-        The minimum duration for the note to be added. Defaults to 50.
+        The minimum duration for the note to be added.
 
     max_duration : int
-        The maximum duration for the added note. Defaults to infinity.
+        The maximum duration for the added note.
         (The offset time will never go beyond the current last offset
         in the excerpt.)
         
@@ -641,7 +636,7 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         less efficient.
 
     seed : int
-        A seed to be supplied to np.random.seed(). Defaults to None, which
+        A seed to be supplied to np.random.seed(). None leaves numpy's
         leaves numpy's random state unchanged.
 
 
@@ -754,7 +749,7 @@ def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
         less efficient because rows must be appended to the data frame.
 
     seed : int
-        A seed to be supplied to np.random.seed(). Defaults to None, which
+        A seed to be supplied to np.random.seed(). None leaves numpy's
         leaves numpy's random state unchanged.
 
     Returns
@@ -864,7 +859,7 @@ def join_notes(excerpt, max_gap=50, max_notes=20, only_first=False,
         less efficient because rows must be appended to the data frame.
 
     seed : int
-        A seed to be supplied to np.random.seed(). Defaults to None, which
+        A seed to be supplied to np.random.seed(). None leaves numpy's
         leaves numpy's random state unchanged.
 
     Returns

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -88,23 +88,13 @@ def post_process(df, inplace=False):
     df : pd.DataFrame
         The dataframe to post-process
 
-    inplace : boolean
-        True to edit the given dataframe in place. False to create and return
-        a copy.
-
     Returns
     -------
     df : pd.DataFrame
         The postprocessed dataframe, or None if inplace is True.
     """
-    if inplace:
-        df.sort_values(NOTE_DF_SORT_ORDER, inplace=True)
-        df.reset_index(drop=True, inplace=True)
-        return None
-
-    df = df.sort_values(NOTE_DF_SORT_ORDER)
-    df = df.reset_index(drop=True)
-    return df
+    df.sort_values(NOTE_DF_SORT_ORDER, inplace=True)
+    df.reset_index(drop=True, inplace=True)
 
 
 def split_range_sample(split_range, p=None):
@@ -260,7 +250,7 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         distribution = distribution / np.sum(distribution)
         degraded.loc[note_index, 'pitch'] = choice(pitches, p=distribution)
 
-    degraded = post_process(degraded, inplace=inplace)
+    post_process(degraded)
 
     if not inplace:
         return degraded
@@ -348,7 +338,7 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf, inplace=False):
 
     degraded.loc[index, 'onset'] = onset
 
-    degraded = post_process(degraded, inplace=inplace)
+    post_process(degraded)
 
     if not inplace:
         return degraded
@@ -448,7 +438,7 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
     degraded.loc[index, 'onset'] = onset
     degraded.loc[index, 'dur'] = offset[index] - onset
 
-    degraded = post_process(degraded, inplace=inplace)
+    post_process(degraded)
 
     if not inplace:
         return degraded
@@ -547,7 +537,7 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
     degraded.loc[index, 'dur'] = duration
 
-    degraded = post_process(degraded, inplace=inplace)
+    post_process(degraded)
 
     if not inplace:
         return degraded
@@ -690,7 +680,7 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
                                     'track': track},
                                    ignore_index=True)
 
-    degraded = post_process(degraded, inplace=inplace)
+    post_process(degraded)
 
     if not inplace:
         return degraded
@@ -792,7 +782,7 @@ def split_note(excerpt, min_duration=50, num_splits=1, inplace=False):
                                'dur': durs})
         degraded = degraded.append(new_df, ignore_index=True)
 
-    degraded = post_process(degraded, inplace=inplace)
+    post_process(degraded)
 
     if not inplace:
         return degraded
@@ -880,7 +870,7 @@ def join_notes(excerpt, max_gap=50, inplace=False):
     degraded.drop(next_i, inplace=True)
     degraded.reset_index(drop=True, inplace=True)
 
-    degraded = post_process(degraded, inplace=inplace)
+    post_process(degraded)
 
     if not inplace:
         return degraded

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -712,12 +712,20 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
     for iters in range(10):
         if align_pitch:
-            pitch = choice(excerpt['pitch'].unique())
+            pitch = excerpt['pitch'].between(min_pitch, max_pitch,
+                                             inclusive=True)
+            pitch = excerpt['pitch'][pitch].unique()
+            if len(pitch) == 0:
+                warnings.warn("WARNING: No valid aligned pitch in given "
+                              "range.", category=UserWarning)
+                return None
+            pitch = choice(pitch)
         else:
             pitch = randint(min_pitch, max_pitch + 1)
 
         # Find onset and duration
         if align_time:
+            # TODO: Keep in correct ranges
             onset = choice(excerpt['onset'].unique())
             dur_unique = excerpt['dur'].unique()
             dur_in_range = dur_unique[dur_unique <= end_time - onset]

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -326,6 +326,42 @@ def test_time_shift():
             f"Shift {shift} outside of range [{10 * i}, {10 * (i + 1)}]."
         )
 
+        # Check with align_onset=True
+        if 10 * i <= 200 and 10 * (i + 1) >= 100:
+            res = deg.time_shift(BASIC_DF, min_shift=10 * i,
+                             max_shift=10 * (i + 1), align_onset=True)
+
+            # Check that only things that should have changed have changed
+            diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
+            assert diff.shape[0] == 2, "Time shift changed more than 1 note." + "\n" + str(BASIC_DF) + "\n" + str(res)
+            assert diff.iloc[0]['onset'] != diff.iloc[1]['onset'], (
+                "Time shift did not change any onset time."
+            )
+            assert diff.iloc[0]['track'] == diff.iloc[1]['track'], (
+                "Time shift changed some track."
+            )
+            assert diff.iloc[0]['dur'] == diff.iloc[1]['dur'], (
+                "Time shift changed some duration."
+            )
+            assert diff.iloc[0]['pitch'] == diff.iloc[1]['pitch'], (
+                "Time shift changed some pitch."
+            )
+            assert diff.iloc[0]['onset'] in BASIC_DF['onset'].unique(), (
+                "Time shift didn't change to an aligned onset."
+            )
+
+            # Check that changed onset is within given range
+            changed_onset = diff.iloc[0]['onset']
+            original_onset = diff.iloc[1]['onset']
+            shift = abs(changed_onset - original_onset)
+            assert 10 * i <= shift <= 10 * (i + 1), (
+                f"Shift {shift} outside of range [{10 * i}, {10 * (i + 1)}]."
+            )
+        else:
+            with pytest.warns(UserWarning, match=re.escape('WARNING:')):
+                res = deg.time_shift(BASIC_DF, min_shift=10 * i,
+                                     max_shift=10 * (i + 1), align_onset=True)
+
     # Check for range too large warning
     with pytest.warns(UserWarning, match=re.escape('WARNING: No valid notes to '
                                                    'time shift.')):

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -89,17 +89,8 @@ def test_post_process():
         'dur': [100, 100, 100, 100]
     })
 
-    res = deg.post_process(UNSORTED_DF)
-    assert res.equals(basic_res), (
-        f"Post-processing \n{UNSORTED_DF}\n resulted in "
-        f"\n{res}\ninstead of \n{basic_res}"
-    )
-
     copy = UNSORTED_DF.copy()
-    res = deg.post_process(copy, inplace=True)
-    assert res is None, (
-        f"Post-processing \n{UNSORTED_DF}\n with inplace returned something."
-    )
+    deg.post_process(copy)
     assert copy.equals(basic_res), (
         f"Post-processing \n{UNSORTED_DF}\n with inplace "
         f"resulted in \n{copy}\ninstead of \n{basic_res}"

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -34,8 +34,8 @@ BASIC_DF_FINAL = BASIC_DF
 UNSORTED_DF = BASIC_DF.iloc[[0,2,3,1]]
 
 
-def assert_None(res):
-    assert res is None, f"Expected None, but got:\n{res}"
+def assert_none(res, msg=""):
+    assert res is None, f"{msg}\nExpected None, but got:\n{res}"
 
 
 def test_pre_process():

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -12,6 +12,7 @@ EMPTY_DF = pd.DataFrame({
     'dur': []
 })
 
+# test_join_notes() uses its own df, defined in the function
 # Create a garbled df with indices: [0, 2, 2, 4]
 BASIC_DF = pd.DataFrame({
     'onset': [0, 100, 200, 200, 200],
@@ -25,6 +26,27 @@ BASIC_DF.iloc[1]['track'] = 1
 BASIC_DF.iloc[1]['pitch'] = 20
 BASIC_DF.iloc[1]['dur'] = 100
 
+# This version will not change
+BASIC_DF_FINAL = BASIC_DF
+
+# Create an unsorted BASIC_DF
+UNSORTED_DF = BASIC_DF.iloc[[0,2,3,1]]
+
+
+def test_unsorted():
+    global BASIC_DF
+    BASIC_DF = UNSORTED_DF
+    
+    test_pitch_shift()
+    test_time_shift()
+    test_onset_shift()
+    test_offset_shift()
+    test_remove_note()
+    test_add_note()
+    test_split_note()
+    
+    BASIC_DF = BASIC_DF_FINAL
+
 
 def test_pitch_shift():
     with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to pitch"
@@ -33,40 +55,41 @@ def test_pitch_shift():
             "Pitch shifting with empty data frame did not return None."
         )
 
-    # In place testing
-    for i in range(2):
-        copy = BASIC_DF.copy()
-        res = deg.pitch_shift(copy, seed=1, inplace=True)
+    if BASIC_DF.equals(BASIC_DF_FINAL):
+        # In place testing
+        for i in range(2):
+            copy = BASIC_DF.copy()
+            res = deg.pitch_shift(copy, seed=1, inplace=True)
 
-        assert res is None, (
-            "Pitch shift with inplace=True returned something."
-        )
+            assert res is None, (
+                "Pitch shift with inplace=True returned something."
+            )
 
-        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
-                                  'track': [0, 1, 0, 1],
-                                  'pitch': [10, 107, 30, 40],
-                                  'dur': [100, 100, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
+                                      'track': [0, 1, 0, 1],
+                                      'pitch': [10, 107, 30, 40],
+                                      'dur': [100, 100, 100, 100]})
 
-        assert copy.equals(basic_res), (
-            f"Pitch shifting \n{BASIC_DF}\n resulted in \n{copy}\n"
-            f"instead of \n{basic_res}"
-        )
+            assert copy.equals(basic_res), (
+                f"Pitch shifting \n{BASIC_DF}\n resulted in \n{copy}\n"
+                f"instead of \n{basic_res}"
+            )
 
-    # Deterministic testing
-    for i in range(2):
-        res = deg.pitch_shift(BASIC_DF, seed=1)
+        # Deterministic testing
+        for i in range(2):
+            res = deg.pitch_shift(BASIC_DF, seed=1)
 
-        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
-                                  'track': [0, 1, 0, 1],
-                                  'pitch': [10, 107, 30, 40],
-                                  'dur': [100, 100, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
+                                      'track': [0, 1, 0, 1],
+                                      'pitch': [10, 107, 30, 40],
+                                      'dur': [100, 100, 100, 100]})
 
-        assert res.equals(basic_res), (
-            f"Pitch shifting \n{BASIC_DF}\n resulted in \n{res}\n"
-            f"instead of \n{basic_res}"
-        )
+            assert res.equals(basic_res), (
+                f"Pitch shifting \n{BASIC_DF}\n resulted in \n{res}\n"
+                f"instead of \n{basic_res}"
+            )
 
-        assert not BASIC_DF.equals(res), "Note_df was not copied."
+            assert not BASIC_DF.equals(res), "Note_df was not copied."
 
     # Truly random testing
     for i in range(10):
@@ -172,40 +195,41 @@ def test_time_shift():
         assert deg.time_shift(EMPTY_DF) is None, ("Time shifting with empty data "
                                                   "frame did not return None.")
 
-    # In place testing
-    for i in range(2):
-        copy = BASIC_DF.copy()
-        res = deg.time_shift(copy, seed=1, inplace=True)
+    if BASIC_DF.equals(BASIC_DF_FINAL):
+        # In place testing
+        for i in range(2):
+            copy = BASIC_DF.copy()
+            res = deg.time_shift(copy, seed=1, inplace=True)
 
-        assert res is None, (
-            "Time shift with inplace=True returned something."
-        )
+            assert res is None, (
+                "Time shift with inplace=True returned something."
+            )
 
-        basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
-                                  'track': [0, 1, 0, 1],
-                                  'pitch': [10, 20, 30, 40],
-                                  'dur': [100, 100, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
+                                      'track': [0, 1, 0, 1],
+                                      'pitch': [10, 20, 30, 40],
+                                      'dur': [100, 100, 100, 100]})
 
-        assert copy.equals(basic_res), (
-            f"Time shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
-            f"instead of \n{basic_res}"
-        )
+            assert copy.equals(basic_res), (
+                f"Time shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
+                f"instead of \n{basic_res}"
+            )
 
-    # Deterministic testing
-    for i in range(2):
-        res = deg.time_shift(BASIC_DF, seed=1)
+        # Deterministic testing
+        for i in range(2):
+            res = deg.time_shift(BASIC_DF, seed=1)
 
-        basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
-                                  'track': [0, 1, 0, 1],
-                                  'pitch': [10, 20, 30, 40],
-                                  'dur': [100, 100, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
+                                      'track': [0, 1, 0, 1],
+                                      'pitch': [10, 20, 30, 40],
+                                      'dur': [100, 100, 100, 100]})
 
-        assert res.equals(basic_res), (
-            f"Time shifting \n{BASIC_DF}\nresulted in \n{res}\n"
-            f"instead of \n{basic_res}"
-        )
+            assert res.equals(basic_res), (
+                f"Time shifting \n{BASIC_DF}\nresulted in \n{res}\n"
+                f"instead of \n{basic_res}"
+            )
 
-        assert not BASIC_DF.equals(res), "Note_df was not copied."
+            assert not BASIC_DF.equals(res), "Note_df was not copied."
 
     # Truly random testing
     for i in range(10):
@@ -294,40 +318,41 @@ def test_onset_shift():
             "Onset shifting with empty data frame did not return None."
         )
 
-    # In place testing
-    for i in range(2):
-        copy = BASIC_DF.copy()
-        res = deg.onset_shift(copy, seed=1, inplace=True)
+    if BASIC_DF.equals(BASIC_DF_FINAL):
+        # In place testing
+        for i in range(2):
+            copy = BASIC_DF.copy()
+            res = deg.onset_shift(copy, seed=1, inplace=True)
 
-        assert res is None, (
-            "Onset shift with inplace=True returned something."
-        )
+            assert res is None, (
+                "Onset shift with inplace=True returned something."
+            )
 
-        basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
-                                  'track': [0, 1, 0, 1],
-                                  'pitch': [10, 20, 30, 40],
-                                  'dur': [100, 50, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
+                                      'track': [0, 1, 0, 1],
+                                      'pitch': [10, 20, 30, 40],
+                                      'dur': [100, 50, 100, 100]})
 
-        assert copy.equals(basic_res), (
-            f"Onset shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
-            f"instead of \n{basic_res}"
-        )
+            assert copy.equals(basic_res), (
+                f"Onset shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
+                f"instead of \n{basic_res}"
+            )
 
-    # Deterministic testing
-    for i in range(2):
-        res = deg.onset_shift(BASIC_DF, seed=1)
+        # Deterministic testing
+        for i in range(2):
+            res = deg.onset_shift(BASIC_DF, seed=1)
 
-        basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
-                                  'track': [0, 1, 0, 1],
-                                  'pitch': [10, 20, 30, 40],
-                                  'dur': [100, 50, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
+                                      'track': [0, 1, 0, 1],
+                                      'pitch': [10, 20, 30, 40],
+                                      'dur': [100, 50, 100, 100]})
 
-        assert res.equals(basic_res), (
-            f"Onset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
-            f"instead of \n{basic_res}"
-        )
+            assert res.equals(basic_res), (
+                f"Onset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
+                f"instead of \n{basic_res}"
+            )
 
-        assert not BASIC_DF.equals(res), "Note_df was not copied."
+            assert not BASIC_DF.equals(res), "Note_df was not copied."
 
     # Random testing
     for i in range(10):
@@ -458,40 +483,41 @@ def test_offset_shift():
             "Offset shifting with empty data frame did not return None."
         )
 
-    # In place testing
-    for i in range(2):
-        copy = BASIC_DF.copy()
-        res = deg.offset_shift(copy, seed=1, inplace=True)
+    if BASIC_DF.equals(BASIC_DF_FINAL):
+        # In place testing
+        for i in range(2):
+            copy = BASIC_DF.copy()
+            res = deg.offset_shift(copy, seed=1, inplace=True)
 
-        assert res is None, (
-            "Offset shift with inplace=True returned something."
-        )
+            assert res is None, (
+                "Offset shift with inplace=True returned something."
+            )
 
-        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
-                                  'track': [0, 1, 0, 1],
-                                  'pitch': [10, 20, 30, 40],
-                                  'dur': [100, 158, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
+                                      'track': [0, 1, 0, 1],
+                                      'pitch': [10, 20, 30, 40],
+                                      'dur': [100, 158, 100, 100]})
 
-        assert copy.equals(basic_res), (
-            f"Offset shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
-            f"instead of \n{basic_res}"
-        )
+            assert copy.equals(basic_res), (
+                f"Offset shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
+                f"instead of \n{basic_res}"
+            )
 
-    # Deterministic testing
-    for i in range(2):
-        res = deg.offset_shift(BASIC_DF, seed=1)
+        # Deterministic testing
+        for i in range(2):
+            res = deg.offset_shift(BASIC_DF, seed=1)
 
-        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
-                                  'track': [0, 1, 0, 1],
-                                  'pitch': [10, 20, 30, 40],
-                                  'dur': [100, 158, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
+                                      'track': [0, 1, 0, 1],
+                                      'pitch': [10, 20, 30, 40],
+                                      'dur': [100, 158, 100, 100]})
 
-        assert res.equals(basic_res), (
-            f"Offset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
-            f"instead of \n{basic_res}"
-        )
+            assert res.equals(basic_res), (
+                f"Offset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
+                f"instead of \n{basic_res}"
+            )
 
-        assert not BASIC_DF.equals(res), "Note_df was not copied."
+            assert not BASIC_DF.equals(res), "Note_df was not copied."
 
     # Random testing
     for i in range(10):
@@ -585,40 +611,41 @@ def test_remove_note():
             "Remove note with empty data frame did not return None."
         )
 
-    # In place testing
-    for i in range(2):
-        copy = BASIC_DF.copy()
-        res = deg.remove_note(copy, seed=1, inplace=True)
+    if BASIC_DF.equals(BASIC_DF_FINAL):
+        # In place testing
+        for i in range(2):
+            copy = BASIC_DF.copy()
+            res = deg.remove_note(copy, seed=1, inplace=True)
 
-        assert res is None, (
-            "Removing note with inplace=True returned something."
-        )
+            assert res is None, (
+                "Removing note with inplace=True returned something."
+            )
 
-        basic_res = pd.DataFrame({'onset': [0, 200, 200],
-                                  'track': [0, 0, 1],
-                                  'pitch': [10, 30, 40],
-                                  'dur': [100, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 200, 200],
+                                      'track': [0, 0, 1],
+                                      'pitch': [10, 30, 40],
+                                      'dur': [100, 100, 100]})
 
-        assert copy.equals(basic_res), (
-            f"Removing note from \n{BASIC_DF}\n resulted in "
-            f"\n{copy}\ninstead of \n{basic_res}"
-        )
+            assert copy.equals(basic_res), (
+                f"Removing note from \n{BASIC_DF}\n resulted in "
+                f"\n{copy}\ninstead of \n{basic_res}"
+            )
 
-    # Deterministic testing
-    for i in range(2):
-        res = deg.remove_note(BASIC_DF, seed=1)
+        # Deterministic testing
+        for i in range(2):
+            res = deg.remove_note(BASIC_DF, seed=1)
 
-        basic_res = pd.DataFrame({'onset': [0, 200, 200],
-                                  'track': [0, 0, 1],
-                                  'pitch': [10, 30, 40],
-                                  'dur': [100, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 200, 200],
+                                      'track': [0, 0, 1],
+                                      'pitch': [10, 30, 40],
+                                      'dur': [100, 100, 100]})
 
-        assert res.equals(basic_res), (
-            f"Removing note from \n{BASIC_DF}\n resulted in "
-            f"\n{res}\ninstead of \n{basic_res}"
-        )
+            assert res.equals(basic_res), (
+                f"Removing note from \n{BASIC_DF}\n resulted in "
+                f"\n{res}\ninstead of \n{basic_res}"
+            )
 
-        assert not BASIC_DF.equals(res), "Note_df was not copied."
+            assert not BASIC_DF.equals(res), "Note_df was not copied."
 
     # Random testing
     for i in range(10):
@@ -722,40 +749,41 @@ def test_split_note():
             "Split note with empty data frame did not return None."
         )
 
-    # In place testing
-    for i in range(2):
-        copy = BASIC_DF.copy()
-        res = deg.split_note(copy, seed=1, inplace=True)
+    if BASIC_DF.equals(BASIC_DF_FINAL):
+        # In place testing
+        for i in range(2):
+            copy = BASIC_DF.copy()
+            res = deg.split_note(copy, seed=1, inplace=True)
 
-        assert res is None, (
-            "Splitting with inplace=True returned something."
-        )
+            assert res is None, (
+                "Splitting with inplace=True returned something."
+            )
 
-        basic_res = pd.DataFrame({'onset': [0, 100, 150, 200, 200],
-                                  'track': [0, 1, 1, 0, 1],
-                                  'pitch': [10, 20, 20, 30, 40],
-                                  'dur': [100, 50, 50, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 100, 150, 200, 200],
+                                      'track': [0, 1, 1, 0, 1],
+                                      'pitch': [10, 20, 20, 30, 40],
+                                      'dur': [100, 50, 50, 100, 100]})
 
-        assert copy.equals(basic_res), (
-            f"Splitting note in \n{BASIC_DF}\n resulted in "
-            f"\n{copy}\ninstead of \n{basic_res}"
-        )
+            assert copy.equals(basic_res), (
+                f"Splitting note in \n{BASIC_DF}\n resulted in "
+                f"\n{copy}\ninstead of \n{basic_res}"
+            )
 
-    # Deterministic testing
-    for i in range(2):
-        res = deg.split_note(BASIC_DF, seed=1)
+        # Deterministic testing
+        for i in range(2):
+            res = deg.split_note(BASIC_DF, seed=1)
 
-        basic_res = pd.DataFrame({'onset': [0, 100, 150, 200, 200],
-                                  'track': [0, 1, 1, 0, 1],
-                                  'pitch': [10, 20, 20, 30, 40],
-                                  'dur': [100, 50, 50, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 100, 150, 200, 200],
+                                      'track': [0, 1, 1, 0, 1],
+                                      'pitch': [10, 20, 20, 30, 40],
+                                      'dur': [100, 50, 50, 100, 100]})
 
-        assert res.equals(basic_res), (
-            f"Splitting note in \n{BASIC_DF}\n resulted in "
-            f"\n{res}\ninstead of \n{basic_res}"
-        )
+            assert res.equals(basic_res), (
+                f"Splitting note in \n{BASIC_DF}\n resulted in "
+                f"\n{res}\ninstead of \n{basic_res}"
+            )
 
-        assert not BASIC_DF.equals(res), "Note_df was not copied."
+            assert not BASIC_DF.equals(res), "Note_df was not copied."
 
     # Random testing
     for i in range(8):
@@ -844,12 +872,21 @@ def test_join_notes():
             "Joining notes with none back-to-back didn't return None."
         )
 
+    # Create a garbled df with indices: [0, 2, 2, 4]
     join_df = pd.DataFrame({
-        'onset': [0, 100, 200, 200],
-        'track': [0, 0, 0, 1],
-        'pitch': [10, 10, 10, 40],
-        'dur': [100, 100, 100, 100]
+        'onset': [0, 100, 200, 200, 200],
+        'track': [0, 0, 0, 1, 1],
+        'pitch': [10, 10, 10, 40, 40],
+        'dur': [100, 100, 100, 100, 100]
     })
+    join_df = pd.concat([join_df.iloc[[0,2]], join_df.iloc[[2,4]]])
+    join_df.iloc[1]['onset'] = 100
+    join_df.iloc[1]['track'] = 0
+    join_df.iloc[1]['pitch'] = 10
+    join_df.iloc[1]['dur'] = 100
+
+    # Create an unsorted join_df
+    unsorted_join_df = join_df.iloc[[0,2,3,1]]
 
     # In place testing
     for i in range(2):
@@ -872,6 +909,14 @@ def test_join_notes():
             f"instead of \n{join_res}"
         )
 
+        copy = unsorted_join_df.copy()
+        res = deg.join_notes(copy, seed=1, inplace=True)
+
+        assert copy.equals(join_res), (
+            f"Joining \n{unsorted_join_df}\nresulted in \n{copy}\n"
+            f"instead of \n{join_res}"
+        )
+
     # Deterministic testing
     for i in range(2):
         res = deg.join_notes(join_df, seed=1)
@@ -888,18 +933,24 @@ def test_join_notes():
             f"instead of \n{join_res}"
         )
 
+        res = deg.join_notes(unsorted_join_df, seed=1)
+        assert res.equals(join_res), (
+            f"Joining \n{unsorted_join_df}\nresulted in \n{res}\n"
+            f"instead of \n{join_res}"
+        )
+
         assert not join_df.equals(res), "Note_df was not copied."
 
     # Check different pitch and track
-    join_df.loc[1]['pitch'] = 20
+    join_df.iloc[1]['pitch'] = 20
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " join. Returning None.")):
         assert deg.join_notes(join_df) is None, (
             "Joining notes with different pitches didn't return None."
         )
 
-    join_df.loc[1]['pitch'] = 10
-    join_df.loc[1]['track'] = 1
+    join_df.iloc[1]['pitch'] = 10
+    join_df.iloc[1]['track'] = 1
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " join. Returning None.")):
         assert deg.join_notes(join_df) is None, (
@@ -907,16 +958,16 @@ def test_join_notes():
         )
 
     # Check some with different max_gaps
-    join_df.loc[1]['track'] = 0
+    join_df.iloc[1]['track'] = 0
     for i in range(10):
         np.random.seed()
 
         max_gap = i * 10
 
-        join_df.loc[0]['dur'] = join_df.loc[1]['onset'] - \
-            max_gap - join_df.loc[0]['onset']
-        join_df.loc[1]['dur'] = join_df.loc[2]['onset'] - \
-            max_gap - join_df.loc[1]['onset']
+        join_df.iloc[0]['dur'] = join_df.iloc[1]['onset'] - \
+            max_gap - join_df.iloc[0]['onset']
+        join_df.iloc[1]['dur'] = join_df.iloc[2]['onset'] - \
+            max_gap - join_df.iloc[1]['onset']
 
         res = deg.join_notes(join_df, max_gap=max_gap)
 
@@ -950,8 +1001,8 @@ def test_join_notes():
             "Joined duration not equal to original durations plus gap."
         )
 
-        join_df.loc[0]['dur'] -= 1
-        join_df.loc[1]['dur'] -= 1
+        join_df.iloc[0]['dur'] -= 1
+        join_df.iloc[1]['dur'] -= 1
 
         # Gap too large
         with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -834,9 +834,19 @@ def test_add_note():
         )
 
         # Test align_pitch and align_time
-        res = deg.add_note(BASIC_DF, min_pitch=min_pitch, max_pitch=max_pitch,
-                           min_duration=min_duration, max_duration=max_duration,
-                           align_pitch=True, align_time=True)
+        if (min_pitch > BASIC_DF['pitch'].max() or
+            max_pitch < BASIC_DF['pitch'].min()):
+            with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+                res = deg.add_note(BASIC_DF, min_pitch=min_pitch,
+                                   max_pitch=max_pitch, min_duration=min_duration,
+                                   max_duration=max_duration, align_pitch=True,
+                                   align_time=True)
+            continue
+
+        res = deg.add_note(BASIC_DF, min_pitch=min_pitch,
+                           max_pitch=max_pitch, min_duration=min_duration,
+                           max_duration=max_duration, align_pitch=True,
+                           align_time=True)
 
         diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
         assert (diff.shape[0] == 1), (

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -60,26 +60,6 @@ def test_pre_process():
         f"\n{res}\ninstead of \n{basic_res}"
     )
 
-    copy = UNSORTED_DF.copy()
-    res = deg.pre_process(copy, inplace=True)
-    assert res is None, (
-        f"Pre-processing \n{UNSORTED_DF}\n with inplace returned something."
-    )
-    assert copy.equals(unsorted_res), (
-        f"Pre-processing \n{UNSORTED_DF}\n with inplace resulted in "
-        f"\n{copy}\ninstead of \n{unsorted_res}"
-    )
-
-    copy = UNSORTED_DF.copy()
-    res = deg.pre_process(copy, inplace=True, sort=True)
-    assert res is None, (
-        f"Pre-processing \n{UNSORTED_DF}\n with inplace returned something."
-    )
-    assert copy.equals(basic_res), (
-        f"Pre-processing \n{UNSORTED_DF}\n with inplace and sort=True "
-        f"resulted in \n{copy}\ninstead of \n{basic_res}"
-    )
-
 
 def test_post_process():
     basic_res = pd.DataFrame({
@@ -89,11 +69,10 @@ def test_post_process():
         'dur': [100, 100, 100, 100]
     })
 
-    copy = UNSORTED_DF.copy()
-    deg.post_process(copy)
-    assert copy.equals(basic_res), (
-        f"Post-processing \n{UNSORTED_DF}\n with inplace "
-        f"resulted in \n{copy}\ninstead of \n{basic_res}"
+    res = deg.post_process(UNSORTED_DF)
+    assert res.equals(basic_res), (
+        f"Post-processing \n{UNSORTED_DF}\n  "
+        f"resulted in \n{res}\ninstead of \n{basic_res}"
     )
 
 
@@ -120,25 +99,6 @@ def test_pitch_shift():
         )
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
-        # In place testing
-        for i in range(2):
-            copy = BASIC_DF.copy()
-            res = deg.pitch_shift(copy, seed=1, inplace=True)
-
-            assert res is None, (
-                "Pitch shift with inplace=True returned something."
-            )
-
-            basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
-                                      'track': [0, 1, 0, 1],
-                                      'pitch': [10, 107, 30, 40],
-                                      'dur': [100, 100, 100, 100]})
-
-            assert copy.equals(basic_res), (
-                f"Pitch shifting \n{BASIC_DF}\n resulted in \n{copy}\n"
-                f"instead of \n{basic_res}"
-            )
-
         # Deterministic testing
         for i in range(2):
             res = deg.pitch_shift(BASIC_DF, seed=1)
@@ -260,25 +220,6 @@ def test_time_shift():
                                                   "frame did not return None.")
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
-        # In place testing
-        for i in range(2):
-            copy = BASIC_DF.copy()
-            res = deg.time_shift(copy, seed=1, inplace=True)
-
-            assert res is None, (
-                "Time shift with inplace=True returned something."
-            )
-
-            basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
-                                      'track': [0, 1, 0, 1],
-                                      'pitch': [10, 20, 30, 40],
-                                      'dur': [100, 100, 100, 100]})
-
-            assert copy.equals(basic_res), (
-                f"Time shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
-                f"instead of \n{basic_res}"
-            )
-
         # Deterministic testing
         for i in range(2):
             res = deg.time_shift(BASIC_DF, seed=1)
@@ -419,25 +360,6 @@ def test_onset_shift():
         )
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
-        # In place testing
-        for i in range(2):
-            copy = BASIC_DF.copy()
-            res = deg.onset_shift(copy, seed=1, inplace=True)
-
-            assert res is None, (
-                "Onset shift with inplace=True returned something."
-            )
-
-            basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
-                                      'track': [0, 1, 0, 1],
-                                      'pitch': [10, 20, 30, 40],
-                                      'dur': [100, 50, 100, 100]})
-
-            assert copy.equals(basic_res), (
-                f"Onset shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
-                f"instead of \n{basic_res}"
-            )
-
         # Deterministic testing
         for i in range(2):
             res = deg.onset_shift(BASIC_DF, seed=1)
@@ -584,25 +506,6 @@ def test_offset_shift():
         )
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
-        # In place testing
-        for i in range(2):
-            copy = BASIC_DF.copy()
-            res = deg.offset_shift(copy, seed=1, inplace=True)
-
-            assert res is None, (
-                "Offset shift with inplace=True returned something."
-            )
-
-            basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
-                                      'track': [0, 1, 0, 1],
-                                      'pitch': [10, 20, 30, 40],
-                                      'dur': [100, 158, 100, 100]})
-
-            assert copy.equals(basic_res), (
-                f"Offset shifting \n{BASIC_DF}\nresulted in \n{copy}\n"
-                f"instead of \n{basic_res}"
-            )
-
         # Deterministic testing
         for i in range(2):
             res = deg.offset_shift(BASIC_DF, seed=1)
@@ -712,25 +615,6 @@ def test_remove_note():
         )
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
-        # In place testing
-        for i in range(2):
-            copy = BASIC_DF.copy()
-            res = deg.remove_note(copy, seed=1, inplace=True)
-
-            assert res is None, (
-                "Removing note with inplace=True returned something."
-            )
-
-            basic_res = pd.DataFrame({'onset': [0, 200, 200],
-                                      'track': [0, 0, 1],
-                                      'pitch': [10, 30, 40],
-                                      'dur': [100, 100, 100]})
-
-            assert copy.equals(basic_res), (
-                f"Removing note from \n{BASIC_DF}\n resulted in "
-                f"\n{copy}\ninstead of \n{basic_res}"
-            )
-
         # Deterministic testing
         for i in range(2):
             res = deg.remove_note(BASIC_DF, seed=1)
@@ -763,25 +647,6 @@ def test_add_note():
     assert deg.add_note(EMPTY_DF) is not None, (
         "Add note to empty data frame returned None."
     )
-
-    # In place testing
-    for i in range(2):
-        copy = BASIC_DF.copy()
-        res = deg.add_note(copy, seed=1, inplace=True)
-
-        assert res is None, (
-            "Adding note with inplace=True returned something."
-        )
-
-        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 235],
-                                  'track': [0, 1, 0, 1, 0],
-                                  'pitch': [10, 20, 30, 40, 37],
-                                  'dur': [100, 100, 100, 100, 62]})
-
-        assert copy.equals(basic_res), (
-            f"Adding note to \n{BASIC_DF}\n resulted in "
-            f"\n{copy}\ninstead of \n{basic_res}"
-        )
 
     # Deterministic testing
     for i in range(2):
@@ -886,25 +751,6 @@ def test_split_note():
         )
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
-        # In place testing
-        for i in range(2):
-            copy = BASIC_DF.copy()
-            res = deg.split_note(copy, seed=1, inplace=True)
-
-            assert res is None, (
-                "Splitting with inplace=True returned something."
-            )
-
-            basic_res = pd.DataFrame({'onset': [0, 100, 150, 200, 200],
-                                      'track': [0, 1, 1, 0, 1],
-                                      'pitch': [10, 20, 20, 30, 40],
-                                      'dur': [100, 50, 50, 100, 100]})
-
-            assert copy.equals(basic_res), (
-                f"Splitting note in \n{BASIC_DF}\n resulted in "
-                f"\n{copy}\ninstead of \n{basic_res}"
-            )
-
         # Deterministic testing
         for i in range(2):
             res = deg.split_note(BASIC_DF, seed=1)
@@ -1023,35 +869,6 @@ def test_join_notes():
 
     # Create an unsorted join_df
     unsorted_join_df = join_df.iloc[[0,2,3,1]]
-
-    # In place testing
-    for i in range(2):
-        copy = join_df.copy()
-        res = deg.join_notes(copy, seed=1, inplace=True)
-
-        assert res is None, (
-            "Joining with inplace=True returned something."
-        )
-
-        join_res = pd.DataFrame({
-            'onset': [0, 100, 200],
-            'track': [0, 0, 1],
-            'pitch': [10, 10, 40],
-            'dur': [100, 200, 100]
-        })
-
-        assert copy.equals(join_res), (
-            f"Joining \n{join_df}\nresulted in \n{copy}\n"
-            f"instead of \n{join_res}"
-        )
-
-        copy = unsorted_join_df.copy()
-        res = deg.join_notes(copy, seed=1, inplace=True)
-
-        assert copy.equals(join_res), (
-            f"Joining \n{unsorted_join_df}\nresulted in \n{copy}\n"
-            f"instead of \n{join_res}"
-        )
 
     # Deterministic testing
     for i in range(2):

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -34,6 +34,10 @@ BASIC_DF_FINAL = BASIC_DF
 UNSORTED_DF = BASIC_DF.iloc[[0,2,3,1]]
 
 
+def assert_None(res):
+    assert res is None, f"Expected None, but got:\n{res}"
+
+
 def test_pre_process():
     basic_res = pd.DataFrame({
         'onset': [0, 100, 200, 200],
@@ -468,7 +472,19 @@ def test_onset_shift():
                 res['dur'].isin([50, 100, 150]).all()), (
             "Onset with align_dur didn't align duration."
         )
-            
+
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, min_shift=101)
+            assert_none(res)
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, max_shift=49)
+            assert_none(res)
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, min_duration=151)
+            assert_none(res)
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, max_duration=49)
+            assert_none(res)
 
         # Test with align_onset
         res = deg.onset_shift(align_df, align_onset=True)
@@ -478,6 +494,19 @@ def test_onset_shift():
                 len(set(res['onset'])) == 4), (
             "Onset with align_onset didn't align onset."
         )
+
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, min_shift=201)
+            assert_none(res)
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, max_shift=49)
+            assert_none(res)
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, min_duration=301)
+            assert_none(res)
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, max_duration=49)
+            assert_none(res)
 
         # Test with align both
         res = deg.onset_shift(align_df, align_onset=True, align_dur=True)
@@ -492,6 +521,19 @@ def test_onset_shift():
                 len(set(res['onset'])) == 4), (
             "Onset with align_dur and align_onset didn't align onset."
         )
+
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, min_shift=101)
+            assert_none(res)
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, max_shift=49)
+            assert_none(res)
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, min_duration=151)
+            assert_none(res)
+        with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+            res = deg.onset_shift(align_df, align_dur=True, max_duration=49)
+            assert_none(res)
 
     with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
                                                    " onset shift. Returning "

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -33,6 +33,79 @@ BASIC_DF_FINAL = BASIC_DF
 UNSORTED_DF = BASIC_DF.iloc[[0,2,3,1]]
 
 
+def test_pre_process():
+    basic_res = pd.DataFrame({
+        'onset': [0, 100, 200, 200],
+        'track': [0, 1, 0, 1],
+        'pitch': [10, 20, 30, 40],
+        'dur': [100, 100, 100, 100]
+    })
+
+    unsorted_res = pd.DataFrame({
+        'onset': [0, 200, 200, 100],
+        'track': [0, 0, 1, 1],
+        'pitch': [10, 30, 40, 20],
+        'dur': [100, 100, 100, 100]
+    })
+
+    res = deg.pre_process(UNSORTED_DF)
+    assert res.equals(unsorted_res), (
+        f"Pre-processing \n{UNSORTED_DF}\n resulted in \n{res}\n"
+        f"instead of \n{unsorted_res}"
+    )
+
+    res = deg.pre_process(UNSORTED_DF, sort=True)
+    assert res.equals(basic_res), (
+        f"Pre-processing \n{UNSORTED_DF}\n with sort=True resulted in "
+        f"\n{res}\ninstead of \n{basic_res}"
+    )
+
+    copy = UNSORTED_DF.copy()
+    res = deg.pre_process(copy, inplace=True)
+    assert res is None, (
+        f"Pre-processing \n{UNSORTED_DF}\n with inplace returned something."
+    )
+    assert copy.equals(unsorted_res), (
+        f"Pre-processing \n{UNSORTED_DF}\n with inplace resulted in "
+        f"\n{copy}\ninstead of \n{unsorted_res}"
+    )
+
+    copy = UNSORTED_DF.copy()
+    res = deg.pre_process(copy, inplace=True, sort=True)
+    assert res is None, (
+        f"Pre-processing \n{UNSORTED_DF}\n with inplace returned something."
+    )
+    assert copy.equals(basic_res), (
+        f"Pre-processing \n{UNSORTED_DF}\n with inplace and sort=True "
+        f"resulted in \n{copy}\ninstead of \n{basic_res}"
+    )
+
+
+def test_post_process():
+    basic_res = pd.DataFrame({
+        'onset': [0, 100, 200, 200],
+        'track': [0, 1, 0, 1],
+        'pitch': [10, 20, 30, 40],
+        'dur': [100, 100, 100, 100]
+    })
+
+    res = deg.post_process(UNSORTED_DF)
+    assert res.equals(basic_res), (
+        f"Post-processing \n{UNSORTED_DF}\n resulted in "
+        f"\n{res}\ninstead of \n{basic_res}"
+    )
+
+    copy = UNSORTED_DF.copy()
+    res = deg.post_process(copy, inplace=True)
+    assert res is None, (
+        f"Post-processing \n{UNSORTED_DF}\n with inplace returned something."
+    )
+    assert copy.equals(basic_res), (
+        f"Post-processing \n{UNSORTED_DF}\n with inplace "
+        f"resulted in \n{copy}\ninstead of \n{basic_res}"
+    )
+
+
 def test_unsorted():
     global BASIC_DF
     BASIC_DF = UNSORTED_DF

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -12,14 +12,18 @@ EMPTY_DF = pd.DataFrame({
     'dur': []
 })
 
-# Add and then remove a duplicate row to get non-consecutive indices
+# Create a garbled df with indices: [0, 2, 2, 4]
 BASIC_DF = pd.DataFrame({
     'onset': [0, 100, 200, 200, 200],
     'track': [0, 1, 0, 1, 1],
     'pitch': [10, 20, 30, 40, 40],
     'dur': [100, 100, 100, 100, 100]
 })
-BASIC_DF = BASIC_DF.iloc[[0,1,2,4]]
+BASIC_DF = pd.concat([BASIC_DF.iloc[[0,2]], BASIC_DF.iloc[[2,4]]])
+BASIC_DF.iloc[1]['onset'] = 100
+BASIC_DF.iloc[1]['track'] = 1
+BASIC_DF.iloc[1]['pitch'] = 20
+BASIC_DF.iloc[1]['dur'] = 100
 
 
 def test_pitch_shift():

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -835,7 +835,9 @@ def test_add_note():
 
         # Test align_pitch and align_time
         if (min_pitch > BASIC_DF['pitch'].max() or
-            max_pitch < BASIC_DF['pitch'].min()):
+            max_pitch < BASIC_DF['pitch'].min() or
+            min_duration > BASIC_DF['dur'].max() or
+            max_duration < BASIC_DF['dur'].min()):
             with pytest.warns(UserWarning, match=re.escape("WARNING:")):
                 res = deg.add_note(BASIC_DF, min_pitch=min_pitch,
                                    max_pitch=max_pitch, min_duration=min_duration,
@@ -851,7 +853,7 @@ def test_add_note():
         diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
         assert (diff.shape[0] == 1), (
             "Adding a note changed an existing note, or added note is a "
-            "duplicate."
+            "duplicate." + "\n" + str(BASIC_DF) + "\n" + str(res)
         )
         assert res.shape[0] == BASIC_DF.shape[0] + 1, "No note was added."
 


### PR DESCRIPTION
This makes a number of changes/enhancements to the degradations:

1. Per our Skype conversation, this removes the inplace option. It is no faster and results in complications.
2. Adds align_xxxx (align_onset, align_dur, align_pitch) parameters to the time-based degradations (and add_note), defaulting to False, which force the shifted onset or duration (or both, or pitch, in the case of add_note) to be the same as some other existing note's. This makes the degradations more difficult to detect. For example, before, you may have had all notes of duration 50 or 100, plus the degraded note with duration 123333. This fixes #44.
3. Regarding the conversation I've been having with myself in #37, this adds pre_process and post_process functions to degradations, which are called automatically by each degradation at their beginning and end. This ensures that we can handle: (1) out of order indexes, (2) non-consecutive indexes, (3) indexes not starting from 0, and (4) unsorted inputs. The post_process function further ensures that our outputs are always with consecutive indexes from 0, and sorted properly. I am leaving #37 open because we should decide how/if to handle incorrect columns and non-integers.
4. Allows join_notes to join >2 notes, if possible with the parameters max_notes and only_first. Max_notes sets the number of notes to join together (if possible). Notes after a randomly chosen starting note (which will be joinable if possible) will be greedily joined until this number has been reached (or the chain of notes ends). only_first forces this choice to be the first of a chain, if possible. So only_first=True and max_notes=np.inf will always join full note chains together. This fixes #39.

Still TODO:
1. How to handle tracks (#46).
2. Check that outputs are valid and don't contain, e.g., overlapping notes. (#8).
3. 2 more possible parameters in #29: (1) "shift_direction_prob" (to have equal chance of making shorter or longer), (2) Splitting notes into notes of non-equal duration.

Of these, 2 is most important. 1 we should do before code release, and 3 is probably not important yet.