### PR TITLE
Eval script

### DIFF
--- a/baselines/eval_script.py
+++ b/baselines/eval_script.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+import argparse
+import os
+
+import numpy as np
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+import mdtk.pytorch_models
+import mdtk.pytorch_trainers
+from mdtk.pytorch_datasets import transform_to_torchtensor
+from mdtk.formatters import CommandVocab, FORMATTERS, create_corpus_csvs
+from mdtk.eval import helpfulness
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    # Filepath stuff
+    parser.add_argument("-i", "--input", default='acme', help='The '
+                        'base directory of the ACME dataset to use as input.')
+    parser.add_argument("-m", "--model", required=True, help='The '
+                        'filename of the model to use in evaluation.')
+
+    # Basic task setup args
+    parser.add_argument("--format", required=False, choices=FORMATTERS.keys(),
+                        help='The format to use as input to the model. If the '
+                        'format-specific csvs have not yet been created, this '
+                        'will create them. Choices are '
+                        f'{list(FORMATTERS.keys())}. Required if --baseline '
+                        'is not given.')
+
+    parser.add_argument("--task", required=True, choices=range(1, 5), help='The '
+                        'task number to train a model for.', type=int)
+
+    parser.add_argument("--baseline", action='store_true', help='Ignore all '
+                        'arguments and run the baseline model for the given '
+                        '--task.')
+    
+    # Dataset structure arg
+    parser.add_argument("-s", "--seq_len", type=int, default=250,
+                        help="maximum sequence length.")
+
+    # Training/DataLoading args
+    parser.add_argument("-b", "--batch_size", type=int, default=64,
+                        help="number of batch_size")
+    parser.add_argument("-w", "--num_workers", type=int, default=4,
+                        help="dataloader worker size")
+    parser.add_argument("--with_cpu", action='store_true', default=False,
+                        help="Train with CPU, default is to try and use CUDA. "
+                        "A warning will be thrown if CUDA is not available, "
+                        "and CPU used in that case.")
+    parser.add_argument("--cuda_devices", type=int, nargs='+',
+                        default=None, help="CUDA device ids")
+    parser.add_argument("--in_memory", type=bool, default=True,
+                        help="Loading on memory: true or false")
+
+    # Piano-roll specific size args
+    parser.add_argument("--pr-min-pitch", type=int, default=21,
+                        help="Minimum pianoroll pitch")
+    parser.add_argument("--pr-max-pitch", type=int, default=108,
+                        help="Maximum pianoroll pitch")
+
+    args = parser.parse_args()
+    return args
+
+
+
+task_names = [
+    'ErrorDetection',
+    'ErrorClassification',
+    'ErrorIdentification',
+    'ErrorCorrection'
+]
+
+task_trainers = [
+    getattr(mdtk.pytorch_trainers, f'{task_name}Trainer')
+    for task_name in task_names
+]
+
+task_criteria = [
+    nn.CrossEntropyLoss(),
+    nn.CrossEntropyLoss(),
+    nn.CrossEntropyLoss(),
+    nn.BCEWithLogitsLoss(reduction='mean')
+]
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    
+    if args.baseline:
+        # Setup args for the baseline for args.task
+        raise NotImplementedError(f"Baseline not created for task {args.task} yet.")
+    else:
+        assert args.format is not None, (
+            '--format is a required argument if --baseline is not given.'
+        )
+
+    # Generate (if needed) and load formatted test csv
+    prefix = FORMATTERS[args.format]["prefix"]
+    if not os.path.exists(os.path.join(args.input,
+                                       f'test_{prefix}_corpus.csv')):
+        create_corpus_csvs(args.input, FORMATTERS[args.format])
+    test_dataset = os.path.join(args.input, f'test_{prefix}_corpus.csv')
+    
+    task_idx = args.task - 1
+    task_name = task_names[task_idx]
+    model_name = FORMATTERS[args.format]['models'][task_idx]
+    if model_name is None:
+        raise NotImplementedError("No model implemented to load for task "
+                                  f"{task_name} with format {args.format}")
+    Dataset = getattr(mdtk.pytorch_datasets, FORMATTERS[args.format]['dataset'])
+    Trainer = task_trainers[task_idx]
+    Criterion = task_criteria[task_idx]
+    
+    if args.format == 'command':
+        vocab = CommandVocab()
+        dataset_args = [vocab, args.seq_len]
+        dataset_kwargs = {
+        }
+    elif args.format == 'pianoroll':
+        dataset_args = [args.seq_len]
+        dataset_kwargs = {
+            'min_pitch': args.pr_min_pitch,
+            'max_pitch': args.pr_max_pitch
+        }
+
+    print(f"Loading test {Dataset.__name__} from {test_dataset}")
+    test_dataset = Dataset(test_dataset, *dataset_args, **dataset_kwargs,
+                           in_memory=args.in_memory,
+                           transform=transform_to_torchtensor)
+
+    print(f"Creating test DataLoaders")
+    test_dataloader = DataLoader(test_dataset, batch_size=args.batch_size,
+                                 num_workers=args.num_workers)
+    
+    print(f"Loading model {args.model}")
+    model = torch.load(args.model)
+        
+    print("Creating Tester")
+    with_cuda = not args.with_cpu
+    if with_cuda:
+        print("Attempting to test on GPU")
+    else:
+        print("Attempting to test on CPU")
+    
+    trainer = Trainer(
+        model=model,
+        criterion=Criterion,
+        train_dataloader=None,
+        test_dataloader=test_dataloader,
+        with_cuda=with_cuda,
+        batch_log_freq=None,
+        epoch_log_freq=None,
+        formatter=FORMATTERS[args.format],
+        log_file=None
+    )
+    
+    print("Testing Start")
+    trainer.test(0, evaluate=True)

