### PR TITLE
Org

### DIFF
--- a/baselines/eval_task.py
+++ b/baselines/eval_task.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import argparse
 import os
+import warnings
+import sys
 
 import numpy as np
 
@@ -16,22 +18,13 @@ from mdtk.eval import helpfulness
 from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
 
 
+def print_warn_msg_only(message, category, filename, lineno, file=None,
+                        line=None):
+    print(message, file=sys.stderr)
 
-
-## For dev mode warnings...
-#import sys
-#if not sys.warnoptions:
-#    import warnings
-#    warnings.simplefilter("always") # Change the filter in this process
-#    os.environ["PYTHONWARNINGS"] = "always" # Also affect subprocesses
-
-
-# For user mode warnings...
-import sys
-if not sys.warnoptions:
-    import warnings
-    warnings.simplefilter("ignore") # Change the filter in this process
-    os.environ["PYTHONWARNINGS"] = "ignore" # Also affect subprocesses
+warnings.showwarning = print_warn_msg_only
+# TODO: This should ideally be 'once', but it doesn't work for some reason
+warnings.filterwarnings('ignore', message='.* exceeds given seq_len')
     
 
 

--- a/baselines/eval_task.py
+++ b/baselines/eval_task.py
@@ -13,6 +13,7 @@ import mdtk.pytorch_trainers
 from mdtk.pytorch_datasets import transform_to_torchtensor
 from mdtk.formatters import CommandVocab, FORMATTERS, create_corpus_csvs
 from mdtk.eval import helpfulness
+from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
 
 
 
@@ -81,9 +82,9 @@ def construct_parser():
                         help="Loading on memory: true or false")
 
     # Piano-roll specific size args
