### PR TITLE
Overlaps

### DIFF
--- a/make_dataset.py
+++ b/make_dataset.py
@@ -362,7 +362,7 @@ if __name__ == '__main__':
         track=1,
         sort=False,
         header=None,
-        overlap_check=False,
+        overlap_check=True,
         flatten_tracks=True
     )
     compositions = [data_structures.Composition(

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -456,6 +456,9 @@ if __name__ == '__main__':
                           "lower --min-notes. Skipping.", UserWarning)
             continue
 
+        # Add some value so that not only degraded excerpts start from > 0
+        excerpt.loc[:, 'onset'] += np.random.randint(0, 200)
+
         # Try degradations in reverse order of the difference between
         # their current distribution and their desired distribution.
         diffs = goal_dist - current_dist

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -362,7 +362,8 @@ if __name__ == '__main__':
         track=1,
         sort=False,
         header=None,
-        overlap_check=False
+        overlap_check=False,
+        flatten_tracks=True
     )
     compositions = [data_structures.Composition(
                         csv_path=csv_path,

--- a/mdtk/data_structures.py
+++ b/mdtk/data_structures.py
@@ -3,6 +3,7 @@ for converting between different data formats.
 """
 import copy
 import warnings
+import itertools
 
 import numpy as np
 import pandas as pd
@@ -40,7 +41,9 @@ def read_note_csv(path, onset='onset', track='track', pitch='pitch', dur='dur',
     track : str or int
         The name or index of the column in the csv describing the midi track
     sort : bool
-        Whether to sort the resulting DataFrame to the default sort order
+        Whether to sort the resulting DataFrame to the default sort order.
+        Regardless of this value, if overlap_check is True, the df will be
+        sorted.
     header : int, list of int, default ‘infer’
         parameter to pass to pandas read_csv - see their documentation. Must
         set to None if your csv has no header.
@@ -53,7 +56,8 @@ def read_note_csv(path, onset='onset', track='track', pitch='pitch', dur='dur',
         True to check and fix overlaps. This will create a situation where,
         for every (track, pitch) pair, for any point in time which there is a
         sustained note present in the input, there will be a sustained note
-        in the returned df. Likewise for any point with a note onset.
+        in the returned df. Likewise for any point with a note onset. If True,
+        the resulting df will be sorted, even if sort is False.
     flatten_tracks : boolean
         True to set the track of every note to 0.
     """
@@ -74,8 +78,8 @@ def read_note_csv(path, onset='onset', track='track', pitch='pitch', dur='dur',
         df.loc[:, 'track'] = 0
     
     if overlap_check is True:
-        # Check no overlapping notes of the same pitch
-        df = df.groupby('track').apply(fix_overlapping_pitches)
+        df.sort_values(by=NOTE_DF_SORT_ORDER, inplace=True)
+        df = fix_overlaps(df)
 
     if monophonic_tracks is not None:
         df = make_monophonic(df, tracks=monophonic_tracks)
@@ -83,7 +87,7 @@ def read_note_csv(path, onset='onset', track='track', pitch='pitch', dur='dur',
     if max_note_len is not None:
         df.loc[df['dur'] > max_note_len, 'dur'] = max_note_len
 
-    if sort:
+    if sort and not overlap_check:
         df.sort_values(by=NOTE_DF_SORT_ORDER, inplace=True)
         df.reset_index(drop=True, inplace=True)
     return df.loc[:, NOTE_DF_SORT_ORDER]
@@ -243,6 +247,68 @@ def fix_overlapping_pitches(df):
     df.loc[bad_note, 'dur'] = (next_note_on[bad_note[:-1]]
                                - df.loc[bad_note, 'onset'].values)
     # TODO: add an assertion to catch dur==0 and add a test
+    return df
+
+
+def fix_overlaps(df):
+    """
+    Returns a version of the given df with all overlaps fixed as:
+
+    For every (track, pitch) pair, for any point in time which there is a
+    sustained note present in the input, there will be a sustained note
+    in the returned df. Likewise for any point with a note onset.
+
+    This relies on the given df being sorted already.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Pandas DataFrame with at least the columns onset, pitch, track, and dur,
+        sorted in that order.
+
+    Returns
+    -------
+    df : pd.DataFrame
+        A non-overlapping version of the given df, as described above.
+    """
+    if len(df) < 2:
+        return df
+
+    # Copy since we're going to be editing in place
+    df = df.copy()
+
+    # We'll work with onsets here, and fix dur at the end
+    df.loc[:, 'offset'] = df['onset'] + df['dur']
+
+    for track, track_df in df.groupby('track'):
+        if len(track_df) < 2:
+            continue
+
+        for pitch, pitch_df in track_df.groupby('pitch'):
+            if len(pitch_df) < 2:
+                continue
+
+            # Last of any offset in the current set of overlapping notes
+            current_offset = pitch_df.iloc[0]['offset']
+            # We will need to change the previous offset in the case of an overlap
+            prev_idx = pitch_df.index[0]
+
+            for idx, note in itertools.islice(pitch_df.iterrows(), 1, None):
+                if current_offset > note.onset:
+                    # Overlap found. Cut previous note and extend offset
+                    # Changes here are performed in the original df
+                    df.loc[prev_idx, 'offset'] = note.onset
+                    current_offset = max(current_offset, note.offset)
+                    df.loc[idx, 'offset'] = current_offset
+                # Always iterate, but no need to update current_offset here,
+                # because it will definitely be < next_note.onset (because sorted).
+                prev_idx = idx
+
+    # Fix dur based on offsets and remove offset column
+    df.loc[:, 'dur'] = df['offset'] - df['onset']
+    df = df.loc[df['dur'] != 0, ['onset', 'track', 'pitch', 'dur']]
+    df.reset_index(drop=True, inplace=True)
+
     return df
 
 

--- a/mdtk/data_structures.py
+++ b/mdtk/data_structures.py
@@ -25,7 +25,7 @@ NR_MIDINOTES = 128
 
 def read_note_csv(path, onset='onset', track='track', pitch='pitch', dur='dur',
                   sort=True, header='infer', monophonic_tracks=None,
-                  max_note_len=None, overlap_check=True, flatten_tracks=False):
+                  max_note_len=None, overlap_check=False, flatten_tracks=False):
     """Read a csv and create a standard note event DataFrame - a `note_df`.
 
     Parameters

--- a/mdtk/data_structures.py
+++ b/mdtk/data_structures.py
@@ -24,7 +24,7 @@ NR_MIDINOTES = 128
 
 def read_note_csv(path, onset='onset', track='track', pitch='pitch', dur='dur',
                   sort=True, header='infer', monophonic_tracks=None,
-                  max_note_len=None, overlap_check=True):
+                  max_note_len=None, overlap_check=True, flatten_tracks=False):
     """Read a csv and create a standard note event DataFrame - a `note_df`.
 
     Parameters
@@ -49,6 +49,13 @@ def read_note_csv(path, onset='onset', track='track', pitch='pitch', dur='dur',
         makes all tracks monophonic.
     max_note_len : int, float, or None
         A value for the maximum duration of a note
+    overlap_check : boolean
+        True to check and fix overlaps. This will create a situation where,
+        for every (track, pitch) pair, for any point in time which there is a
+        sustained note present in the input, there will be a sustained note
+        in the returned df. Likewise for any point with a note onset.
+    flatten_tracks : boolean
+        True to set the track of every note to 0.
     """
     cols = {}
     cols[onset] = 'onset'
@@ -63,7 +70,7 @@ def read_note_csv(path, onset='onset', track='track', pitch='pitch', dur='dur',
 
     df = pd.read_csv(path, header=header, usecols=list(cols.keys()))
     df.rename(columns=cols, inplace=True)
-    if track is None:
+    if track is None or flatten_tracks:
         df.loc[:, 'track'] = 0
     
     if overlap_check is True:

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -130,7 +130,7 @@ def post_process(df, sort=True):
     """
     Function which will post-process a degraded dataframe.
 
-    That means optionally sorting it, and resetting the indeces to be
+    That means optionally sorting it, resetting the indices to be
     consecutive ints starting from 0. All degradations call this
     function after their execution.
 

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -11,6 +11,10 @@ from mdtk.data_structures import NOTE_DF_SORT_ORDER
 MIN_PITCH = 0
 MAX_PITCH = 127
 
+TRIES_WARN_MSG = ("WARNING: Generated invalid (overlapping) degraded excerpt "
+                  "too many times. Try raising tries parameter (default 10). "
+                  "Returning None.")
+
 
 def set_random_seed(func, seed=None):
     """This is a function decorator which just adds the keyword argument `seed`

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -89,7 +89,14 @@ def overlaps(df, idx):
     overlap : boolean
         True if the note overlaps some other note. False otherwise.
     """
-    pass
+    note = df.loc[idx]
+    df = df.loc[(df['pitch'] == note.pitch) &
+                (df['track'] == note.track) &
+                (df.index != idx)]
+    offsets = df['onset'] + df['dur']
+    overlap = any((note.onset < df['onset'] + df['dur']) &
+                  (note.onset + note.dur > df['onset']))
+    return overlap
 
 
 def pre_process(df, sort=False):

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -38,39 +38,6 @@ def set_random_seed(func, seed=None):
     return seeded_func
 
 
-def set_tries(func, tries=10):
-    """This is a function decorator which just adds the keyword argument
-    `tries` to the end of the supplied function that it decorates.
-    Each degradation should check if its generated DataFrame is valid, and
-    if not, retry with `tries=tries - 1`. If tries is 0, the function should
-    return None and warn.
-
-    Note that some degradations (e.g., remove_note) will not need to use this.
-    Nevertheless, we add tries to to those functions for consistency.
-
-    Parameters
-    ----------
-    func : function
-        function to be decorated
-    tries : int
-        The number of times to try the degradation before giving up, in the case
-        that the degraded excerpt overlaps.
-
-    Returns
-    -------
-    seeded_func : function
-        The originally supplied function, but now with an aditional optional
-        tries keyword argument.
-    """
-    def seeded_func(*args, tries=tries, **kwargs):
-        return func(*args, **kwargs)
-    return seeded_func
-
-TRIES_WARN_MSG = ("WARNING: Generated invalid (overlapping) degraded excerpt "
-                  "too many times. Try raising tries parameter (default 10). "
-                  "Returning None.")
-
-
 def overlaps(df, idx):
     """
     Check if the note at the given index in the given dataframe overlaps any
@@ -189,9 +156,8 @@ def split_range_sample(split_range, p=None):
 
 
 @set_random_seed
-@set_tries
 def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
-                distribution=None):
+                distribution=None, tries=10):
     """
     Shift the pitch of one note from the given excerpt.
 
@@ -313,8 +279,8 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
 
 @set_random_seed
-@set_tries
-def time_shift(excerpt, min_shift=50, max_shift=np.inf, align_onset=False):
+def time_shift(excerpt, min_shift=50, max_shift=np.inf, align_onset=False,
+               tries=10):
     """
     Shift the onset and offset times of one note from the given excerpt,
     leaving its duration unchanged.
@@ -428,9 +394,9 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf, align_onset=False):
 
 
 @set_random_seed
-@set_tries
 def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
-                max_duration=np.inf, align_onset=False, align_dur=False):
+                max_duration=np.inf, align_onset=False, align_dur=False,
+                tries=10):
     """
     Shift the onset time of one note from the given excerpt.
 
@@ -610,9 +576,8 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
 
 @set_random_seed
-@set_tries
 def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
-                 max_duration=np.inf, align_dur=False):
+                 max_duration=np.inf, align_dur=False, tries=10):
     """
     Shift the offset time of one note from the given excerpt.
 
@@ -739,8 +704,7 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
 
 @set_random_seed
-@set_tries
-def remove_note(excerpt):
+def remove_note(excerpt, tries=10):
     """
     Remove one note from the given excerpt.
 
@@ -755,7 +719,8 @@ def remove_note(excerpt):
 
     tries : int
         The number of times to try the degradation before giving up, in the case
-        that the degraded excerpt overlaps.
+        that the degraded excerpt overlaps. This is not used, but we keep it for
+        consistency.
 
     Returns
     -------
@@ -782,10 +747,9 @@ def remove_note(excerpt):
 
 
 @set_random_seed
-@set_tries
 def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
              min_duration=50, max_duration=np.inf,
-             align_pitch=False, align_time=False):
+             align_pitch=False, align_time=False, tries=10):
     """
     Add one note to the given excerpt.
 
@@ -921,8 +885,7 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
 
 @set_random_seed
-@set_tries
-def split_note(excerpt, min_duration=50, num_splits=1):
+def split_note(excerpt, min_duration=50, num_splits=1, tries=10):
     """
     Split one note from the excerpt into two or more notes of equal
     duration.