--- a/baselines/train_task.py
+++ b/baselines/train_task.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# TODO: turn this into a script which can train any of the tasks given 
-# a command line argument
 import argparse
 import os
 

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -31,6 +31,10 @@ def helpfulness(corrected_df, degraded_df, clean_df, time_increment=40):
            F-measures of corrected vs clean is the output.
         -- Else, using 0.0 == 0.0, degraded == 0.5 and clean == 1.0 as anchor
            points, place corrected's score on that scale.
+
+    f_measure : float
+        The average of the degraded_df's framewise F-measure and its notewise
+        F-measure, when compared to the clean_df.
     """
     corrected_fm = get_combined_fmeasure(corrected_df, clean_df,
                                          time_increment=time_increment)
@@ -43,9 +47,11 @@ def helpfulness(corrected_df, degraded_df, clean_df, time_increment=40):
                                         time_increment=time_increment)
 
     if corrected_fm < degraded_fm:
-        return 0.5 * corrected_fm / degraded_fm
+        h = 0.5 * corrected_fm / degraded_fm
     else:
-        return 1 - 0.5 * (1 - corrected_fm) / (1 - degraded_fm)
+        h = 1 - 0.5 * (1 - corrected_fm) / (1 - degraded_fm)
+
+    return h, corrected_fm
 
 
 def get_combined_fmeasure(df, gt_df, time_increment=40):

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -70,7 +70,7 @@ def get_combined_fmeasure(df, gt_df, time_increment=40):
         framewise and notewise F-measures.
      """
     fw = get_framewise_f_measure(df, gt_df, time_increment=time_increment)
-    nw = get_notewise_f_measure(df, gt_df, time_increment=time_increment)
+    nw = get_notewise_f_measure(df, gt_df)
     return (fw + nw) / 2
 
 
@@ -95,9 +95,9 @@ def get_framewise_f_measure(df, gt_df, time_increment=40):
         The framewise f_measure of the given dataframe.
     """
     raise NotImplementedError()
- 
- 
- def get_notewise_f_measure(df, gt_df, time_increment=40):
+
+
+def get_notewise_f_measure(df, gt_df):
     """
     Get the notewise F-measure of a dtaframe, given a ground truth dataframe.
 
@@ -118,6 +118,14 @@ def get_framewise_f_measure(df, gt_df, time_increment=40):
     f_measure : float
         The notewise f_measure of the given dataframe, using mir_eval.
     """
-    raise NotImplementedError()
-    # Use this for note-based F-measure
-    #precision_recall_f1_overlap(ref_intervals, ref_pitches, est_intervals, est_pitches, onset_tolerance=0.05, pitch_tolerance=50.0, offset_ratio=0.2, offset_min_tolerance=0.05, strict=False, beta=1.0)
+    gt_pitches = np.array(gt_df['pitch'])
+    gt_times = np.vstack((gt_df['onset'], gt_df['onset'] + gt_df['dur'])).T
+
+    pitches = np.array(df['pitch'])
+    times = np.vstack((df['onset'], df['onset'] + df['dur'])).T
+
+    _, _, fm, _ = precision_recall_f1_overlap(gt_times, gt_pitches, times,
+                                              pitches, onset_tolerance=50,
+                                              pitch_tolerance=0,
+                                              offset_ratio=None)
+    return fm

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -172,7 +172,7 @@ def get_notewise_f_measure(df, gt_df):
 def get_f1(tp, fp, fn):
     """
     Get the precision, recall, and f1 of a given count of TPs, FPs, and FNs.