-    parser.add_argument("--pr-min-pitch", type=int, default=21,
+    parser.add_argument("--pr-min-pitch", type=int, default=MIN_PITCH_DEFAULT,
                         help="Minimum pianoroll pitch")
-    parser.add_argument("--pr-max-pitch", type=int, default=108,
+    parser.add_argument("--pr-max-pitch", type=int, default=MAX_PITCH_DEFAULT,
                         help="Maximum pianoroll pitch")
     return parser
 

--- a/baselines/eval_task.py
+++ b/baselines/eval_task.py
@@ -176,7 +176,7 @@ def main(args):
 task_names = [
     'ErrorDetection',
     'ErrorClassification',
-    'ErrorIdentification',
+    'ErrorLocation',
     'ErrorCorrection'
 ]
 

--- a/baselines/train_task.py
+++ b/baselines/train_task.py
@@ -100,6 +100,9 @@ def parse_args():
                         'will create them. Choices are '
                         f'{list(FORMATTERS.keys())}. Required if --baseline '
                         'is not given.')
+    parser.add_argument("--reformat", action="store_true", help="Force the "
+                        "creation of the desired --format csvs, even if they "
+                        "already exist.")
 
     parser.add_argument("--task", required=True, choices=range(1, 5), help='The '
                         'task number to train a model for.', type=int)
@@ -210,9 +213,9 @@ if __name__ == '__main__':
 
     # Generate (if needed) and load formatted csv
     prefix = FORMATTERS[args.format]["prefix"]
-    if not all([os.path.exists(
+    if (not all([os.path.exists(
             os.path.join(args.input, f'{split}_{prefix}_corpus.csv')
-        ) for split in ['train', 'valid', 'test']]):
+        ) for split in ['train', 'valid', 'test']])) or args.reformat:
         create_corpus_csvs(args.input, FORMATTERS[args.format])
     train_dataset = os.path.join(args.input, f'train_{prefix}_corpus.csv')
     valid_dataset = os.path.join(args.input, f'valid_{prefix}_corpus.csv')

--- a/baselines/train_task.py
+++ b/baselines/train_task.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 import argparse
 import os
+import sys
 import pandas as pd
 import numpy as np
+import warnings
 
 import torch
 import torch.nn as nn
@@ -15,22 +17,13 @@ from mdtk.formatters import CommandVocab, FORMATTERS, create_corpus_csvs
 from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
 
 
+def print_warn_msg_only(message, category, filename, lineno, file=None,
+                        line=None):
+    print(message, file=sys.stderr)
 
-## For dev mode warnings...
-#import sys
-#if not sys.warnoptions:
-#    import warnings
-#    warnings.simplefilter("always") # Change the filter in this process
-#    os.environ["PYTHONWARNINGS"] = "always" # Also affect subprocesses
-
-
-# For user mode warnings...
-import sys
-if not sys.warnoptions:
-    import warnings
-    warnings.simplefilter("ignore") # Change the filter in this process
-    os.environ["PYTHONWARNINGS"] = "ignore" # Also affect subprocesses
-
+warnings.showwarning = print_warn_msg_only
+# TODO: This should ideally be 'once', but it doesn't work for some reason
+warnings.filterwarnings('ignore', message='.* exceeds given seq_len')
 
 def get_inverse_weights(dataset, task, formatter, transform=torch.tensor):
     """

--- a/baselines/train_task.py
+++ b/baselines/train_task.py
@@ -12,6 +12,7 @@ import mdtk.pytorch_models
 import mdtk.pytorch_trainers
 from mdtk.pytorch_datasets import transform_to_torchtensor
 from mdtk.formatters import CommandVocab, FORMATTERS, create_corpus_csvs
+from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
 
 
 
@@ -165,9 +166,9 @@ def parse_args():
                         help="adam first beta value")
 
     # Piano-roll specific size args
-    parser.add_argument("--pr-min-pitch", type=int, default=21,
+    parser.add_argument("--pr-min-pitch", type=int, default=MIN_PITCH_DEFAULT,
                         help="Minimum pianoroll pitch")
-    parser.add_argument("--pr-max-pitch", type=int, default=108,
+    parser.add_argument("--pr-max-pitch", type=int, default=MAX_PITCH_DEFAULT,
                         help="Maximum pianoroll pitch")
 
     args = parser.parse_args()

--- a/baselines/train_task.py
+++ b/baselines/train_task.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import os
-
+import pandas as pd
 import numpy as np
 
 import torch
@@ -232,6 +232,7 @@ if __name__ == '__main__':
     Trainer = task_trainers[task_idx]
     Criterion = task_criteria[task_idx]
     
+    deg_ids_df = pd.read_csv(os.path.join(args.input, 'degradation_ids.csv'))
     if args.format == 'command':
         vocab = CommandVocab()
         vocab_size = len(vocab)
@@ -243,7 +244,7 @@ if __name__ == '__main__':
             'vocab_size': vocab_size,
             'embedding_dim': args.embedding,
             'hidden_dim': args.hidden,
-            'output_size': 2 if args.task == 1 else 9,
+            'output_size': 2 if args.task == 1 else len(deg_ids_df),
             'dropout_prob': args.dropout
         }
     elif args.format == 'pianoroll':
@@ -256,7 +257,7 @@ if __name__ == '__main__':
         model_kwargs = {
             'input_dim': 2 * (args.pr_max_pitch - args.pr_min_pitch + 1),
             'hidden_dim': args.hidden,
-            'output_dim': 2 if args.task in [1, 3] else 9,
+            'output_dim': 2 if args.task in [1, 3] else len(deg_ids_df),
             'layers': args.layers,
             'dropout_prob': args.dropout
         }

--- a/baselines/train_task.py
+++ b/baselines/train_task.py
@@ -175,7 +175,7 @@ def parse_args():
 task_names = [
     'ErrorDetection',
     'ErrorClassification',
-    'ErrorIdentification',
+    'ErrorLocation',
     'ErrorCorrection'
 ]
 

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -298,8 +298,9 @@ if __name__ == '__main__':
         csv_input_dirs[dirname] = csv_outdir
         if ARGS.recursive:
             path = os.path.join(path, '**')
-        for filepath in glob(os.path.join(path, '*.mid'),
-                             recursive=ARGS.recursive):
+        for filepath in tqdm(glob(os.path.join(path, '*.mid'),
+                                  recursive=ARGS.recursive),
+                             desc=f'Loading user midi from {path}'):
             if ARGS.recursive:
                 outdir = os.path.join(
                     basedir,
@@ -307,7 +308,7 @@ if __name__ == '__main__':
                     os.path.basename(filepath)
                 )
             os.makedirs(os.path.dirname(outdir), exist_ok=True)
-            copy_file(filepath, outdir, verbose=ARGS.verbose)
+            copy_file(filepath, outdir)
 
 
     # Copy over user csv ======================================================
@@ -322,8 +323,9 @@ if __name__ == '__main__':
         csv_input_dirs[dirname] = outdir
         if ARGS.recursive:
             path = os.path.join(path, '**')
-        for filepath in glob(os.path.join(path, '*.csv'),
-                             recursive=ARGS.recursive):
+        for filepath in tqdm(glob(os.path.join(path, '*.mid'),
+                                  recursive=ARGS.recursive),
+                             desc=f'Loading user csv from {path}'):
             if ARGS.recursive:
                 outdir = os.path.join(
                     basedir,
@@ -331,7 +333,7 @@ if __name__ == '__main__':
                     os.path.basename(filepath)
                 )
             os.makedirs(os.path.dirname(outdir), exist_ok=True)
-            copy_file(filepath, outdir, verbose=ARGS.verbose)
+            copy_file(filepath, outdir)
 
 
     # Convert from midi to csv ================================================

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -99,6 +99,7 @@ def pre_process(df, sort=False):
     df : pd.DataFrame
         The postprocessed dataframe.
     """
+    df = df.loc[:, NOTE_DF_SORT_ORDER]
     if sort:
         df = df.sort_values(NOTE_DF_SORT_ORDER)
     df = df.reset_index(drop=True)

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -102,6 +102,7 @@ def pre_process(df, sort=False):
     if sort:
         df = df.sort_values(NOTE_DF_SORT_ORDER)
     df = df.reset_index(drop=True)
+    df = df.round().astype(int)
     return df
 
 

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -8,8 +8,16 @@ from numpy.random import randint, choice
 from mdtk.data_structures import NOTE_DF_SORT_ORDER
 
 
-MIN_PITCH = 0
-MAX_PITCH = 127
+MIN_PITCH_DEFAULT = 21
+MAX_PITCH_DEFAULT = 108
+
+MIN_SHIFT_DEFAULT = 100
+MAX_SHIFT_DEFAULT = np.inf
+
+MIN_DURATION_DEFAULT = 50
+MAX_DURATION_DEFAULT = np.inf
+
+TRIES_DEFAULT = 10
 
 TRIES_WARN_MSG = ("WARNING: Generated invalid (overlapping) degraded excerpt "
                   "too many times. Try raising tries parameter (default 10). "
@@ -160,8 +168,9 @@ def split_range_sample(split_range, p=None):
 
 
 @set_random_seed
-def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
-                distribution=None, tries=10):
+def pitch_shift(excerpt, min_pitch=MIN_PITCH_DEFAULT,
+                max_pitch=MAX_PITCH_DEFAULT, distribution=None,
+                tries=TRIES_DEFAULT):
     """
     Shift the pitch of one note from the given excerpt.
 
@@ -286,8 +295,9 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
 
 @set_random_seed
-def time_shift(excerpt, min_shift=50, max_shift=np.inf, align_onset=False,
-               tries=10):
+def time_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
+               max_shift=MAX_SHIFT_DEFAULT, align_onset=False,
+               tries=TRIES_DEFAULT):
     """
     Shift the onset and offset times of one note from the given excerpt,
     leaving its duration unchanged.
@@ -401,9 +411,10 @@ def time_shift(excerpt, min_shift=50, max_shift=np.inf, align_onset=False,
 
 
 @set_random_seed
-def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
-                max_duration=np.inf, align_onset=False, align_dur=False,
-                tries=10):
+def onset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
+                max_shift=MAX_SHIFT_DEFAULT, min_duration=MIN_DURATION_DEFAULT,
+                max_duration=MAX_DURATION_DEFAULT, align_onset=False,
+                align_dur=False, tries=TRIES_DEFAULT):
     """
     Shift the onset time of one note from the given excerpt.
 
@@ -583,8 +594,10 @@ def onset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
 
 @set_random_seed
-def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
-                 max_duration=np.inf, align_dur=False, tries=10):
+def offset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
+                 max_shift=MAX_SHIFT_DEFAULT, min_duration=MIN_DURATION_DEFAULT,
+                 max_duration=MAX_DURATION_DEFAULT, align_dur=False,
+                 tries=TRIES_DEFAULT):
     """
     Shift the offset time of one note from the given excerpt.
 
