### PR TITLE
Acme

### DIFF
--- a/make_dataset.py
+++ b/make_dataset.py
@@ -229,7 +229,6 @@ if __name__ == '__main__':
         comp.note_df.to_csv(outpath)
 
     # Perform degradations and write degraded data to output ==================
-    # Because we have already written clean data, we can do this in place
     # output to output_dir/degraded/dataset_name/filename.csv
     # The reason for this is that there could be filename duplicates (as above,
     # it's assumed there shouldn't be duplicates within each dataset!), and
@@ -252,13 +251,14 @@ if __name__ == '__main__':
             if not deg_fun_kwargs:
                 kwarg_str = ''
             else:
-                kwarg_str = ", ".join(
+                kwarg_str = ', ' + ", ".join(
                     f'{x[0]}={x[1]!r}' for x in deg_fun_kwargs.items()
-                ) + ', '
-            fun_str = f'{deg_name}(note_df, {kwarg_str}inplace=True)'
+                )
+            fun_str = f'{deg_name}(note_df{kwarg_str})'
             meta_fh.write(fun_str)
-        deg_fun(comp.note_df, **deg_fun_kwargs, inplace=True)
-        comp.note_df.to_csv(outpath)
+        degraded = deg_fun(comp.note_df, **deg_fun_kwargs)
+        if degraded is not None:
+            degraded.note_df.to_csv(outpath)
 
     print('Finished!')
     print(f'You will find the generated dataset at {ARGS.output_dir}')

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -95,6 +95,10 @@ def parse_args(args_input=None):
     parser.add_argument('--local-csv-dirs', metavar='csv_dir', type=str,
                         nargs='*', help='directories containing csv files to '
                         'include in the dataset', default=[])
+    # TODO: check this works!
+    parser.add_argument('--recursive', action='store_true', help='Search local'
+                        ' dataset directories recursively for all midi or csv '
+                        'files.')
     parser.add_argument('--datasets', metavar='dataset_name',
                         nargs='*', choices=downloaders.DATASETS,
                         default=downloaders.DATASETS,
@@ -244,7 +248,10 @@ if __name__ == '__main__':
         midi_input_dirs[dirname] = outdir
         csv_outdir = os.path.join(ARGS.input_dir, 'csv', dirname)
         csv_input_dirs[dirname] = csv_outdir
-        for filepath in glob(os.path.join(path, '*.mid')):
+        if ARGS.recursive:
+            path = os.path.join(path, '**')
+        for filepath in glob(os.path.join(path, '*.mid'),
+                             recursive=ARGS.recursive):
             copy_file(filepath, outdir)
 
     # Copy over user csv ======================================================
@@ -252,7 +259,10 @@ if __name__ == '__main__':
         dirname = f'local_{os.path.basename(path)}'
         outdir = os.path.join(ARGS.input_dir, 'csv', dirname)
         csv_input_dirs[dirname] = outdir
-        for filepath in glob(os.path.join(path, '*.csv')):
+        if ARGS.recursive:
+            path = os.path.join(path, '**')
+        for filepath in glob(os.path.join(path, '*.csv'),
+                             recursive=ARGS.recursive):
             copy_file(filepath, outdir)
 
     # Convert from midi to csv ================================================

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -398,7 +398,7 @@ if __name__ == '__main__':
         # Grab an excerpt from this composition
         excerpt = None
         if len(comp.note_df) >= ARGS.min_notes:
-            for iter in range(10):
+            for _ in range(10):
                 note_index = np.random.choice(list(comp.note_df.index.values)
                                               [:-ARGS.min_notes])
                 note_onset = comp.note_df.loc[note_index]['onset']

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -292,16 +292,16 @@ if __name__ == '__main__':
             degraded = deg_fun(comp.note_df, **deg_fun_kwargs)
 
             if degraded is not None:
-                print(f"{degs[deg_index]} SUCCESS.")
                 current_counts[np.where(deg_choices == deg_name)[0][0]] += 1
                 break
 
-            print(f"{degs[deg_index]} failed.")
-            print(comp.note_df)
             # Remove the degradation we just did from the current choices
-            # TODO: This doesn't seem to work yet...
-            np.delete(diffs, deg_index)
-            np.delete(degs, deg_index)
+            if len(positive_degs) > 0:
+                positive_diffs = np.delete(positive_diffs, deg_index)
+                positive_degs = np.delete(positive_degs, deg_index)
+            else:
+                non_positive_diffs = np.delete(non_positive_diffs, deg_index)
+                non_positive_degs = np.delete(non_positive_degs, deg_index)
 
         # Filenames
         fn = os.path.basename(comp.csv_path)

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -153,6 +153,8 @@ def parse_args(args_input=None):
                         nargs=3, type=float, help='The relative sizes of the '
                         'train, test, and validation sets respectively.',
                         default=[0.8, 0.1, 0.1])