-    
+
     Parameters
     ----------
     tp : int

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -170,6 +170,31 @@ def get_notewise_f_measure(df, gt_df):
 
 
 def get_f1(tp, fp, fn):
+    """
+    Get the precision, recall, and f1 of a given count of TPs, FPs, and FNs.
+    
+    Parameters
+    ----------
+    tp : int
+        True positive count.
+
+    fp : int
+        False positive count.
+
+    fn : int
+        False negative count.
+
+    Returns
+    -------
+    p : float
+        Precision. 0 if tp == 0 (even if fp is also 0).
+
+    r : float
+        Recall. 0 if tp == 0 (even if fn is also 0).
+
+    fm : float
+        F1 score. 0 if tp == 0 (even if fn or fp are also 0).
+    """
     if tp == 0:
         return 0, 0, 0
     p = tp / (tp + fp)

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -131,14 +131,7 @@ def get_framewise_f_measure(df, gt_df, time_increment=40):
     fp = np.sum(pr) - tp
     fn = np.sum(gt_pr) - tp
 
-    if tp + fp == 0 or tp + fn == 0:
-        return 0
-    p = tp / (tp + fp)
-    r = tp / (tp + fn)
-    if p + r == 0:
-        return 0
-    fm = 2 * p * r / (p + r)
-    return fm
+    return get_f1(tp, fp, fn)
 
 
 def get_notewise_f_measure(df, gt_df):
@@ -172,4 +165,15 @@ def get_notewise_f_measure(df, gt_df):
                                               pitches, onset_tolerance=50,
                                               pitch_tolerance=0,
                                               offset_ratio=None)