@@ -711,7 +724,7 @@ def offset_shift(excerpt, min_shift=50, max_shift=np.inf, min_duration=50,
 
 
 @set_random_seed
-def remove_note(excerpt, tries=10):
+def remove_note(excerpt, tries=TRIES_DEFAULT):
     """
     Remove one note from the given excerpt.
 
@@ -754,9 +767,10 @@ def remove_note(excerpt, tries=10):
 
 
 @set_random_seed
-def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
-             min_duration=50, max_duration=np.inf,
-             align_pitch=False, align_time=False, tries=10):
+def add_note(excerpt, min_pitch=MIN_PITCH_DEFAULT, max_pitch=MAX_PITCH_DEFAULT,
+             min_duration=MIN_DURATION_DEFAULT,
+             max_duration=MAX_DURATION_DEFAULT, align_pitch=False,
+             align_time=False, tries=TRIES_DEFAULT):
     """
     Add one note to the given excerpt.
 
@@ -892,7 +906,8 @@ def add_note(excerpt, min_pitch=MIN_PITCH, max_pitch=MAX_PITCH,
 
 
 @set_random_seed
-def split_note(excerpt, min_duration=50, num_splits=1, tries=10):
+def split_note(excerpt, min_duration=MIN_DURATION_DEFAULT, num_splits=1,
+               tries=TRIES_DEFAULT):
     """
     Split one note from the excerpt into two or more notes of equal
     duration.
@@ -976,7 +991,7 @@ def split_note(excerpt, min_duration=50, num_splits=1, tries=10):
 
 @set_random_seed
 def join_notes(excerpt, max_gap=50, max_notes=20, only_first=False,
-               tries=10):
+               tries=TRIES_DEFAULT):
     """
     Combine two notes of the same pitch and track into one.
 
@@ -1094,7 +1109,7 @@ DEGRADATIONS = {
 }
 
 
-def get_degradations(degradation_list):
+def get_degradations(degradation_list=DEGRADATIONS):
     """
     A convenience function to get degradation functions from strings.
 

--- a/mdtk/filesystem_utils.py
+++ b/mdtk/filesystem_utils.py
@@ -8,14 +8,15 @@ import zipfile
 
 
 
-def download_file(source, dest, verbose=True, overwrite=None):
+def download_file(source, dest, verbose=False, overwrite=None):
         """Get a file from a url and save it locally"""
         if verbose:
             print(f'Downloading {source} to {dest}')
         if os.path.exists(dest):
             if overwrite is None:
-                warnings.warn(f'WARNING: {dest} already exists, not '
-                              'downloading', category=UserWarning)
+                if verbose:
+                    warnings.warn(f'WARNING: {dest} already exists, not '
+                                  'downloading', category=UserWarning)
                 return
             if not overwrite:
                 raise OSError(f'{dest} already exists')
@@ -26,7 +27,7 @@ def download_file(source, dest, verbose=True, overwrite=None):
             raise e
 
 
-def make_directory(path, overwrite=None, verbose=True):
+def make_directory(path, overwrite=None, verbose=False):
         """Convenience function to create a directory and handle cases where
         it already exists.
         
@@ -49,13 +50,15 @@ def make_directory(path, overwrite=None, verbose=True):
             mkdir(path)
         except FileExistsError as e:
             if overwrite is True:
-                print(f'Deleting existing directory: {path}')
+                if verbose:
+                    print(f'Deleting existing directory: {path}')
                 shutil.rmtree(path)
                 mkdir(path)
             elif overwrite is None:
-                warnings.warn(f'WARNING: {path} already exists, writing files '
-                      'within here only if they do not already exist.',
-                      category=UserWarning)
+                if verbose:
+                    warnings.warn(f'WARNING: {path} already exists, writing '
+                                  'files only if they do not already exist.',
+                                  category=UserWarning)
             elif overwrite is False:
                 raise e
             else:
@@ -63,7 +66,7 @@ def make_directory(path, overwrite=None, verbose=True):
                                  f'"{overwrite}"')
 
 
-def extract_zip(zip_path, out_path, overwrite=None, verbose=True):
+def extract_zip(zip_path, out_path, overwrite=None, verbose=False):
     """Convenience function to extract zip file to out_path.
     TODO: make work for all types of zip files."""
     if verbose:
@@ -72,12 +75,15 @@ def extract_zip(zip_path, out_path, overwrite=None, verbose=True):
     extracted_path = os.path.join(out_path, dirname)
     if os.path.exists(extracted_path):     
         if overwrite is True:
-            warnings.warn(f'Deleting existing directory: {extracted_path}')
+            if verbose:
+                warnings.warn('Deleting existing directory: '
+                              f'{extracted_path}')
             shutil.rmtree(extracted_path)
         elif overwrite is None:
-            warnings.warn(f'{extracted_path} already exists. Assuming this '
-                          'zip has already been extracted, not extracting.',
-                  category=UserWarning)
+            if verbose:
+                warnings.warn(f'{extracted_path} already exists. Assuming '
+                              'this zip has already been extracted, not '
+                              'extracting.', category=UserWarning)
             return extracted_path
         elif overwrite is False:
             raise FileExistsError(f'{extracted_path} already exists')

--- a/mdtk/formatters.py
+++ b/mdtk/formatters.py
@@ -452,7 +452,7 @@ FORMATTERS = {
         'dataset': 'PianorollDataset',
         'models': [None,
                    None,
-                   'Pianoroll_ErrorIdentificationNet',
+                   'Pianoroll_ErrorLocationNet',
                    'Pianoroll_ErrorCorrectionNet']
     }
 }