+    parser.add_argument('--seed', type=int, default=None, help='The numpy seed'
+                        ' to use when creating the dataset.')
     args = parser.parse_args(args=args_input)
     return args
 
@@ -160,6 +162,7 @@ def parse_args(args_input=None):
 if __name__ == '__main__':
     # TODO: set warning level such that we avoid warning fatigue
     ARGS = parse_args()
+    np.random.seed(ARGS.seed)
     assert (ARGS.degradation_kwargs is None or
             ARGS.degradation_kwarg_json is None), ("Don't specify both "
                 "--degradation-kwargs and --degradation-kwarg-json")

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -373,6 +373,7 @@ if __name__ == '__main__':
 
     # Write out deg_choices to labels.csv
     with open(os.path.join(ARGS.output_dir, 'labels.csv'), 'w') as file:
+        file.write('id,degradation_name\n')
         for i, deg_name in enumerate(deg_choices):
             file.write(f'{i},{deg_name}\n')
 
@@ -383,6 +384,7 @@ if __name__ == '__main__':
     current_splits = np.zeros(len(splits))
     
     
+    meta_file.write('out_path,degraded,degradation_id,in_path,split\n')
     for i, comp in enumerate(tqdm(compositions, desc="Making target data")):
         # First, get the degradation order for this iteration.
         # Get the current distribution of degradations

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -138,7 +138,9 @@ def parse_args(args_input=None):
     # TODO: check this works!
     parser.add_argument('--degradation-kwarg-json', metavar='json_file',
                         help='A file containing parameters as described in '
-                        '--degradation-kwargs', type=json.load, default=None)
+                        '--degradation-kwargs. If this file is given, '
+                        '--degradation-kwargs is ignored.', type=json.load,
+                        default=None)
     # TODO: check this works!
     parser.add_argument('--degradation-dist', metavar='relative_probability',
                         nargs='*', default=None, help='A list of relative '
@@ -174,6 +176,11 @@ if __name__ == '__main__':
         )
     # TODO: warn user they specified kwargs for degradation not being used
     # TODO: bomb out if degradation-dist is a diff length to degradations
+    assert (ARGS.degradation_dist is None or
+            len(ARGS.degradation_dist) == len(ARGS.degradations)), (
+        "Given degradation_dist is not the same length as degradations:\n"
+        f"len({ARGS.degradations_dist}) != len({ARGS.degradations})"
+    )
     # TODO: handle csv downloading if csv data is available in downloader...
     #       then there's no need for midi conversion
 

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -135,6 +135,14 @@ def parse_args(args_input=None):
                         nargs='*', default=None, help='a list of relative '
                         'probabilities that each degradation will used. Must '
                         'be the same length as --degradations')