@@ -945,7 +908,8 @@ def split_note(excerpt, min_duration=50, num_splits=1):
 
     tries : int
         The number of times to try the degradation before giving up, in the case
-        that the degraded excerpt overlaps.
+        that the degraded excerpt overlaps. This is not used, but we keep it for
+        consistency.
 
     Returns
     -------
@@ -1004,8 +968,8 @@ def split_note(excerpt, min_duration=50, num_splits=1):
 
 
 @set_random_seed
-@set_tries
-def join_notes(excerpt, max_gap=50, max_notes=20, only_first=False):
+def join_notes(excerpt, max_gap=50, max_notes=20, only_first=False,
+               tries=10):
     """
     Combine two notes of the same pitch and track into one.
 
@@ -1035,7 +999,8 @@ def join_notes(excerpt, max_gap=50, max_notes=20, only_first=False):
 
     tries : int
         The number of times to try the degradation before giving up, in the case
-        that the degraded excerpt overlaps.
+        that the degraded excerpt overlaps. This is not used, but we keep it for
+        consistency.
 
     Returns
     -------

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -38,6 +38,32 @@ def set_random_seed(func, seed=None):
     return seeded_func
 
 
+def set_tries(func, tries=10):
+    """This is a function decorator which just adds the keyword argument
+    `tries` to the end of the supplied function that it decorates.
+    Each degradation should check if its generated DataFrame is valid, and
+    if not, retry with `tries=tries - 1`. If tries is 0, the function should
+    return None and warn.
+
+    Parameters
+    ----------
+    func : function
+        function to be decorated
+    tries : int
+        The number of times to try the degradation before giving up, in the case
+        that the degraded excerpt overlaps.
+
+    Returns
+    -------
+    seeded_func : function
+        The originally supplied function, but now with an aditional optional
+        tries keyword argument.
+    """
+    def seeded_func(*args, tries=tries, **kwargs):
+        return func(*args, **kwargs)
+    return seeded_func
+
+
 def pre_process(df, sort=False):
     """
     Function which will pre-process a dataframe to be degraded.