--- a/mdtk/formatters.py
+++ b/mdtk/formatters.py
@@ -108,7 +108,10 @@ def create_corpus_csvs(acme_dir, format_dict):
         meta_df.loc[idx, f'{prefix}_corpus_path'] = fh.name
         meta_df.loc[idx, f'{prefix}_corpus_line_nr'] = line_counts[split]
         line_counts[split] += 1
-    meta_df.to_csv(os.path.join(acme_dir, 'metadata.csv'))
+    meta_df.loc[:, f'{prefix}_corpus_line_nr'] = (
+        meta_df[f'{prefix}_corpus_line_nr'].astype(int)
+    )
+    meta_df.to_csv(os.path.join(acme_dir, 'metadata.csv'), index=False)
 
 
 def df_to_pianoroll_str(df, time_increment=40):

--- a/mdtk/formatters.py
+++ b/mdtk/formatters.py
@@ -7,6 +7,7 @@ import os
 import warnings
 
 from mdtk.data_structures import NOTE_DF_SORT_ORDER
+from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
 
 # Convenience function...
 def diff_pd(df1, df2):
@@ -34,8 +35,8 @@ def diff_pd(df1, df2):
 #       I'm doing things this way just for ability to change things
 #       later with ease
 class CommandVocab(object):
-    def __init__(self, min_pitch=0,
-                 max_pitch=127,
+    def __init__(self, min_pitch=MIN_PITCH_DEFAULT,
+                 max_pitch=MAX_PITCH_DEFAULT,
                  time_increment=40,
                  max_time_shift=4000, 
                  specials=["<pad>", "<unk>", "<eos>", "<sos>"]):
@@ -215,8 +216,8 @@ def pianoroll_str_to_df(pr_str, time_increment=40):
     return df
 
 
-def double_pianoroll_to_df(pianoroll, min_pitch=0, max_pitch=127,
-                           time_increment=40):
+def double_pianoroll_to_df(pianoroll, min_pitch=MIN_PITCH_DEFAULT,
+                           max_pitch=MAX_PITCH_DEFAULT, time_increment=40):
     """
     Convert a double pianoroll (sustain and onset, as output by a task 4 model),
     into a DataFrame for use in evaluation.
@@ -309,8 +310,8 @@ def double_pianoroll_to_df(pianoroll, min_pitch=0, max_pitch=127,
     return df
 
 
-def df_to_command_str(df, min_pitch=0, max_pitch=127, time_increment=40,
-                      max_time_shift=4000):
+def df_to_command_str(df, min_pitch=MIN_PITCH_DEFAULT, max_pitch=MAX_PITCH_DEFAULT,
+                      time_increment=40, max_time_shift=4000):
     """
     Convert a given pandas DataFrame into a sequence commands, note_on (o),
     note_off (f), and time_shift (t). Each command is followed by a number:

--- a/mdtk/formatters.py
+++ b/mdtk/formatters.py
@@ -250,7 +250,7 @@ def double_pianoroll_to_df(pianoroll, min_pitch=MIN_PITCH_DEFAULT,
     if max_pitch != pianoroll.shape[1] / 2 + min_pitch - 1:
         warnings.warn("max_pitch doesn't match pianoroll shape and min_pitch. "
                       "Setting max_pitch to "
-                      f"{pianoroll.shape[1] / 2 + min_pitch - 1}.")
+                      f"{int(pianoroll.shape[1] / 2 + min_pitch - 1)}.")
         max_pitch = int(pianoroll.shape[1] / 2 + min_pitch - 1)
 
     df_notes = []

--- a/mdtk/midi.py
+++ b/mdtk/midi.py
@@ -97,7 +97,11 @@ def midi_to_df(midi_path, warn=False):
             dur: The duration of the note (offset - onset), in milliseconds.
         Sorting will be first by onset, then track, then pitch, then duration.
     """
-    midi = pretty_midi.PrettyMIDI(midi_path)
+    try:
+        midi = pretty_midi.PrettyMIDI(midi_path)
+    except:
+        warnings.warn(f'Error parsing midi file {midi_path}. Skipping.')
+        return None
 
     notes = []
     for index, instrument in enumerate(midi.instruments):

--- a/mdtk/midi.py
+++ b/mdtk/midi.py
@@ -1,12 +1,12 @@
 """Code to interact with MIDI files, including parsing and converting them
 to csvs."""
-
 import os
 import glob
 import warnings
 
 import pandas as pd
 import numpy as np
+from tqdm import tqdm
 
 import pretty_midi
 
@@ -43,7 +43,10 @@ def midi_dir_to_csv(midi_dir_path, csv_dir_path, recursive=False):
     if recursive:
         dir_prefix_len = len(midi_dir_path) + 1
         midi_dir_path = os.path.join(midi_dir_path, '**')
-    for midi_path in glob.glob(os.path.join(midi_dir_path, '*.mid')):
+    for midi_path in tqdm(glob.glob(os.path.join(midi_dir_path, '*.mid')),
+                          desc='Converting midi from '
+                          f'{os.path.basename(midi_dir_path)} to csv at '
+                          f'{os.path.basename(csv_dir_path)}: '):
         if recursive:
             csv_path = os.path.join(
                 csv_dir_path,

--- a/mdtk/pytorch_datasets.py
+++ b/mdtk/pytorch_datasets.py
@@ -9,6 +9,7 @@ import os
 import warnings
 
 from mdtk.formatters import FORMATTERS
+from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
 
 
 
@@ -156,9 +157,9 @@ class CommandDataset(Dataset):
 
 # This is adapted from https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/dataset/dataset.py
 class PianorollDataset(Dataset):
-    def __init__(self, corpus_path, seq_len, min_pitch=0,
-                 max_pitch=127, encoding="utf-8", corpus_lines=None,
-                 in_memory=True, transform=None):
+    def __init__(self, corpus_path, seq_len, min_pitch=MIN_PITCH_DEFAULT,
+                 max_pitch=MAX_PITCH_DEFAULT, encoding="utf-8",
+                 corpus_lines=None, in_memory=True, transform=None):
         """
         Returns piano-roll-based data for ACME tasks.
 

--- a/mdtk/pytorch_models.py
+++ b/mdtk/pytorch_models.py
@@ -83,9 +83,9 @@ class Command_ErrorClassificationNet(Command_ErrorDetectionNet):
 
 
 
-class Pianoroll_ErrorIdentificationNet(nn.Module):
+class Pianoroll_ErrorLocationNet(nn.Module):
     """
-    Baseline model for the Error Identification task, in which the label for
+    Baseline model for the Error Location task, in which the label for
     each data point is a binary label for each frame of input, with  0 = not
     degraded and 1 = degraded.
     

--- a/mdtk/pytorch_trainers.py
+++ b/mdtk/pytorch_trainers.py
@@ -704,6 +704,8 @@ class ErrorCorrectionTrainer(BaseTrainer):
                 total_data_points += len(input_data)
                 for in_data, out_data, clean_data in \
                         zip(input_data, model_output, labels):
+                    # TODO: Only 1 of these calls is necessary. deg and clean
+                    # could conceivably be returned by the data loader.
                     deg_df = self.formatter['model_to_df'](
                         in_data.cpu().data.numpy(), min_pitch=21,
                         max_pitch=108, time_increment=40)

--- a/mdtk/pytorch_trainers.py
+++ b/mdtk/pytorch_trainers.py
@@ -355,8 +355,7 @@ class ErrorClassificationTrainer(BaseTrainer):
         total_loss = 0
         total_correct = 0
         total_element = 0
-        if evaluate:
-            confusion_mat = np.zeros((9, 9))
+        confusion_mat = None
         
         # Setting the tqdm progress bar
         data_iter = tqdm.tqdm(enumerate(data_loader),
@@ -397,6 +396,9 @@ class ErrorClassificationTrainer(BaseTrainer):
 
             # Confusion matrix
             if evaluate:
+                if confusion_mat is None:
+                    num_degs = model_output.shape[1]
+                    confusion_mat = np.zeros((num_degs, num_degs))
                 for label, output in zip(labels.cpu(),
                                          model_output.cpu().data.numpy()):
                     confusion_mat[label, np.argmax(output)] += 1

--- a/mdtk/pytorch_trainers.py
+++ b/mdtk/pytorch_trainers.py
@@ -437,9 +437,9 @@ class ErrorClassificationTrainer(BaseTrainer):
 
 
 
-class ErrorIdentificationTrainer(BaseTrainer):
-    """Trains Task 3 - Error identification. The model provided is expected to be
-    an mdtk.pytorch_models.ErrorIdentificationNet. Expects a DataLoader using an
+class ErrorLocationTrainer(BaseTrainer):
+    """Trains Task 3 - Error Location. The model provided is expected to be
+    an mdtk.pytorch_models.ErrorLocationNet. Expects a DataLoader using an
     mdtk.pytorch_datasets.CommandDataset."""
     def __init__(self, model, criterion, train_dataloader: DataLoader,
                  test_dataloader: DataLoader = None,
@@ -587,8 +587,8 @@ class ErrorIdentificationTrainer(BaseTrainer):
 
 
 class ErrorCorrectionTrainer(BaseTrainer):
-    """Trains Task 4 - Error identification. The model provided is expected to be
-    an mdtk.pytorch_models.ErrorIdentificationNet. Expects a DataLoader using an
+    """Trains Task 4 - Error Correction. The model provided is expected to be
+    an mdtk.pytorch_models.ErrorCorrectionNet. Expects a DataLoader using an
     mdtk.pytorch_datasets.CommandDataset."""
     def __init__(self, model, criterion, train_dataloader: DataLoader,
                  test_dataloader: DataLoader = None,

--- a/mdtk/pytorch_trainers.py
+++ b/mdtk/pytorch_trainers.py
@@ -707,16 +707,25 @@ class ErrorCorrectionTrainer(BaseTrainer):
                         zip(input_data, model_output, labels):
                     # TODO: Only 1 of these calls is necessary. deg and clean
                     # could conceivably be returned by the data loader.
-                    deg_df = self.formatter['model_to_df'](
-                        in_data.cpu().data.numpy(), min_pitch=MIN_PITCH_DEFAULT,
-                        max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
-                    model_out_df = self.formatter['model_to_df'](
-                        out_data.round().cpu().data.numpy(),
-                        min_pitch=MIN_PITCH_DEFAULT,
-                        max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
-                    clean_df = self.formatter['model_to_df'](
-                        clean_data.cpu().data.numpy(), min_pitch=MIN_PITCH_DEFAULT,
-                        max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
+                    # N.B. Currently, the precise min and max pitch don't
+                    # matter here. The converter just treats them all the same,
+                    # corrects and warns if the range doesn't make sense.
+                    # However, if loading deg and clean from the original df,
+                    # using the correct min and max pitch will be important.
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        deg_df = self.formatter['model_to_df'](
+                            in_data.cpu().data.numpy(),
+                            min_pitch=MIN_PITCH_DEFAULT,
+                            max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
+                        model_out_df = self.formatter['model_to_df'](
+                            out_data.round().cpu().data.numpy(),
+                            min_pitch=MIN_PITCH_DEFAULT,
+                            max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
+                        clean_df = self.formatter['model_to_df'](
+                            clean_data.cpu().data.numpy(),
+                            min_pitch=MIN_PITCH_DEFAULT,
+                            max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
                     h, f = helpfulness(model_out_df, deg_df, clean_df)
                     total_help += h
                     total_fm += f

--- a/mdtk/pytorch_trainers.py
+++ b/mdtk/pytorch_trainers.py
@@ -5,6 +5,7 @@ from torch.utils.data import DataLoader
 import numpy as np
 import tqdm
 from mdtk.eval import helpfulness, get_f1
+from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
 
 
 
@@ -707,14 +708,15 @@ class ErrorCorrectionTrainer(BaseTrainer):
                     # TODO: Only 1 of these calls is necessary. deg and clean
                     # could conceivably be returned by the data loader.
                     deg_df = self.formatter['model_to_df'](
-                        in_data.cpu().data.numpy(), min_pitch=21,
-                        max_pitch=108, time_increment=40)
+                        in_data.cpu().data.numpy(), min_pitch=MIN_PITCH_DEFAULT,
+                        max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
                     model_out_df = self.formatter['model_to_df'](
-                        out_data.round().cpu().data.numpy(), min_pitch=21,
-                        max_pitch=108, time_increment=40)
+                        out_data.round().cpu().data.numpy(),
+                        min_pitch=MIN_PITCH_DEFAULT,
+                        max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
                     clean_df = self.formatter['model_to_df'](
-                        clean_data.cpu().data.numpy(), min_pitch=21,
-                        max_pitch=108, time_increment=40)
+                        clean_data.cpu().data.numpy(), min_pitch=MIN_PITCH_DEFAULT,
+                        max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
                     h, f = helpfulness(model_out_df, deg_df, clean_df)
                     total_help += h
                     total_fm += f

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -66,10 +66,11 @@ def test_pre_process():
     )
     
     float_df = pd.DataFrame({
-        'onset': [0.5, 100.5, 200.5, 200.5],
         'track': [0, 1, 0, 1.5],
+        'onset': [0.5, 100.5, 200.5, 200.5],
         'pitch': [10, 20, 30.5, 40],
-        'dur': [100, 100, 100.5, 100]
+        'dur': [100, 100, 100.5, 100],
+        'extra': [5, 5, 'apple', None]
     })
     float_res = pd.DataFrame({
         'onset': [0, 100, 200, 200],

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -167,7 +167,7 @@ def test_pitch_shift():
 
             basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
                                       'track': [0, 1, 0, 1],
-                                      'pitch': [10, 107, 30, 40],
+                                      'pitch': [10, 33, 30, 40],
                                       'dur': [100, 100, 100, 100]})
 
             assert res.equals(basic_res), (
@@ -292,9 +292,9 @@ def test_time_shift():
         for i in range(2):
             res = deg.time_shift(BASIC_DF, seed=1)
 
-            basic_res = pd.DataFrame({'onset': [0, 158, 200, 200],
-                                      'track': [0, 1, 0, 1],
-                                      'pitch': [10, 20, 30, 40],
+            basic_res = pd.DataFrame({'onset': [0, 200, 200, 200],
+                                      'track': [0, 0, 1, 1],
+                                      'pitch': [10, 30, 20, 40],
                                       'dur': [100, 100, 100, 100]})
 
             assert res.equals(basic_res), (
@@ -436,10 +436,10 @@ def test_onset_shift():
         for i in range(2):
             res = deg.onset_shift(BASIC_DF, seed=1)
 
-            basic_res = pd.DataFrame({'onset': [0, 150, 200, 200],
-                                      'track': [0, 1, 0, 1],
-                                      'pitch': [10, 20, 30, 40],
-                                      'dur': [100, 50, 100, 100]})
+            basic_res = pd.DataFrame({'onset': [0, 72, 100, 200],
+                                      'track': [0, 0, 1, 1],
+                                      'pitch': [10, 30, 20, 40],
+                                      'dur': [100, 228, 100, 100]})
 
             assert res.equals(basic_res), (
                 f"Onset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
@@ -661,7 +661,7 @@ def test_offset_shift():
             basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
                                       'track': [0, 1, 0, 1],
                                       'pitch': [10, 20, 30, 40],
-                                      'dur': [100, 158, 100, 100]})
+                                      'dur': [100, 200, 100, 100]})
 
             assert res.equals(basic_res), (
                 f"Offset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
@@ -829,7 +829,7 @@ def test_add_note():
 
         basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 235],
                                   'track': [0, 1, 0, 1, 0],
-                                  'pitch': [10, 20, 30, 40, 37],
+                                  'pitch': [10, 20, 30, 40, 58],
                                   'dur': [100, 100, 100, 100, 62]})
 
         assert res.equals(basic_res), (

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -64,6 +64,24 @@ def test_pre_process():
         f"Pre-processing \n{UNSORTED_DF}\n with sort=True resulted in "
         f"\n{res}\ninstead of \n{basic_res}"
     )
+    
+    float_df = pd.DataFrame({
+        'onset': [0.5, 100.5, 200.5, 200.5],
+        'track': [0, 1, 0, 1.5],
+        'pitch': [10, 20, 30.5, 40],
+        'dur': [100, 100, 100.5, 100]
+    })
+    float_res = pd.DataFrame({
+        'onset': [0, 100, 200, 200],
+        'track': [0, 1, 0, 2],
+        'pitch': [10, 20, 30, 40],
+        'dur': [100, 100, 100, 100]
+    })
+    res = deg.pre_process(float_df)
+    assert res.equals(float_res), (
+        f"Pre-processing \n{float_df}\n resulted in \n{res}\n"
+        f"instead of \n{float_res}"
+    )
 
 
 def test_post_process():


### PR DESCRIPTION
Fixes a number of issues:
- Fixes #76 by renaming task 3 to Location.
- Fixes #42 with default values for all degradation params. I also use the default min/max pitches throughout the code: when creating the pianoroll and command datasets (*make sure this seems ok for command*), and as defaults for arg parsing.
- Fixes #66 by adding a --reformat arg to train_task.py, forcing csv re-creation.
- Fixes #80 by adding evaluators for all tasks in mdtk.eval.py. Check how I've named the task 4 evaluator (as ErrorCorrection, a la the others, and also as `helpfulness = ErrorCorrection`).
- Fixes #52 by adding a --verbose (-v) option to make_dataset, and suppressing warnings from the degradations within the script (because we handle them with code). This allows other (important) warnings to print. Also adds verbose option to the downloaders, and defaults all verbose args to False (there and in the filesystem_utils). Also, places the unimportant (I'd say) warnings in filesystem_utils behind the --verbose flag. Shortened some of the tqdm texts (it's just long filepaths).
- Fixes #87 by making clearing the output and input directory default. Using --stale-data causes --input-dir not to be cleared. There is no way not to clear --output-dir. I just cannot think of a use case for this.

Additionally, this does some work on #37.

Please also check #37, #27, and #22. For these, I am happy to not fix them. If you agree, remove the milestone marker from them (and optionally also close the issues).