+    return fm
+
+
+def get_f1(tp, fp, fn):
+    if tp + fp == 0 or tp + fn == 0:
+        return 0
+    p = tp / (tp + fp)
+    r = tp / (tp + fn)
+    if p + r == 0:
+        return 0
+    fm = 2 * p * r / (p + r)
     return fm

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -31,18 +31,93 @@ def helpfulness(corrected_df, degraded_df, clean_df, time_increment=40):
         -- Else, using 0.0 == 0.0, degraded == 0.5 and clean == 1.0 as anchor
            points, place corrected's score on that scale.
     """
-    # Use this for note-based F-measure
-    #precision_recall_f1_overlap(ref_intervals, ref_pitches, est_intervals, est_pitches, onset_tolerance=0.05, pitch_tolerance=50.0, offset_ratio=0.2, offset_min_tolerance=0.05, strict=False, beta=1.0)
-    corrected_fm = 0 # TODO: Get F-measure
-    # TODO: also get frame-based
+    corrected_fm = get_combined_fmeasure(corrected_df, clean_df,
+                                         time_increment=time_increment)
 
+    # Quick exit on border cases
     if corrected_fm == 0 or corrected_fm == 1 or degraded_df.equals(clean_df):
         return corrected_fm
 
-    degraded_fm = 0 # TODO: Calculate this
-    # TODO: Also get frame-based
+    degraded_fm = get_combined_fmeasure(degraded_df, clean_df,
+                                        time_increment=time_increment)
 
     if corrected_fm < degraded_fm:
         return 0.5 * corrected_fm / degraded_fm
     else:
         return 1 - 0.5 * (1 - corrected_fm) / (1 - degraded_fm)
+
+
+def get_combined_fmeasure(df, gt_df, time_increment=40):
+    """
+    Get the combined framewise and notewise F-measure of a dtaframe,
+    given a ground truth dataframe.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The dataframe whose F-measure to return.
+
+    gt_df : pd.DataFrame
+        The ground truth dataframe.
+
+    time_increment : int
+        The length of a frame to use when performing evaluations.
+
+    Returns
+    -------
+    f_measure : float
+        The combined f_measure of the given dataframe. The mean of its
+        framewise and notewise F-measures.
+     """
+    fw = get_framewise_f_measure(df, gt_df, time_increment=time_increment)
+    nw = get_notewise_f_measure(df, gt_df, time_increment=time_increment)
+    return (fw + nw) / 2
+
+
+def get_framewise_f_measure(df, gt_df, time_increment=40):
+    """
+    Get the framewise F-measure of a dtaframe, given a ground truth dataframe.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The dataframe whose framewise F-measure to return.
+
+    gt_df : pd.DataFrame
+        The ground truth dataframe.
+
+    time_increment : int
+        The length of a frame to use when performing evaluations.
+
+    Returns
+    -------
+    f_measure : float
+        The framewise f_measure of the given dataframe.
+    """
+    raise NotImplementedError()
+ 
+ 
+ def get_notewise_f_measure(df, gt_df, time_increment=40):
+    """
+    Get the notewise F-measure of a dtaframe, given a ground truth dataframe.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The dataframe whose notewise F-measure to return.
+
+    gt_df : pd.DataFrame
+        The ground truth dataframe.
+
+    time_increment : int
+        The length of a frame to use for quantization when performing
+        evaluations.
+
+    Returns
+    -------
+    f_measure : float
+        The notewise f_measure of the given dataframe, using mir_eval.
+    """
+    raise NotImplementedError()
+    # Use this for note-based F-measure
+    #precision_recall_f1_overlap(ref_intervals, ref_pitches, est_intervals, est_pitches, onset_tolerance=0.05, pitch_tolerance=50.0, offset_ratio=0.2, offset_min_tolerance=0.05, strict=False, beta=1.0)

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -1,0 +1,1 @@
+"""Module containing methods to evaluate performance on Error Correction"""

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -1,1 +1,30 @@
 """Module containing methods to evaluate performance on Error Correction"""
+
+
+def helpfulness(corrected, degraded, clean, timestep=40):
+    """
+    Get the helpfulness of an excerpt, given the degraded and clean versions.
+
+    Parameters
+    ----------
+    corrected : pd.DataFrame
+        The data frame of the corrected excerpt as output by a model.
+
+    degraded : pd.DataFrame
+        The degraded excerpt given as input to the model.
+
+    clean : pd.DataFrame
+        The clean excerpt expected as output.
+
+    Returns
+    -------
+    helpfulness : float
+        The helpfulness of the given correction, defined as follows:
+        -- First, take the mean of the note-based and frame-based F-measures
+           of corrected and degraded.
+        -- If degraded's score is 1, the mean of note-based and frame-based
+           F-measures of corrected vs clean is the output.
+        -- Else, using 0.0 == 0.0, degraded == 0.5 and clean == 1.0 as anchor
+           points, place corrected's score on that scale.
+    """
+    raise NotImplementedError()

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -1,5 +1,6 @@
 """Module containing methods to evaluate performance on Error Correction"""
 from mir_eval.transcription import precision_recall_f1_overlap
+import numpy as np
 
 
 def helpfulness(corrected_df, degraded_df, clean_df, time_increment=40):
@@ -94,7 +95,7 @@ def get_framewise_f_measure(df, gt_df, time_increment=40):
     f_measure : float
         The framewise f_measure of the given dataframe.
     """