@@ -124,6 +150,7 @@ def split_range_sample(split_range, p=None):
 
 
 @set_random_seed
+@set_tries
 def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
                 distribution=None):
     """
@@ -151,6 +178,10 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
         random state unchanged.
+
+    tries : int
+        The number of times to try the degradation before giving up, in the case
+        that the degraded excerpt overlaps.
 
 
     Returns
@@ -235,6 +266,7 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
 
 @set_random_seed
+@set_tries
 def time_shift(excerpt, min_shift=50, max_shift=np.inf, align_onset=False):
     """
     Shift the onset and offset times of one note from the given excerpt,
@@ -258,6 +290,10 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf, align_onset=False):
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
         random state unchanged.
+
+    tries : int
+        The number of times to try the degradation before giving up, in the case
+        that the degraded excerpt overlaps.
 
 
     Returns
@@ -360,6 +396,7 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf, align_onset=False):
 
 
 @set_random_seed
+@set_tries
 def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
                 max_duration=np.inf, align_onset=False, align_dur=False):
     """
@@ -394,6 +431,10 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
         random state unchanged.
+
+    tries : int
+        The number of times to try the degradation before giving up, in the case
+        that the degraded excerpt overlaps.
 
     Returns
     -------
@@ -529,6 +570,7 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
 
 @set_random_seed
+@set_tries
 def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
                  max_duration=np.inf, align_dur=False):
     """