+    # TODO: Test these
+    parser.add_argument('--clean-prop', type=float, help='The proportion of '
+                        'excerpts in the final dataset that should be clean.',
+                        default=1 / (1 + len(degradations.DEGRADATIONS)))
+    parser.add_argument('--splits', metavar=('train', 'test', 'valid'),
+                        nargs=3, type=float, help='The relative sizes of the '
+                        'train, test, and validation sets respectively.',
+                        default=[0.8, 0.1, 0.1])
     args = parser.parse_args(args=args_input)
     return args
 

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Script to generate Altered and Corrupted Midi Exerpt (ACME) datasets"""
+"""Script to generate Altered and Corrupted Midi excerpt (ACME) datasets"""
 import os
 import json
 import argparse
@@ -27,7 +27,7 @@ with open('./img/logo.txt', 'r') as ff:
     LOGO = ff.read()
 
 
-DESCRIPTION = "Make datasets of altered and corrupted midi exerpts."
+DESCRIPTION = "Make datasets of altered and corrupted midi excerpts."
 
 
 
@@ -381,7 +381,8 @@ if __name__ == '__main__':
     # the goal distribution. We do the same for splits.
     current_counts = np.zeros(len(deg_choices))
     current_splits = np.zeros(len(splits))
-
+    
+    
     for i, comp in enumerate(tqdm(compositions, desc="Making target data")):
         # First, get the degradation order for this iteration.
         # Get the current distribution of degradations

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -102,12 +102,12 @@ def parse_args(args_input=None):
                         ' dataset directories recursively for all midi or csv '
                         'files.')
     parser.add_argument('--datasets', metavar='dataset_name',
-                        nargs='*', choices=downloaders.DATASETS,
-                        default=[],
+                        nargs='*', default=downloaders.DATASETS,
                         help='datasets to download and use. Must match names '
                         'of classes in the downloaders module. By default, '
                         'will use cached downloaded data if available, see '
-                        '--download-cache-dir and --clear-download-cache',
+                        '--download-cache-dir and --clear-download-cache. To '
+                        'download no data, provide an input of "None"',
                         )
     # TODO: check this works!
     parser.add_argument('--download-cache-dir', type=str,
@@ -167,7 +167,7 @@ def parse_args(args_input=None):
 if __name__ == '__main__':
     # TODO: set warning level such that we avoid warning fatigue
     ARGS = parse_args()
-
+    print(ARGS)
     np.random.seed(ARGS.seed)
 
     # Check given degradation_kwargs
@@ -220,6 +220,13 @@ if __name__ == '__main__':
     # TODO: make OVERWRITE this an arg for the script
     OVERWRITE = None
     ds_names = ARGS.datasets
+    if len(ds_names) == 1 and ds_names[0].lower() == 'none':
+        ds_names = []
+    else:
+        assert all([name in downloaders.DATASETS for name in ds_names]), (
+                f"all provided dataset names {ds_names} must be in the "
+                "list of available datasets for download "
+                f"{downloaders.DATASETS}")
     # Instantiated downloader classes
     downloader_dict = {
         ds_name: getattr(downloaders, ds_name)(

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -290,15 +290,15 @@ if __name__ == '__main__':
 
         # Grab an excerpt from this composition
         excerpt = None
-        pd.options.mode.chained_assignment = None
         for iter in range(10):
             note_index = np.random.choice(list(comp.note_df.index.values)
                                           [:-ARGS.min_notes])
             note_onset = comp.note_df.loc[note_index]['onset']
-            excerpt = comp.note_df.loc[comp.note_df['onset'].between(
-                note_onset, note_onset + ARGS.excerpt_length)]
+            excerpt = pd.DataFrame(
+                comp.note_df.loc[comp.note_df['onset'].between(
+                    note_onset, note_onset + ARGS.excerpt_length)])
             excerpt['onset'] = excerpt['onset'] - note_onset
-            excerpt.reset_index(drop=True)
+            excerpt = excerpt.reset_index(drop=True)
 
             # Check for validity of excerpt
             if len(excerpt) < ARGS.min_notes:
@@ -307,7 +307,6 @@ if __name__ == '__main__':
                 break
 
         # If no valid excerpt was found, skip this piece
-        pd.options.mode.chained_assignment = 'warn'
         if excerpt is None:
             warnings.warn(UserWarning, "Unable to find valid excerpt from "
                           f"composition {comp.csv_path}. Skipping.")
@@ -345,7 +344,7 @@ if __name__ == '__main__':
             deg_fun = degradations.DEGRADATIONS[deg_name]
             deg_fun_kwargs = degradation_kwargs[deg_name] # degradation_kwargs
                                                           # at top of main call
-            degraded = deg_fun(comp.note_df, **deg_fun_kwargs)
+            degraded = deg_fun(excerpt, **deg_fun_kwargs)
 
             if degraded is not None:
                 # Write clean csv

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Script to generate Altered and Corrupted Midi excerpt (ACME) datasets"""
+"""Script to generate Altered and Corrupted Midi Excerpt (ACME) datasets"""
 import os
 import json
 import argparse
@@ -168,8 +168,12 @@ if __name__ == '__main__':
     # TODO: set warning level such that we avoid warning fatigue
     ARGS = parse_args()
     print(ARGS)