-    gt_quant_df = df.loc[:, ['pitch']]
+    gt_quant_df = gt_df.loc[:, ['pitch']]
     gt_quant_df['onset'] = (gt_df['onset'] / time_increment).round().astype(int)
     gt_quant_df['offset'] = (((gt_df['onset'] + gt_df['dur']) / time_increment)
                              .round().astype(int)

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -1,20 +1,24 @@
 """Module containing methods to evaluate performance on Error Correction"""
+from mir_eval.transcription import precision_recall_f1_overlap
 
 
-def helpfulness(corrected, degraded, clean, timestep=40):
+def helpfulness(corrected_df, degraded_df, clean_df, time_increment=40):
     """
     Get the helpfulness of an excerpt, given the degraded and clean versions.
 
     Parameters
     ----------
-    corrected : pd.DataFrame
+    corrected_df : pd.DataFrame
         The data frame of the corrected excerpt as output by a model.
 
-    degraded : pd.DataFrame
+    degraded_df : pd.DataFrame
         The degraded excerpt given as input to the model.
 
-    clean : pd.DataFrame
+    clean_df : pd.DataFrame
         The clean excerpt expected as output.
+
+    time_increment : int
+        The length of a frame to use when performing evaluations.
 
     Returns
     -------
@@ -27,4 +31,18 @@ def helpfulness(corrected, degraded, clean, timestep=40):
         -- Else, using 0.0 == 0.0, degraded == 0.5 and clean == 1.0 as anchor
            points, place corrected's score on that scale.
     """
-    raise NotImplementedError()
+    # Use this for note-based F-measure
+    #precision_recall_f1_overlap(ref_intervals, ref_pitches, est_intervals, est_pitches, onset_tolerance=0.05, pitch_tolerance=50.0, offset_ratio=0.2, offset_min_tolerance=0.05, strict=False, beta=1.0)
+    corrected_fm = 0 # TODO: Get F-measure
+    # TODO: also get frame-based
+
+    if corrected_fm == 0 or corrected_fm == 1 or degraded_df.equals(clean_df):
+        return corrected_fm
+
+    degraded_fm = 0 # TODO: Calculate this
+    # TODO: Also get frame-based
+
+    if corrected_fm < degraded_fm:
+        return 0.5 * corrected_fm / degraded_fm
+    else:
+        return 1 - 0.5 * (1 - corrected_fm) / (1 - degraded_fm)

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -131,7 +131,8 @@ def get_framewise_f_measure(df, gt_df, time_increment=40):
     fp = np.sum(pr) - tp
     fn = np.sum(gt_pr) - tp
 
-    return get_f1(tp, fp, fn)
+    _, _, f = get_f1(tp, fp, fn)
+    return f
 
 
 def get_notewise_f_measure(df, gt_df):
@@ -169,11 +170,9 @@ def get_notewise_f_measure(df, gt_df):
 
 
 def get_f1(tp, fp, fn):
-    if tp + fp == 0 or tp + fn == 0:
-        return 0
+    if tp == 0:
+        return 0, 0, 0
     p = tp / (tp + fp)
     r = tp / (tp + fn)
-    if p + r == 0:
-        return 0
     fm = 2 * p * r / (p + r)
-    return fm
+    return p, r, fm

--- a/mdtk/formatters.py
+++ b/mdtk/formatters.py
@@ -241,6 +241,12 @@ def double_pianoroll_to_df(pianoroll, min_pitch=0, max_pitch=127,
     df : pd.DataFrame
         A dataframe equal to the given pianoroll.
     """
+    if max_pitch != pianoroll.shape[1] / 2 + min_pitch - 1:
+        warnings.warn("max_pitch doesn't match pianoroll shape and min_pitch. "
+                      "Setting max_pitch to "
+                      f"{pianoroll.shape[1] / 2 + min_pitch - 1}.")
+        max_pitch = pianoroll.shape[1] / 2 + min_pitch - 1
+
     notes = []
     active = [-1] * (max_pitch - min_pitch + 1) # Index of active note in notes
     midpoint = pianoroll.shape[1] / 2

--- a/mdtk/formatters.py
+++ b/mdtk/formatters.py
@@ -4,6 +4,7 @@ import tqdm
 import pandas as pd
 import numpy as np
 import os
+import warnings
 
 from mdtk.data_structures import NOTE_DF_SORT_ORDER
 
@@ -245,7 +246,7 @@ def double_pianoroll_to_df(pianoroll, min_pitch=0, max_pitch=127,
         warnings.warn("max_pitch doesn't match pianoroll shape and min_pitch. "
                       "Setting max_pitch to "
                       f"{pianoroll.shape[1] / 2 + min_pitch - 1}.")
-        max_pitch = pianoroll.shape[1] / 2 + min_pitch - 1
+        max_pitch = int(pianoroll.shape[1] / 2 + min_pitch - 1)
 
     df_notes = []
     active = [-1] * (max_pitch - min_pitch + 1) # Index of active note in notes

--- a/mdtk/pytorch_trainers.py
+++ b/mdtk/pytorch_trainers.py
@@ -234,7 +234,7 @@ class ErrorDetectionTrainer(BaseTrainer):
                                      # unbiased estimate...)
             total_correct += correct
             total_element += labels.nelement()
-            total_positive += model_output.argmax(dim=-1).round().sum().item()
+            total_positive += model_output.argmax(dim=-1).sum().item()
             total_positive_labels += labels.sum().item()
             total_true_pos += true_pos
 
@@ -265,7 +265,8 @@ class ErrorDetectionTrainer(BaseTrainer):
             tp = total_true_pos
             fn = total_positive_labels - tp
             fp = total_positive - tp
-            print(f"F-measure: {get_f1(tp, fp, fn)}")
+            p, r, f = get_f1(tp, fp, fn)
+            print(f"P, R, F-measure: {p}, {r}, {f}")
         
         
         return log_info
@@ -472,6 +473,9 @@ class ErrorIdentificationTrainer(BaseTrainer):
         avg_loss = 0.0
         total_correct = 0
         total_element = 0
+        total_positive = 0
+        total_positive_labels = 0
+        total_true_pos = 0
         
         for ii, data in data_iter:
             # N tensors of integers representing (potentially) degraded midi
@@ -501,7 +505,7 @@ class ErrorIdentificationTrainer(BaseTrainer):
                                      # unbiased estimate...)
             total_correct += correct
             total_element += labels.nelement()
-            total_positive += model_output.argmax(dim=-1).round().sum().item()
+            total_positive += model_output.argmax(dim=-1).sum().item()
             total_positive_labels += labels.sum().item()
             total_true_pos += true_pos
 

--- a/mdtk/pytorch_trainers.py
+++ b/mdtk/pytorch_trainers.py
@@ -102,13 +102,14 @@ class BaseTrainer:
         self.log_file.flush()
         return log_info
         
-    def test(self, epoch):
+    def test(self, epoch, evaluate=False):
         with torch.no_grad():
-            log_info = self.iteration(epoch, self.test_data, train=False)
+            log_info = self.iteration(epoch, self.test_data, train=False,
+                                      evaluate=evaluate)
         self.log_file.flush()
         return log_info
 
-    def iteration(self, epoch, data_loader, train=True):
+    def iteration(self, epoch, data_loader, train=True, evaluate=False):
         """This must be overwritten by classes inheriting this"""
         raise NotImplementedError()
 
@@ -162,7 +163,7 @@ class ErrorDetectionTrainer(BaseTrainer):
             log_file=log_file
         )
 
-    def iteration(self, epoch, data_loader, train=True):
+    def iteration(self, epoch, data_loader, train=True, evaluate=False):
         """
         The loop used for train and test methods. Loops over the provided
         data_loader for one epoch getting only the necessary data for the task.
@@ -288,7 +289,7 @@ class ErrorClassificationTrainer(BaseTrainer):
             log_file=log_file
         )
 
-    def iteration(self, epoch, data_loader, train=True):
+    def iteration(self, epoch, data_loader, train=True, evaluate=False):
         """
         The loop used for train and test methods. Loops over the provided
         data_loader for one epoch getting only the necessary data for the task.
@@ -414,7 +415,7 @@ class ErrorIdentificationTrainer(BaseTrainer):
             log_file=log_file
         )
 
-    def iteration(self, epoch, data_loader, train=True):
+    def iteration(self, epoch, data_loader, train=True, evaluate=False):
         """
         The loop used for train and test methods. Loops over the provided
         data_loader for one epoch getting only the necessary data for the task.
@@ -541,7 +542,7 @@ class ErrorCorrectionTrainer(BaseTrainer):
             log_file=log_file
         )
 
-    def iteration(self, epoch, data_loader, train=True):
+    def iteration(self, epoch, data_loader, train=True, evaluate=False):
         """
         The loop used for train and test methods. Loops over the provided
         data_loader for one epoch getting only the necessary data for the task.


### PR DESCRIPTION
This supersedes (and contains) #69, which I will cancel.

This fixes #63 

It creates a baselines/eval_script.py file, which requires as input a saved model and a task number.
It then creates the same Trainers as usual given the args, but runs only 1 epoch with train=False and evaluate=True, and prints out the appropriate metric to the command line.

I have tested with all 4 tasks.

TODO:
- Remove formatters from the trainers
- Figure out how to pass in min_pitch, max_pitch, and time_increment to task 4 trainer. Actually, min_pitch and max_pitch don't matter at all, because we look for exact matches (and both the target and the output will be shifted by the same amount), but time_increment is important, because the standard is to allow for 50ms differences in timing to count as matches. So for us, 1 frame, but with time_increment=25, 2 frames)