@@ -560,6 +602,10 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
         random state unchanged.
+
+    tries : int
+        The number of times to try the degradation before giving up, in the case
+        that the degraded excerpt overlaps.
 
 
     Returns
@@ -643,6 +689,7 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
 
 @set_random_seed
+@set_tries
 def remove_note(excerpt):
     """
     Remove one note from the given excerpt.
@@ -655,6 +702,10 @@ def remove_note(excerpt):
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
         random state unchanged.
+
+    tries : int
+        The number of times to try the degradation before giving up, in the case
+        that the degraded excerpt overlaps.
 
     Returns
     -------
@@ -680,6 +731,7 @@ def remove_note(excerpt):
 
 
 @set_random_seed
+@set_tries
 def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
              min_duration=50, max_duration=np.inf,
              align_pitch=False, align_time=False):
@@ -720,6 +772,10 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
         random state unchanged.
+
+    tries : int
+        The number of times to try the degradation before giving up, in the case
+        that the degraded excerpt overlaps.
 
 
     Returns
@@ -812,6 +868,7 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
 
 @set_random_seed
+@set_tries
 def split_note(excerpt, min_duration=50, num_splits=1):
     """
     Split one note from the excerpt into two or more notes of equal
@@ -832,6 +889,10 @@ def split_note(excerpt, min_duration=50, num_splits=1):
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
         random state unchanged.