-    np.random.seed(ARGS.seed)
-
+    if ARGS.seed is None:
+        seed = np.random.seed()
+    else:
+        seed = ARGS.seed
+    np.random.seed(seed)
+    
     # Check given degradation_kwargs
     assert (ARGS.degradation_kwargs is None or
             ARGS.degradation_kwarg_json is None), ("Don't specify both "
@@ -497,5 +501,7 @@ if __name__ == '__main__':
     print('\t* which split (train, valid, test) the file should be used in')
     print('labels.csv is a mapping of degradation name to the id number used '
           'in metadata.csv')
+    print('To reproduce this dataset again, run the script with argument '
+          '--seed {seed}')
     #TODO: print('see the examples directory for baseline models using this data')
     print(LOGO)

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -484,11 +484,18 @@ if __name__ == '__main__':
 
     print('Finished!')
     print(f'Count of degradations {deg_choices} = {current_counts}')
-    print(f'You will find the generated dataset at {ARGS.output_dir}')
-    print('The clean and altered files are located under directories named as '
-          'such.')
-    print('The (integer) labels and splits for each excerpt are located in '
-          'metadata.csv')
-    print('The labels are defined in labels.csv')
-
+    print(f'The data used as input is contained in {ARGS.input_dir}')
+    print(f'You will find the generated data at {ARGS.output_dir} '
+          'with subdirectories\n')
+    print(f'\t* clean - contains the extracted clean excerpts')
+    print(f'\t* altered - contains the excerpts altered by the degradations '
+          'described in metadata.csv')
+    print('metadata.csv describes:\n')
+    print('\t* (the id number for) the type of degradation used for the '
+          'alteration')
+    print('\t* the path for the altered and clean files')
+    print('\t* which split (train, valid, test) the file should be used in')
+    print('labels.csv is a mapping of degradation name to the id number used '
+          'in metadata.csv')
+    #TODO: print('see the examples directory for baseline models using this data')
     print(LOGO)

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -5,6 +5,7 @@ import json
 import argparse
 from glob import glob
 import warnings
+import pandas as pd
 
 import numpy as np
 from tqdm import tqdm
@@ -363,6 +364,9 @@ if __name__ == '__main__':
 
         # Write meta
         if degraded is not None or ARGS.clean_prop > 0:
+            clean_path = os.path.join('clean', dataset, fn)
+            clean_outpath = os.path.join(ARGS.output_dir, clean_path)
+            midi.df_to_csv(excerpt, clean_outpath)
             meta_file.write(f'{altered_outpath},{deg_binary},{deg_num},'
                             f'{clean_outpath},{split}\n')
         else:

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -6,6 +6,7 @@ import argparse
 from glob import glob
 import warnings
 import pandas as pd
+import shutil
 
 import numpy as np
 from tqdm import tqdm
@@ -87,7 +88,9 @@ def parse_args(args_input=None):
     parser.add_argument('-i', '--input-dir', type=str, default=default_indir,
                         help='the directory to store the preprocessed '
                         'downloaded data to.')
-    # TODO: check this works!
+    parser.add_argument('--clear', action='store_true', help='Delete '
+                        '--input-dir and --output-dir prior to creating this '
+                        'dataset. This ensures no stale data remains.')
     parser.add_argument('--local-midi-dirs', metavar='midi_dir', type=str,
                         nargs='*', help='directories containing midi files to '
                         'include in the dataset', default=[])
@@ -95,7 +98,6 @@ def parse_args(args_input=None):
     parser.add_argument('--local-csv-dirs', metavar='csv_dir', type=str,
                         nargs='*', help='directories containing csv files to '
                         'include in the dataset', default=[])
-    # TODO: check this works!
     parser.add_argument('--recursive', action='store_true', help='Search local'
                         ' dataset directories recursively for all midi or csv '
                         'files.')
@@ -202,6 +204,18 @@ if __name__ == '__main__':
     assert min(ARGS.splits) >= 0, "--splits values must not be negative."
     assert sum(ARGS.splits) > 0, "Some --splits value must be positive."
 
+    # Clear input and output dirs =============================================
+    if ARGS.clear:
+        if os.path.exists(ARGS.input_dir):
+            shutil.rmtree(ARGS.input_dir)
+        if os.path.exists(ARGS.output_dir):
+            shutil.rmtree(ARGS.output_dir)
+    # This avoids an error if no datasets are selected
+    if not os.path.exists(ARGS.input_dir):
+        os.makedirs(ARGS.input_dir, exist_ok=True)
+    if not os.path.exists(ARGS.output_dir):
+        os.makedirs(ARGS.output_dir, exist_ok=True)
+
     # Instantiate downloaders =================================================
     # TODO: make OVERWRITE this an arg for the script
     OVERWRITE = None
@@ -219,9 +233,6 @@ if __name__ == '__main__':
                       for name in ds_names}
 
     # Set up directories ======================================================
-    # TODO: Should we delete ARGS.output_dir and ARGS.input_dir?
-    # Not doing so leads to problems (existing input_dir files are used, even
-    # if unwanted, and extra output_dir files are confusing).
     for path in midi_input_dirs.values():
         make_directory(path)
     for path in csv_input_dirs.values():

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -5,7 +5,6 @@ import json
 import argparse
 from glob import glob
 import warnings
-import pandas as pd
 
 import numpy as np
 from tqdm import tqdm
@@ -76,16 +75,17 @@ def parse_degradation_kwargs(kwarg_dict):
 
 def parse_args(args_input=None):
     """Convenience function for parsing user supplied command line args"""
-    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser = argparse.ArgumentParser(
+        description=DESCRIPTION,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     default_outdir = os.path.join(os.getcwd(), 'acme')
     parser.add_argument('-o', '--output-dir', type=str, default=default_outdir,
-                        help='the directory to write the dataset to (defaults '
-                        f'to current working directory: {default_outdir})')
+                        help='the directory to write the dataset to.')
     default_indir = os.path.join(os.getcwd(), 'input_data')
     parser.add_argument('-i', '--input-dir', type=str, default=default_indir,
                         help='the directory to store the preprocessed '
-                        'downloaded data to (defaults to current working '
-                        f'directory: {default_indir})')
+                        'downloaded data to.')
     # TODO: implement this - users could have directories containing midi they
     #       want to use in conjunction with any downloaded for them
     parser.add_argument('--local-midi-dirs', metavar='midi_dir', type=str,
@@ -107,8 +107,7 @@ def parse_args(args_input=None):
     parser.add_argument('--download-cache-dir', type=str,
                         default=downloaders.DEFAULT_CACHE_PATH, help='The '
                         'directory to use for storing intermediate downloaded '
-                        'data e.g. zip files, and prior to preprocessing. By '
-                        f'default is set to {downloaders.DEFAULT_CACHE_PATH}')
+                        'data e.g. zip files, and prior to preprocessing.')
     # TODO: check this works!
     parser.add_argument('--clear-download-cache', action='store_true',
                         help='clear downloaded data cache')