+
+    tries : int
+        The number of times to try the degradation before giving up, in the case
+        that the degraded excerpt overlaps.
 
     Returns
     -------
@@ -889,6 +950,7 @@ def split_note(excerpt, min_duration=50, num_splits=1):
 
 
 @set_random_seed
+@set_tries
 def join_notes(excerpt, max_gap=50, max_notes=20, only_first=False):
     """
     Combine two notes of the same pitch and track into one.
@@ -916,6 +978,10 @@ def join_notes(excerpt, max_gap=50, max_notes=20, only_first=False):
     seed : int
         A seed to be supplied to np.random.seed(). None leaves numpy's
         random state unchanged.
+
+    tries : int
+        The number of times to try the degradation before giving up, in the case
+        that the degraded excerpt overlaps.
 
     Returns
     -------

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -254,8 +254,10 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
     # Shift its pitch
     if distribution is None:
         # Uniform distribution
-        degraded.loc[note_index, 'pitch'] = randint(min_pitch,
-                                                    max_pitch + 1)
+        if min_pitch != max_pitch or min_pitch != pitch:
+            while degraded.loc[note_index, 'pitch'] == pitch:
+                degraded.loc[note_index, 'pitch'] = randint(min_pitch,
+                                                            max_pitch + 1)
     else:
         zero_idx = len(distribution) // 2
         pitches = np.array(range(pitch - zero_idx,
@@ -267,7 +269,8 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
         degraded.loc[note_index, 'pitch'] = choice(pitches, p=distribution)
 
     # Check if overlaps
-    if overlaps(degraded, note_index):
+    if (overlaps(degraded, note_index) or
+        degraded.loc[note_index, 'pitch'] == pitch):
         if tries == 1:
             warnings.warn(TRIES_WARN_MSG)
             return None

--- a/mdtk/tests/test_data_structures.py
+++ b/mdtk/tests/test_data_structures.py
@@ -244,7 +244,7 @@ ALL_VALID_DF = {
 
 for name, df in ALL_DF.items():
     df.to_csv(f'./{name}.csv', index=False)
-note_df_complex_overlap.to_csv(f'./note_df_complex_overlap.csv', index=False)
+note_df_complex_overlap.to_csv('./note_df_complex_overlap.csv', index=False)
 
 all_pitch_df_tracks_sparecol.to_csv(
         './all_pitch_df_tracks_sparecol_noheader.csv',
@@ -259,7 +259,8 @@ all_pitch_df_tracks_sparecol[weird_col_order].to_csv(
 
 ALL_CSV = [f'./{name}.csv' for name in ALL_DF.keys()]
 ALL_CSV += ['./all_pitch_df_tracks_sparecol_noheader.csv',
-            './all_pitch_df_tracks_sparecol_weirdorder.csv']
+            './all_pitch_df_tracks_sparecol_weirdorder.csv',
+            './note_df_complex_overlap.csv']
 
 default_read_note_csv_kwargs = dict(
     onset='onset',
@@ -311,6 +312,8 @@ ALL_CSV_KWARGS = {
             header=None
         ),
     './all_pitch_df_tracks_sparecol_weirdorder.csv':
+        default_read_note_csv_kwargs,
+    './note_df_complex_overlap.csv':
         default_read_note_csv_kwargs
 }
 

--- a/mdtk/tests/test_data_structures.py
+++ b/mdtk/tests/test_data_structures.py
@@ -244,6 +244,7 @@ ALL_VALID_DF = {
 
 for name, df in ALL_DF.items():
     df.to_csv(f'./{name}.csv', index=False)
+note_df_complex_overlap.to_csv(f'./note_df_complex_overlap.csv', index=False)
 
 all_pitch_df_tracks_sparecol.to_csv(
         './all_pitch_df_tracks_sparecol_noheader.csv',
@@ -344,6 +345,10 @@ def test_read_note_csv():
             read_note_csv('./note_df_odd_names.csv', onset='note_on',
                           track='ch', pitch='midinote', dur='duration'))
         )
+    assert all(read_note_csv('./note_df_complex_overlap.csv',
+                             flatten_tracks=True)['track'] == 0), (
+        "flatten_tracks=True didn't set all tracks to 0."
+    )
 
 
 def test_check_overlap():

--- a/mdtk/tests/test_data_structures.py
+++ b/mdtk/tests/test_data_structures.py
@@ -8,7 +8,8 @@ from mdtk.data_structures import (
     check_overlap, check_monophonic, check_overlapping_pitch, check_note_df,
     get_monophonic_tracks, make_monophonic, quantize_df,
     plot_from_df, show_gridlines, plot_matrix, note_df_to_pretty_midi,
-    synthesize_from_quant_df, synthesize_from_note_df, NOTE_DF_SORT_ORDER
+    synthesize_from_quant_df, synthesize_from_note_df, NOTE_DF_SORT_ORDER,
+    fix_overlaps
 )
 
 
@@ -81,6 +82,18 @@ note_df_odd_names = pd.DataFrame({
     'midinote': [60, 61, 60, 60, 60, 60],
     'duration': [1, 3.75, 1, 0.5, 0.5, 2],
     'ch' :[0, 1, 0, 0, 0, 0]
+})
+note_df_complex_overlap = pd.DataFrame({
+    'onset': [50, 75, 150, 200, 200, 300, 300, 300],
+    'track': [0, 0, 0, 0, 0, 0, 0, 1],
+    'pitch': [10, 10, 20, 10, 20, 30, 30, 10],
+    'dur': [300, 25, 100, 125, 50, 50, 100, 100]
+})
+note_df_complex_overlap_fixed = pd.DataFrame({
+    'onset': [50, 75, 150, 200, 200, 300, 300],
+    'track': [0, 0, 0, 0, 0, 0, 1],
+    'pitch': [10, 10, 20, 10, 20, 30, 10],
+    'dur': [25, 125, 50, 150, 50, 100, 100]
 })
 # midinote keyboard range from 0 to 127 inclusive
 all_midinotes = list(range(0, 128))
@@ -389,6 +402,14 @@ def test_fix_overlapping_notes():
         )
     assert all(note_df_2pitch_weird_times.dtypes ==
                fix_overlapping_notes(note_df_2pitch_weird_times.copy()).dtypes)
+
+
+def test_fix_overlaps():
+    res = fix_overlaps(note_df_complex_overlap)
+    assert note_df_complex_overlap_fixed.equals(res), (
+        f"Complex overlap\n{note_df_complex_overlap}\nproduced\n{res}\n"
+        f"instead of\n{note_df_complex_overlap_fixed}"
+    )
 
 
 def test_get_monophonic_tracks():

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -74,10 +74,67 @@ def test_post_process():
         'dur': [100, 100, 100, 100]
     })
 
-    res = deg.post_process(UNSORTED_DF)
+    unsorted_res = pd.DataFrame({
+        'onset': [0, 200, 200, 100],
+        'track': [0, 0, 1, 1],
+        'pitch': [10, 30, 40, 20],
+        'dur': [100, 100, 100, 100]
+    })
+
+    res = deg.post_process(UNSORTED_DF, sort=False)
+    assert res.equals(unsorted_res), (
+        f"Post-processing \n{UNSORTED_DF}\n resulted in \n{res}\n"
+        f"instead of \n{unsorted_res}\n with sort=False"
+    )
+
+    res = deg.post_process(UNSORTED_DF, sort=True)
     assert res.equals(basic_res), (
-        f"Post-processing \n{UNSORTED_DF}\n  "
-        f"resulted in \n{res}\ninstead of \n{basic_res}"
+        f"Post-processing \n{UNSORTED_DF}\n with sort=True resulted in "
+        f"\n{res}\ninstead of \n{basic_res}"
+    )
+
+
+def test_overlaps():
+    fixed_basic = deg.pre_process(BASIC_DF)
+    assert not deg.overlaps(fixed_basic, 0), (
+        f"Overlaps incorrectly returned True for:\n{fixed_basic}."
+    )
+
+    fixed_basic.loc[0, 'onset'] = 50
+    assert not deg.overlaps(fixed_basic, 0), (
+        f"Overlaps incorrectly returned True for:\n{fixed_basic}."
+    )
+
+    fixed_basic.loc[0, 'pitch'] = 20
+    assert not deg.overlaps(fixed_basic, 0), (
+        f"Overlaps incorrectly returned True for:\n{fixed_basic}."
+    )
+
+    fixed_basic.loc[0, 'track'] = 1
+    fixed_basic.loc[0, 'onset'] = 0
+    assert not deg.overlaps(fixed_basic, 0), (
+        f"Overlaps incorrectly returned True for:\n{fixed_basic}."
+    )
+
+    fixed_basic.loc[0, 'onset'] = 50
+    assert deg.overlaps(fixed_basic, 0), (
+        f"Overlaps incorrectly returned False for:\n{fixed_basic}."
+    )
+
+    fixed_basic.loc[0, 'onset'] = 150
+    assert deg.overlaps(fixed_basic, 0), (
+        f"Overlaps incorrectly returned False for:\n{fixed_basic}."
+    )
+
+    fixed_basic.loc[0, 'dur'] = 25
+    assert deg.overlaps(fixed_basic, 0), (
+        f"Overlaps incorrectly returned False for:\n{fixed_basic}."
+    )
+
+    fixed_basic.loc[0, 'dur'] = 150
+    fixed_basic.loc[0, 'onset'] = 75
+    assert deg.overlaps(fixed_basic, 0), (
+        f"Overlaps incorrectly returned False for:\n{fixed_basic}."
     )
 
 

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -177,6 +177,12 @@ def test_pitch_shift():
 
             assert not BASIC_DF.equals(res), "Note_df was not copied."
 
+    # Test if tries works
+    df = pd.DataFrame({'onset': [0], 'pitch': [10], 'track': [0], 'dur': [100]})
+    with pytest.warns(UserWarning, match=re.escape(deg.TRIES_WARN_MSG)):
+        res = deg.pitch_shift(df, min_pitch=10, max_pitch=10)
+        assert_none(res, msg="Pitch shift should run out of tries.")
+
     # Truly random testing
     for i in range(10):
         np.random.seed()


### PR DESCRIPTION
This will:
- Fix #8 by trying `tries` times (default 10) if there are overlaps and then returning None if overlaps were generating every time. This overlap check is quick because the index of the changed note is known.
- Fix #57 in a possibly inefficient way, but I couldn't think of how to do it otherwise. The previous method doesn't work I think (but I left them there--please clean if this one looks fine). I also added a test case for this in test_data_structures. This overlap_check is set to False by default and True in make_dataset.py. (Related to #20).
- Fix #46 by adding a flatten_tracks arg to read_note_csv and added a test for this. This is set to False by default and True in make_dataset.py.
- Fix #59 by adding (the same) random number (between 0 and 200) to the onsets of all notes in each clean excerpt, before degrading, in make_dataset.py.

TODO:
- The data_structures.fix_overlaps function adds around 6 secs per piece in PianoMidi. Should be less for PPDD since they are not full songs, but still... Still, be sure the test case passes. Also, clean up the remaining fix_overlap methods if this one is ok.