@@ -142,9 +141,10 @@ def parse_args(args_input=None):
                         '--degradation-kwargs', type=json.load, default=None)
     # TODO: check this works!
     parser.add_argument('--degradation-dist', metavar='relative_probability',
-                        nargs='*', default=None, help='a list of relative '
+                        nargs='*', default=None, help='A list of relative '
                         'probabilities that each degradation will used. Must '
-                        'be the same length as --degradations')
+                        'be the same length as --degradations. Defaults to a '
+                        'uniform distribution.')
     # TODO: Test these
     parser.add_argument('--clean-prop', type=float, help='The proportion of '
                         'excerpts in the final dataset that should be clean.',

--- a/mdtk/downloaders.py
+++ b/mdtk/downloaders.py
@@ -45,14 +45,14 @@ class DataDownloader:
 #        self.extracted = False
 
 
-    def download_midi(self, output_path, cache_path=None):
+    def download_midi(self, output_path, cache_path=None, overwrite=None):
         """Downloads the MIDI data to output_path"""
         cache_path = self.cache_path if cache_path is None else cache_path
         raise NotImplementedError('In order to download MIDI, you must '
                                   'implement the download_midi method.')
 
 
-    def download_csv(self, output_path, cache_path=None):
+    def download_csv(self, output_path, cache_path=None, overwrite=None):
         """Downloads the csv data to output_path"""
         cache_path = self.cache_path if cache_path is None else cache_path
         raise NotImplementedError('In order to download CSV, you must '

--- a/mdtk/filesystem_utils.py
+++ b/mdtk/filesystem_utils.py
@@ -87,7 +87,7 @@ def extract_zip(zip_path, out_path, overwrite=None, verbose=True):
     return extracted_path
 
 
-def copy_file(filepath, output_path, overwrite=None):
+def copy_file(filepath, output_path, overwrite=None, mkdir=False):
     """Convenience function to copy a file from filepath to output_path."""
     path = os.path.join(output_path, os.path.basename(filepath))
     if os.path.exists(path):     

--- a/mdtk/midi.py
+++ b/mdtk/midi.py
@@ -18,7 +18,7 @@ COLNAMES = NOTE_DF_SORT_ORDER
 
 
 
-def midi_dir_to_csv(midi_dir_path, csv_dir_path):
+def midi_dir_to_csv(midi_dir_path, csv_dir_path, recursive=False):
     """
     Convert an entire directory of MIDI files into csvs in another directory.
     This searches the given MIDI path for any files with the extension 'mid'.
@@ -36,10 +36,25 @@ def midi_dir_to_csv(midi_dir_path, csv_dir_path):
     csv_dir_path : string
         The path of the directory to write out each csv to. If it does not
         exist, it will be created.
+
+    recursive : boolean
+        If True, search the given midi dir recursively.
     """
-    for midi_path in glob.glob(midi_dir_path + os.path.sep + '*.mid'):
-        csv_path = (csv_dir_path + os.path.sep +
-                    os.path.basename(midi_path[:-3] + 'csv'))
+    if recursive:
+        dir_prefix_len = len(midi_dir_path) + 1
+        midi_dir_path = os.path.join(midi_dir_path, '**')
+    for midi_path in glob.glob(os.path.join(midi_dir_path, '*.mid')):
+        if recursive:
+            csv_path = os.path.join(
+                csv_dir_path,
+                os.path.dirname(midi_path[dir_prefix_len:]),
+                os.path.basename(midi_path[:-3] + 'csv')
+            )
+        else:
+            csv_path = os.path.join(
+                csv_dir_path,
+                os.path.basename(midi_path[:-3] + 'csv')
+            )
         midi_to_csv(midi_path, csv_path)
 
 


### PR DESCRIPTION
make_dataset.py updated.

I added args:
-excerpt-length: Length of the excerpts to include in the dataset (in ms). Default 5s.
-min-notes: Minimum number of notes that must be present for a valid excerpt. Default 10. The script will try up to 10 excerpts until it finds a valid one, or skip the composition. (Sample note, get all notes whose onset is w/in excerpt-length after the sampled note).
-seed: numpy seed. I also shuffle the compositions before iterating through them.
-clean-prop: The proportion of excerpts in the dataset which should be non-degraded. This value is NOT relative to --degradation-dist, but an absolute probability. Degradation-dist will all be scaled down by a factor of (1 - clean-prop).
-splits: Relative proportions of train, test, and validation sets.

I fixed degradation error handling. Degradations that can't be performed just try another degradation, or no degradation (if clean-prop > 0). Otherwise, the composition is skipped (if all degradations fail and clean-prop==0).

This chooses degradations to try in order of how far behind the current distribution is to the desired distribution, so the resulting distribution is as correct as possible, no matter how many compositions must be skipped (and where in the iteration the failed comps are).

Splits are chosen the same way as degradations, so those proportions also match.

I validated and tested some args (ones I didn't are marked with TODOs)

I also changed the organization of the resulting directory. The base dir still contains clean and altered dirs, each with csvs, but not they only contain the excerpts used in the dataset, not the entire piece. Also, only those files contained in the dataset are included. That means that for non-altered excerpts, their input and target csvs are exactly the same file. If someone wants to create a new dataset or a new split, there is no guarantee they will want the same excerpts, or the same distribution of degradations, etc. Plus, the processing is pretty quick anyways.

There is no more metadata directory. Instead, there is a labels.csv file, like this:
```
0,none
1,time_shift
2,onset_shift
...
```

And a metadata.csv file, like this:
```
altered/PianoMidi/bach_850.csv,1,4,clean/PianoMidi/bach_850.csv,train
...
```
The columns are altered_file, has_degraded, degradation_num, clean_file, split