### PR TITLE
Code quality settings for developers

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,12 @@
+# To make isort config compatible with black see
+# https://github.com/ambv/black#how-black-wraps-lines
+
+[settings]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 88
+known_third_party = IPython,matplotlib,mir_eval,numpy,pandas,pretty_midi,seaborn,torch,tqdm
+extend-ignore = E203, W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    - id: isort
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.8
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,3 @@ repos:
     hooks:
     - id: black
       language_version: python3.8
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-    - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
     hooks:
     - id: black
       language_version: python3.8
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    - id: flake8

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ onset,track,pitch,dur
 where:
 * `onset` is the time in milliseconds when a note began,
 * `track` is the identifier for a distinct track in the midi file,
-* `pitch` is the midinote pitch number ranging from 0 (C-2) to 127 (G9) (concert 
+* `pitch` is the midinote pitch number ranging from 0 (C-2) to 127 (G9) (concert
   A4 is midinote 69), and
 * `dur` is how long the note is held in milliseconds.
 
@@ -51,7 +51,7 @@ Some highlights include:
 * [`./baselines`](./baselines) - scripts for running the baseline models
   included in the paper (available upon request)
 
-For more information about mdtk modules, see the package readme: 
+For more information about mdtk modules, see the package readme:
 [`./mdtk/README.md`](./mdtk/README.md)
 
 ## Install
@@ -70,7 +70,6 @@ pip install .  # use pip install -e . for dev mode if you want to edit files
 ```
 
 ## Quickstart
-
 To generate an `ACME` dataset simply install the package with instructions
 above and run `./make_dataset.py`.
 
@@ -80,3 +79,14 @@ and a directory of ground truth files (in mid or csv format). The ground truth
 and corresponding transcription should be named the exact same thing.
 
 See `measure_errors_example.ipynb` for an example of the script's usage.
+
+
+## Contributors
+If you would like to contribute, please install in developer mode and use the dev option
+when installing the package. Additionally, please run `pre-commit install` to
+automatically run pre-commit hooks.
+
+```bash
+pip install -e ${path_to_repo}[dev]
+pre-commit install
+```

--- a/baselines/eval_task.py
+++ b/baselines/eval_task.py
@@ -1,32 +1,28 @@
 #!/usr/bin/env python
 import argparse
 import os
-import warnings
 import sys
+import warnings
 
 import numpy as np
-
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
-from mdtk import pytorch_models
-from mdtk import pytorch_trainers
-from mdtk import pytorch_datasets
-from mdtk.pytorch_datasets import transform_to_torchtensor
-from mdtk.formatters import CommandVocab, FORMATTERS, create_corpus_csvs
+from mdtk import pytorch_datasets, pytorch_models, pytorch_trainers
+from mdtk.degradations import MAX_PITCH_DEFAULT, MIN_PITCH_DEFAULT
 from mdtk.eval import helpfulness
-from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
+from mdtk.formatters import FORMATTERS, CommandVocab, create_corpus_csvs
+from mdtk.pytorch_datasets import transform_to_torchtensor
 
 
-def print_warn_msg_only(message, category, filename, lineno, file=None,
-                        line=None):
+def print_warn_msg_only(message, category, filename, lineno, file=None, line=None):
     print(message, file=sys.stderr)
+
 
 warnings.showwarning = print_warn_msg_only
 # TODO: This should ideally be 'once', but it doesn't work for some reason
-warnings.filterwarnings('ignore', message='.* exceeds given seq_len')
-    
+warnings.filterwarnings("ignore", message=".* exceeds given seq_len")
 
 
 # TODO: get formatter out of Trainer
@@ -35,51 +31,94 @@ def construct_parser():
     parser = argparse.ArgumentParser()
 
     # Filepath stuff
-    parser.add_argument("-i", "--input", default='acme', help='The '
-                        'base directory of the ACME dataset to use as input.')
-    parser.add_argument("-m", "--model", required=True, help='The '
-                        'filename of the model to use in evaluation.')
+    parser.add_argument(
+        "-i",
+        "--input",
+        default="acme",
+        help="The " "base directory of the ACME dataset to use as input.",
+    )
+    parser.add_argument(
+        "-m",
+        "--model",
+        required=True,
+        help="The " "filename of the model to use in evaluation.",
+    )
 
     # Basic task setup args
-    parser.add_argument("--format", required=False, choices=FORMATTERS.keys(),
-                        help='The format to use as input to the model. If the '
-                        'format-specific csvs have not yet been created, this '
-                        'will create them. Choices are '
-                        f'{list(FORMATTERS.keys())}. Required if --baseline '
-                        'is not given.')
+    parser.add_argument(
+        "--format",
+        required=False,
+        choices=FORMATTERS.keys(),
+        help="The format to use as input to the model. If the "
+        "format-specific csvs have not yet been created, this "
+        "will create them. Choices are "
+        f"{list(FORMATTERS.keys())}. Required if --baseline "
+        "is not given.",
+    )
 
-    parser.add_argument("-t", "--task", required=True, choices=range(1, 5), help='The '
-                        'task number to train a model for.', type=int)
+    parser.add_argument(
+        "-t",
+        "--task",
+        required=True,
+        choices=range(1, 5),
+        help="The " "task number to train a model for.",
+        type=int,
+    )
 
-    parser.add_argument("--baseline", action='store_true', help='Ignore all '
-                        'arguments and run the baseline model for the given '
-                        '--task.')
-    
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help="Ignore all "
+        "arguments and run the baseline model for the given "
+        "--task.",
+    )
+
     # Dataset structure arg
-    parser.add_argument("-s", "--seq_len", type=int, default=250,
-                        help="maximum sequence length.")
+    parser.add_argument(
+        "-s", "--seq_len", type=int, default=250, help="maximum sequence length."
+    )
 
     # Training/DataLoading args
-    parser.add_argument("--splits", nargs='+', default=['test'],
-                        help="which splits to evaluate: train, valid, test.")
-    parser.add_argument("-b", "--batch_size", type=int, default=64,
-                        help="number of batch_size")
-    parser.add_argument("-w", "--num_workers", type=int, default=4,
-                        help="dataloader worker size")
-    parser.add_argument("--with_cpu", action='store_true', default=False,
-                        help="Train with CPU, default is to try and use CUDA. "
-                        "A warning will be thrown if CUDA is not available, "
-                        "and CPU used in that case.")
-    parser.add_argument("--cuda_devices", type=int, nargs='+',
-                        default=None, help="CUDA device ids")
-    parser.add_argument("--in_memory", type=bool, default=True,
-                        help="Loading on memory: true or false")
+    parser.add_argument(
+        "--splits",
+        nargs="+",
+        default=["test"],
+        help="which splits to evaluate: train, valid, test.",
+    )
+    parser.add_argument(
+        "-b", "--batch_size", type=int, default=64, help="number of batch_size"
+    )
+    parser.add_argument(
+        "-w", "--num_workers", type=int, default=4, help="dataloader worker size"
+    )
+    parser.add_argument(
+        "--with_cpu",
+        action="store_true",
+        default=False,
+        help="Train with CPU, default is to try and use CUDA. "
+        "A warning will be thrown if CUDA is not available, "
+        "and CPU used in that case.",
+    )
+    parser.add_argument(
+        "--cuda_devices", type=int, nargs="+", default=None, help="CUDA device ids"
+    )
+    parser.add_argument(
+        "--in_memory", type=bool, default=True, help="Loading on memory: true or false"
+    )
 
     # Piano-roll specific size args
-    parser.add_argument("--pr-min-pitch", type=int, default=MIN_PITCH_DEFAULT,
-                        help="Minimum pianoroll pitch")
-    parser.add_argument("--pr-max-pitch", type=int, default=MAX_PITCH_DEFAULT,
-                        help="Maximum pianoroll pitch")
+    parser.add_argument(
+        "--pr-min-pitch",
+        type=int,
+        default=MIN_PITCH_DEFAULT,
+        help="Minimum pianoroll pitch",
+    )
+    parser.add_argument(
+        "--pr-max-pitch",
+        type=int,
+        default=MAX_PITCH_DEFAULT,
+        help="Maximum pianoroll pitch",
+    )
     return parser
 
 
@@ -88,67 +127,72 @@ def main(args):
         # Setup args for the baseline for args.task
         raise NotImplementedError(f"Baseline not created for task {args.task} yet.")
     else:
-        assert args.format is not None, (
-            '--format is a required argument if --baseline is not given.'
-        )
+        assert (
+            args.format is not None
+        ), "--format is a required argument if --baseline is not given."
 
     # Generate (if needed) and load formatted test csv
     prefix = FORMATTERS[args.format]["prefix"]
-    if not os.path.exists(os.path.join(args.input,
-                                       f'test_{prefix}_corpus.csv')):
+    if not os.path.exists(os.path.join(args.input, f"test_{prefix}_corpus.csv")):
         create_corpus_csvs(args.input, FORMATTERS[args.format])
     dataset_path = {
-        'train': os.path.join(args.input, f'train_{prefix}_corpus.csv'),
-        'valid': os.path.join(args.input, f'valid_{prefix}_corpus.csv'),
-        'test': os.path.join(args.input, f'test_{prefix}_corpus.csv')
+        "train": os.path.join(args.input, f"train_{prefix}_corpus.csv"),
+        "valid": os.path.join(args.input, f"valid_{prefix}_corpus.csv"),
+        "test": os.path.join(args.input, f"test_{prefix}_corpus.csv"),
     }
-    
+
     task_idx = args.task - 1
     task_name = TASK_NAMES[task_idx]
-    model_name = FORMATTERS[args.format]['models'][task_idx]
+    model_name = FORMATTERS[args.format]["models"][task_idx]
     if model_name is None:
-        raise NotImplementedError("No model implemented to load for task "
-                                  f"{task_name} with format {args.format}")
-    Dataset = getattr(pytorch_datasets, FORMATTERS[args.format]['dataset'])
+        raise NotImplementedError(
+            "No model implemented to load for task "
+            f"{task_name} with format {args.format}"
+        )
+    Dataset = getattr(pytorch_datasets, FORMATTERS[args.format]["dataset"])
     Trainer = TASK_TRAINERS[task_idx]
     Criterion = TASK_CRITERIA[task_idx]
-    
-    if args.format == 'command':
+
+    if args.format == "command":
         vocab = CommandVocab()
         dataset_args = [vocab, args.seq_len]
-        dataset_kwargs = {
-        }
-    elif args.format == 'pianoroll':
+        dataset_kwargs = {}
+    elif args.format == "pianoroll":
         dataset_args = [args.seq_len]
         dataset_kwargs = {
-            'min_pitch': args.pr_min_pitch,
-            'max_pitch': args.pr_max_pitch
+            "min_pitch": args.pr_min_pitch,
+            "max_pitch": args.pr_max_pitch,
         }
-    
+
     dataset = {}
     dataloader = {}
     for split in args.splits:
         path = dataset_path[split]
         print(f"Loading {split} {Dataset.__name__} from {path}")
-        
-        dataset[split] = Dataset(path, *dataset_args, **dataset_kwargs,
-                                 in_memory=args.in_memory,
-                                 transform=transform_to_torchtensor)
+
+        dataset[split] = Dataset(
+            path,
+            *dataset_args,
+            **dataset_kwargs,
+            in_memory=args.in_memory,
+            transform=transform_to_torchtensor,
+        )
 
         print(f"Creating {split} DataLoader")
-        dataloader[split] = DataLoader(dataset[split], batch_size=args.batch_size,
-                                       num_workers=args.num_workers)
-    
+        dataloader[split] = DataLoader(
+            dataset[split], batch_size=args.batch_size, num_workers=args.num_workers
+        )
+
     print(f"Loading model {args.model}")
-    model = torch.load(args.model, map_location='cpu')
-        
+    model = torch.load(args.model, map_location="cpu")
+
     print("Creating Tester")
     with_cuda = not args.with_cpu
     if with_cuda:
         print("Attempting to test on GPU")
     else:
         print("Attempting to test on CPU")
-    
+
     split_log_info = {}
     for split in args.splits:
         trainer = Trainer(
@@ -160,7 +204,7 @@ def main(args):
             batch_log_freq=None,
             epoch_log_freq=None,
             formatter=FORMATTERS[args.format],
-            log_file=None
+            log_file=None,
         )
         print(f"Evaluating {split} split")
         log_info = trainer.test(0, evaluate=True)
@@ -169,27 +213,25 @@ def main(args):
 
 
 TASK_NAMES = [
-    'ErrorDetection',
-    'ErrorClassification',
-    'ErrorLocation',
-    'ErrorCorrection'
+    "ErrorDetection",
+    "ErrorClassification",
+    "ErrorLocation",
+    "ErrorCorrection",
 ]
 
 TASK_TRAINERS = [
-    getattr(pytorch_trainers, f'{task_name}Trainer')
-    for task_name in TASK_NAMES
+    getattr(pytorch_trainers, f"{task_name}Trainer") for task_name in TASK_NAMES
 ]
 
 TASK_CRITERIA = [
     nn.CrossEntropyLoss(),
     nn.CrossEntropyLoss(),
     nn.CrossEntropyLoss(),
-    nn.BCEWithLogitsLoss(reduction='mean')
+    nn.BCEWithLogitsLoss(reduction="mean"),
 ]
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = construct_parser()
     args = parser.parse_args()
     main(args)

--- a/baselines/eval_task.py
+++ b/baselines/eval_task.py
@@ -4,14 +4,12 @@ import os
 import sys
 import warnings
 
-import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
-from mdtk import pytorch_datasets, pytorch_models, pytorch_trainers
+from mdtk import pytorch_datasets, pytorch_trainers
 from mdtk.degradations import MAX_PITCH_DEFAULT, MIN_PITCH_DEFAULT
-from mdtk.eval import helpfulness
 from mdtk.formatters import FORMATTERS, CommandVocab, create_corpus_csvs
 from mdtk.pytorch_datasets import transform_to_torchtensor
 

--- a/baselines/get_results.py
+++ b/baselines/get_results.py
@@ -130,7 +130,7 @@ def plot_confusion(confusion_mat, save_plots=False, ax=None):
         "split_note",
         "join_notes",
     ]
-    im = ax.imshow(confusion_mat, cmap="Oranges", interpolation="nearest")
+    _ = ax.imshow(confusion_mat, cmap="Oranges", interpolation="nearest")
     # We want to show all ticks...
     ax.xaxis.tick_top()
     ax.set_xticks(np.arange(len(degs)))
@@ -144,7 +144,7 @@ def plot_confusion(confusion_mat, save_plots=False, ax=None):
         array_range = np.max(confusion_mat) - np.min(confusion_mat)
         color_cutoff = np.min(confusion_mat) + array_range / 2
         for j in range(len(degs)):
-            text = ax.text(
+            _ = ax.text(
                 j,
                 i,
                 "%.2f" % confusion_mat[i, j],
@@ -174,7 +174,7 @@ def plot_1d_array_per_deg(array, save_plots=False, ax=None):
         "split_note",
         "join_notes",
     ]
-    im = ax.imshow(array.reshape((-1, 1)), cmap="Oranges", interpolation="nearest",)
+    _ = ax.imshow(array.reshape((-1, 1)), cmap="Oranges", interpolation="nearest",)
 
     # We want to show all ticks...
     ax.xaxis.tick_top()
@@ -184,11 +184,11 @@ def plot_1d_array_per_deg(array, save_plots=False, ax=None):
     for ii in range(len(degs)):
         array_range = np.max(array) - np.min(array)
         color_cutoff = np.min(array) + array_range / 2
-        if array[ii] < np.median(array):
+        if array[ii] < color_cutoff:
             color = "black"
         else:
             color = "white"
-        text = ax.text(
+        _ = ax.text(
             0,
             ii,
             f"{array[ii]:.2f}",
@@ -358,8 +358,6 @@ def main(args):
             .apply("_".join, axis=1)
         )
         df.sort_values("expt_id", inplace=True)
-        # df.pivot(index='repeat', columns='expt_id', values='min_vld_loss').T.plot(linestyle=None)
-        # plt.xticks(rotation=90)
         plt.figure()
         sns.pointplot(
             x="expt_id",

--- a/baselines/get_results.py
+++ b/baselines/get_results.py
@@ -1,102 +1,97 @@
 #!/usr/bin/env python
-from glob import glob
 import argparse
 import warnings
+from glob import glob
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 import seaborn as sns
 
-from baselines.eval_task import main as eval_main
 from baselines.eval_task import construct_parser as eval_construct_parser
+from baselines.eval_task import main as eval_main
 
 
 def plot_log_file(log_file, trn_kwargs=None, vld_kwargs=None):
     df = pd.read_csv(log_file)
-    trn_df = df.loc[df['mode'] == 'train']
-    min_trn_loss = trn_df['avg_loss'].min()
-    min_trn_acc = trn_df['avg_acc'].max()
-    vld_df = df.loc[df['mode'] == 'test']
-    min_vld_loss = vld_df['avg_loss'].min()
-    min_vld_acc = vld_df['avg_acc'].max()
+    trn_df = df.loc[df["mode"] == "train"]
+    min_trn_loss = trn_df["avg_loss"].min()
+    min_trn_acc = trn_df["avg_acc"].max()
+    vld_df = df.loc[df["mode"] == "test"]
+    min_vld_loss = vld_df["avg_loss"].min()
+    min_vld_acc = vld_df["avg_acc"].max()
     if trn_kwargs is None:
-        trn_kwargs = dict(
-            label=f'({min_trn_loss:.4f}, {min_trn_acc:.1f})')
-    elif 'label' in trn_kwargs:
-        trn_kwargs['label'] += f' ({min_trn_loss:.4f}, {min_trn_acc:.1f})'
+        trn_kwargs = dict(label=f"({min_trn_loss:.4f}, {min_trn_acc:.1f})")
+    elif "label" in trn_kwargs:
+        trn_kwargs["label"] += f" ({min_trn_loss:.4f}, {min_trn_acc:.1f})"
     if vld_kwargs is None:
-        vld_kwargs = dict(label=f'({min_vld_loss:.4f}, {min_vld_acc:.1f})')
-    elif 'label' in vld_kwargs:
-        vld_kwargs['label'] += f' ({min_vld_loss:.4f}, {min_vld_acc:.1f})'
-    plt.plot(trn_df['epoch'], trn_df['avg_loss'], **trn_kwargs)
-    plt.plot(vld_df['epoch'], vld_df['avg_loss'], **vld_kwargs)
+        vld_kwargs = dict(label=f"({min_vld_loss:.4f}, {min_vld_acc:.1f})")
+    elif "label" in vld_kwargs:
+        vld_kwargs["label"] += f" ({min_vld_loss:.4f}, {min_vld_acc:.1f})"
+    plt.plot(trn_df["epoch"], trn_df["avg_loss"], **trn_kwargs)
+    plt.plot(vld_df["epoch"], vld_df["avg_loss"], **vld_kwargs)
     plt.legend()
-    plt.xlabel('epoch')
-    plt.ylabel('average loss')
+    plt.xlabel("epoch")
+    plt.ylabel("average loss")
     return trn_df, vld_df, (min_trn_loss, min_trn_acc, min_vld_loss, min_vld_acc)
 
 
-def plot_task_losses(output_dir, task_name, settings,
-                     setting_names, save_plots=False, show_plots=True):
-    idx_cols = ['task_name', 'expt_name'] + setting_names + ['repeat']
-    val_cols = ['min_trn_loss',  'min_vld_loss',
-                'min_trn_acc', 'min_vld_acc']
+def plot_task_losses(
+    output_dir, task_name, settings, setting_names, save_plots=False, show_plots=True
+):
+    idx_cols = ["task_name", "expt_name"] + setting_names + ["repeat"]
+    val_cols = ["min_trn_loss", "min_vld_loss", "min_trn_acc", "min_vld_acc"]
     res = pd.DataFrame(columns=idx_cols + val_cols, dtype=float)
     res.set_index(idx_cols, drop=True, inplace=True)
-    
+
     summary_fig = plt.figure()
-    plt.title(f'{task_name} vld loss curves')
-    
-    alphas = [.3, .5, .7]
+    plt.title(f"{task_name} vld loss curves")
+
+    alphas = [0.3, 0.5, 0.7]
     for setting in settings:
         setting_fig = plt.figure()
         # TODO: this shouldn't be hardcoded 3
         for repeat in range(3):
             expt_name = f'{task_name}__{"_".join(setting)}_{repeat}'
-            log_file = f'{output_dir}/{task_name}/{expt_name}.log'
-            
+            log_file = f"{output_dir}/{task_name}/{expt_name}.log"
+
             plt.figure(setting_fig.number)
             try:
                 trn_df, vld_df, losses = plot_log_file(
                     log_file,
-                    trn_kwargs=dict(label=f'train {repeat}',
-                                    color='C0', alpha=alphas[repeat]),
-                    vld_kwargs=dict(label=f'valid {repeat}',
-                                    color='C1', alpha=alphas[repeat])
+                    trn_kwargs=dict(
+                        label=f"train {repeat}", color="C0", alpha=alphas[repeat]
+                    ),
+                    vld_kwargs=dict(
+                        label=f"valid {repeat}", color="C1", alpha=alphas[repeat]
+                    ),
                 )
             except pd.errors.EmptyDataError:
-                print(f'{expt_name}.log found but empty')
+                print(f"{expt_name}.log found but empty")
                 continue
             except FileNotFoundError:
-                print(f'{expt_name}.log not found')
+                print(f"{expt_name}.log not found")
                 continue
             min_trn_loss, min_trn_acc, min_vld_loss, min_vld_acc = losses
             idx = (task_name, expt_name) + setting + (str(repeat),)
-            res.loc[idx, :] = [min_trn_loss, min_vld_loss, 
-                               min_trn_acc, min_vld_acc]
-            
+            res.loc[idx, :] = [min_trn_loss, min_vld_loss, min_trn_acc, min_vld_acc]
+
             plt.figure(summary_fig.number)
-            plt.plot(vld_df['epoch'], vld_df['avg_loss'],
-                     color='C1', alpha=.2)
-            
-        plt.figure(setting_fig.number) 
+            plt.plot(vld_df["epoch"], vld_df["avg_loss"], color="C1", alpha=0.2)
+
+        plt.figure(setting_fig.number)
         if save_plots:
-            plt.savefig(f'{save_plots}/{task_name}__{"_".join(setting)}.png',
-                        dpi=300)
-            plt.savefig(f'{save_plots}/{task_name}__{"_".join(setting)}.pdf',
-                        dpi=300)
+            plt.savefig(f'{save_plots}/{task_name}__{"_".join(setting)}.png', dpi=300)
+            plt.savefig(f'{save_plots}/{task_name}__{"_".join(setting)}.pdf', dpi=300)
         plt.title(f'{task_name}__{"_".join(setting)}')
         if show_plots:
             plt.show()
         plt.close()
-        
+
     plt.figure(summary_fig.number)
     if save_plots:
-        plt.savefig(f'{save_plots}/{task_name}__all_loss_summary.png',
-                    dpi=300)
-        plt.savefig(f'{save_plots}/{task_name}__all_loss_summary.pdf',
-                    dpi=300)
+        plt.savefig(f"{save_plots}/{task_name}__all_loss_summary.png", dpi=300)
+        plt.savefig(f"{save_plots}/{task_name}__all_loss_summary.pdf", dpi=300)
     if show_plots:
         plt.show()
     plt.close()
@@ -104,9 +99,8 @@ def plot_task_losses(output_dir, task_name, settings,
 
 
 def get_settings(output_dir, task_name):
-    files = glob(f'{output_dir}/{task_name}/*')
-    settings = [tuple(ff.split('__')[-1].rsplit('_', 1)[0].split('_'))
-                for ff in files]
+    files = glob(f"{output_dir}/{task_name}/*")
+    settings = [tuple(ff.split("__")[-1].rsplit("_", 1)[0].split("_")) for ff in files]
     settings = set(settings)  # easy dedup
     settings = list(settings)
     settings.sort()
@@ -125,56 +119,68 @@ def round_to_n(x, n=3):
 def plot_confusion(confusion_mat, save_plots=False, ax=None):
     if ax is None:
         ax = plt.gca()
-    degs = ['none', 'pitch_shift', 'time_shift', 'onset_shift',
-            'offset_shift', 'remove_note', 'add_note', 'split_note',
-            'join_notes']
-    im = ax.imshow(confusion_mat, cmap='Oranges', interpolation='nearest')
+    degs = [
+        "none",
+        "pitch_shift",
+        "time_shift",
+        "onset_shift",
+        "offset_shift",
+        "remove_note",
+        "add_note",
+        "split_note",
+        "join_notes",
+    ]
+    im = ax.imshow(confusion_mat, cmap="Oranges", interpolation="nearest")
     # We want to show all ticks...
     ax.xaxis.tick_top()
     ax.set_xticks(np.arange(len(degs)))
     ax.set_yticks(np.arange(len(degs)))
     # ... and label them with the respective list entries
-    ax.set_xticklabels(degs, fontname='serif')
-    ax.set_yticklabels(degs, fontname='serif')
+    ax.set_xticklabels(degs, fontname="serif")
+    ax.set_yticklabels(degs, fontname="serif")
     # Rotate the tick labels and set their alignment.
-    plt.setp(ax.get_xticklabels(), rotation=45, ha="left",
-             rotation_mode="anchor")
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="left", rotation_mode="anchor")
     for i in range(len(degs)):
         array_range = np.max(confusion_mat) - np.min(confusion_mat)
         color_cutoff = np.min(confusion_mat) + array_range / 2
         for j in range(len(degs)):
             text = ax.text(
-                j, i, "%.2f" % confusion_mat[i, j],
-                ha="center", va="center", 
-                color="black" if confusion_mat[i,j] < color_cutoff else "white",
-                fontname='serif'
+                j,
+                i,
+                "%.2f" % confusion_mat[i, j],
+                ha="center",
+                va="center",
+                color="black" if confusion_mat[i, j] < color_cutoff else "white",
+                fontname="serif",
             )
     plt.ylim(8.5, -0.5)
     plt.tight_layout()
     if save_plots:
-        plt.savefig(f'{save_plots}.png',
-                    dpi=300)
-        plt.savefig(f'{save_plots}.pdf',
-                    dpi=300)
+        plt.savefig(f"{save_plots}.png", dpi=300)
+        plt.savefig(f"{save_plots}.pdf", dpi=300)
 
 
 def plot_1d_array_per_deg(array, save_plots=False, ax=None):
     if ax is None:
         ax = plt.gca()
-    degs = ['none', 'pitch_shift', 'time_shift', 'onset_shift',
-            'offset_shift', 'remove_note', 'add_note', 'split_note',
-            'join_notes']
-    im = ax.imshow(
-        array.reshape((-1, 1)),
-        cmap='Oranges',
-        interpolation='nearest',
-    )
-    
+    degs = [
+        "none",
+        "pitch_shift",
+        "time_shift",
+        "onset_shift",
+        "offset_shift",
+        "remove_note",
+        "add_note",
+        "split_note",
+        "join_notes",
+    ]
+    im = ax.imshow(array.reshape((-1, 1)), cmap="Oranges", interpolation="nearest",)
+
     # We want to show all ticks...
     ax.xaxis.tick_top()
     ax.set_yticks(np.arange(len(degs)))
     # ... and label them with the respective list entries
-    ax.set_yticklabels(degs, fontname='serif')
+    ax.set_yticklabels(degs, fontname="serif")
     for ii in range(len(degs)):
         array_range = np.max(array) - np.min(array)
         color_cutoff = np.min(array) + array_range / 2
@@ -183,175 +189,219 @@ def plot_1d_array_per_deg(array, save_plots=False, ax=None):
         else:
             color = "white"
         text = ax.text(
-            0, ii, f"{array[ii]:.2f}",
-            ha="center", va="center",
+            0,
+            ii,
+            f"{array[ii]:.2f}",
+            ha="center",
+            va="center",
             color=color,
-            fontname='serif'
+            fontname="serif",
         )
     plt.ylim(8.5, -0.5)
     plt.tight_layout()
     if save_plots:
-        plt.savefig(f'{save_plots}.png',
-                    dpi=300)
-        plt.savefig(f'{save_plots}.pdf',
-                    dpi=300)
+        plt.savefig(f"{save_plots}.png", dpi=300)
+        plt.savefig(f"{save_plots}.pdf", dpi=300)
 
 
 def construct_parser():
-    parser = argparse.ArgumentParser(description='Script for summarising '
-                                     'results of experiments run. Expects a '
-                                     'directory of output data, with '
-                                     'subdirectories for the name of the task.'
-                                     ' These subdirs contain the logs and '
-                                     'checkpoints for models fitted.')
-    
-    parser.add_argument("--output_dir", default='output',
-                        help='location of logs and model checkpoints')
-    parser.add_argument("--save_plots", default=None,
-                        help='location to save plots. By default will '
-                        'save to output_dir. If set to none no plots '
-                        'saved')
-    parser.add_argument("--in_dir", default='acme',
-                        help='location of the pianoroll and command '
-                        'corpus datasets')
-    parser.add_argument("--task_names", nargs='+', required=True,
-                        help='names of tasks to get results for. '
-                        'must correspond to names of dirs in output_dir')
-    parser.add_argument("--setting_names", nargs='+', required=True,
-                        help='A list (with no spaces) describing the names of '
-                        'variables the gridsearches were performed over '
-                        'for each task e.g. for --task_names task1 task4 '
-                        "--setting_names \"['lr','wd','hid']\" "
-                        "\"['lr','wd','hid','lay']\". You need to be careful "
-                        "to preserve quotes")
-    parser.add_argument("--formats", nargs='+', required=True,
-                        choices=['pianoroll', 'command'],
-                        help='data format type for each task e.g. '
-                        'for --task_names task1 task4 --formats command '
-                        'pianoroll')
-    parser.add_argument("--seq_len", nargs='+', required=True,
-                        help='seq_len for each task')
-    parser.add_argument("--metrics", nargs='+', required=True,
-                        help='metric for each task')
-    parser.add_argument("--task_desc", nargs='+', required=True,
-                        help='description (with no spaces) for each task to '
-                        'use as the identifier in the results table e.g. for '
-                        '--task_names task1 task4 --task_desc ErrorDetection '
-                        'ErrorCorrection')
-    parser.add_argument("--splits", nargs='+', required=True,
-                        default=['train', 'valid', 'test'],
-                        help="which splits to evaluate: train, valid, test.")
-    parser.add_argument("-s", "--show_plots", action='store_true',
-                        help='Whether to use plt.show() or not')
+    parser = argparse.ArgumentParser(
+        description="Script for summarising "
+        "results of experiments run. Expects a "
+        "directory of output data, with "
+        "subdirectories for the name of the task."
+        " These subdirs contain the logs and "
+        "checkpoints for models fitted."
+    )
+
+    parser.add_argument(
+        "--output_dir", default="output", help="location of logs and model checkpoints"
+    )
+    parser.add_argument(
+        "--save_plots",
+        default=None,
+        help="location to save plots. By default will "
+        "save to output_dir. If set to none no plots "
+        "saved",
+    )
+    parser.add_argument(
+        "--in_dir",
+        default="acme",
+        help="location of the pianoroll and command " "corpus datasets",
+    )
+    parser.add_argument(
+        "--task_names",
+        nargs="+",
+        required=True,
+        help="names of tasks to get results for. "
+        "must correspond to names of dirs in output_dir",
+    )
+    parser.add_argument(
+        "--setting_names",
+        nargs="+",
+        required=True,
+        help="A list (with no spaces) describing the names of "
+        "variables the gridsearches were performed over "
+        "for each task e.g. for --task_names task1 task4 "
+        "--setting_names \"['lr','wd','hid']\" "
+        "\"['lr','wd','hid','lay']\". You need to be careful "
+        "to preserve quotes",
+    )
+    parser.add_argument(
+        "--formats",
+        nargs="+",
+        required=True,
+        choices=["pianoroll", "command"],
+        help="data format type for each task e.g. "
+        "for --task_names task1 task4 --formats command "
+        "pianoroll",
+    )
+    parser.add_argument(
+        "--seq_len", nargs="+", required=True, help="seq_len for each task"
+    )
+    parser.add_argument(
+        "--metrics", nargs="+", required=True, help="metric for each task"
+    )
+    parser.add_argument(
+        "--task_desc",
+        nargs="+",
+        required=True,
+        help="description (with no spaces) for each task to "
+        "use as the identifier in the results table e.g. for "
+        "--task_names task1 task4 --task_desc ErrorDetection "
+        "ErrorCorrection",
+    )
+    parser.add_argument(
+        "--splits",
+        nargs="+",
+        required=True,
+        default=["train", "valid", "test"],
+        help="which splits to evaluate: train, valid, test.",
+    )
+    parser.add_argument(
+        "-s",
+        "--show_plots",
+        action="store_true",
+        help="Whether to use plt.show() or not",
+    )
     return parser
-    
-    
+
+
 def main(args):
     task_names = args.task_names
     nr_tasks = len(task_names)
     # TODO: change the way this is done! ATM can't think of
     # better way of handling sending a list of lists
     setting_names = [eval(ll) for ll in args.setting_names]
-    assert len(setting_names) == nr_tasks, ("You must submit a list of "
-              "parameters being searched for each task --setting_names . "
-              "Submit lists of parameter names with no spaces, e.g. "
-              "--task_names task1 task4 "
-              "--setting_names ['lr','wd','hid'] ['lr','wd','hid','lay'] ."
-              f"You submitted {nr_tasks} tasks: {task_names}, but "
-              f"{len(setting_names)} setting names: {setting_names}")
-    for varname in ['formats', 'seq_len', 'metrics', 'task_desc']:
+    assert len(setting_names) == nr_tasks, (
+        "You must submit a list of "
+        "parameters being searched for each task --setting_names . "
+        "Submit lists of parameter names with no spaces, e.g. "
+        "--task_names task1 task4 "
+        "--setting_names ['lr','wd','hid'] ['lr','wd','hid','lay'] ."
+        f"You submitted {nr_tasks} tasks: {task_names}, but "
+        f"{len(setting_names)} setting names: {setting_names}"
+    )
+    for varname in ["formats", "seq_len", "metrics", "task_desc"]:
         value = getattr(args, varname)
         vlen = len(value)
-        assert vlen == nr_tasks, (f"You submitted {vlen} {varname}, but need "
+        assert vlen == nr_tasks, (
+            f"You submitted {vlen} {varname}, but need "
             f"to supply {nr_tasks}. task_names: {task_names}, "
-            f"{varname}: {value}")
-    
+            f"{varname}: {value}"
+        )
+
     in_dir = args.in_dir
     output_dir = args.output_dir
     save_plots = args.save_plots
     if save_plots is None:
         save_plots = output_dir
-    elif save_plots.lower == 'none':
+    elif save_plots.lower == "none":
         save_plots = None
     formats = dict(zip(task_names, args.formats))
     seq_len = dict(zip(task_names, args.seq_len))
     metrics = dict(zip(task_names, args.metrics))
     task_desc = dict(zip(task_names, args.task_desc))
     splits = args.splits
-    
+
     results = {}
     mean_res = {}
     median_res = {}
     min_idx = {}
     median_min_idx = {}
-    
-    
+
     for task_name, setting_name in zip(task_names, setting_names):
         print(f'{task_name} plots {20*"="}')
         settings = get_settings(output_dir, task_name)
         results[task_name] = plot_task_losses(
-            output_dir, task_name, settings, setting_name,
-            save_plots=f'{save_plots}', show_plots=args.show_plots
+            output_dir,
+            task_name,
+            settings,
+            setting_name,
+            save_plots=f"{save_plots}",
+            show_plots=args.show_plots,
         )
-    
-    
+
     for task_name, setting_name in zip(task_names, setting_names):
         res = results[task_name]
         if len(res) == 0:
-            print(f'No results for {task_name}')
+            print(f"No results for {task_name}")
             continue
         mean_res[task_name] = res.mean(level=setting_name)
         median_res[task_name] = res.median(level=setting_name)
         min_idx[task_name] = res.min_vld_loss.idxmin()
         median_min_idx[task_name] = res.min_vld_loss.idxmin()
         df = results[task_name].reset_index()
-        df['expt_id'] = (
+        df["expt_id"] = (
             df[setting_name]
-                .apply(lambda x: x.astype(str), axis=1)
-                .apply('_'.join, axis=1)
+            .apply(lambda x: x.astype(str), axis=1)
+            .apply("_".join, axis=1)
         )
-        df.sort_values('expt_id', inplace=True)
+        df.sort_values("expt_id", inplace=True)
         # df.pivot(index='repeat', columns='expt_id', values='min_vld_loss').T.plot(linestyle=None)
         # plt.xticks(rotation=90)
         plt.figure()
-        sns.pointplot(x='expt_id', y='min_vld_loss', estimator=np.median,
-                      ci='sd', data=df, linewidth=0)
+        sns.pointplot(
+            x="expt_id",
+            y="min_vld_loss",
+            estimator=np.median,
+            ci="sd",
+            data=df,
+            linewidth=0,
+        )
         plt.xticks(rotation=90)
-        plt.title(f'Summary of {task_name} - median over repeats')
+        plt.title(f"Summary of {task_name} - median over repeats")
         if save_plots:
-            plt.savefig(f'{save_plots}/{task_name}__min_loss_summary.pdf',
-                        dpi=300)
-            plt.savefig(f'{save_plots}/{task_name}__min_loss_summary.png',
-                        dpi=300)
+            plt.savefig(f"{save_plots}/{task_name}__min_loss_summary.pdf", dpi=300)
+            plt.savefig(f"{save_plots}/{task_name}__min_loss_summary.png", dpi=300)
         if args.show_plots:
             plt.show()
-        plt.close('all')
-            
+        plt.close("all")
+
     #     sns.pointplot(x='expt_id', y='min_vld_loss', estimator=np.mean,
     #                   ci='sd', data=df, linewidth=0)
     #     plt.xticks(rotation=90)
     #     plt.title(f'Summary of {task_name} - mean over repeats')
     #     plt.show()
-    
-    
-    best_models = {task: f'{output_dir}/{task}/{val[1]}.checkpoint.best'
-               for task, val in min_idx.items()}
-    best_logs = {task: f'{output_dir}/{task}/{val[1]}.log'
-                 for task, val in min_idx.items()}
+
+    best_models = {
+        task: f"{output_dir}/{task}/{val[1]}.checkpoint.best"
+        for task, val in min_idx.items()
+    }
+    best_logs = {
+        task: f"{output_dir}/{task}/{val[1]}.log" for task, val in min_idx.items()
+    }
     print(f"best models: {best_models}")
     for task_name, log_file in best_logs.items():
         plot_log_file(log_file)
-        plt.title(f'{task_name} best model training curve')
+        plt.title(f"{task_name} best model training curve")
         if save_plots:
-            plt.savefig(f'{save_plots}/{task_name}__best_model_loss.png',
-                        dpi=300)
-            plt.savefig(f'{save_plots}/{task_name}__best_model_loss.pdf',
-                        dpi=300)
+            plt.savefig(f"{save_plots}/{task_name}__best_model_loss.png", dpi=300)
+            plt.savefig(f"{save_plots}/{task_name}__best_model_loss.pdf", dpi=300)
         if args.show_plots:
             plt.show()
-        plt.close('all')
-    
-    
+        plt.close("all")
+
     task_eval_log = {}
     for task_name in task_names:
         eval_parser = eval_construct_parser()
@@ -362,40 +412,39 @@ def main(args):
             f"--task {task_name[4]} "
             f"--seq_len {seq_len[task_name]} "
             f"--splits {' '.join(splits)}"
-    #         f"--splits test"
+            #         f"--splits test"
         )
         eval_args = eval_parser.parse_args(eval_args_str.split())
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             log_info = eval_main(eval_args)
         task_eval_log[task_name] = log_info
-    
-    dict_of_df = {k: pd.DataFrame(v).T for k,v in task_eval_log.items()}
-    res_df = pd.concat(dict_of_df).drop(['batch', 'epoch', 'mode'], axis=1)
-    res_df['avg_acc'] = res_df['avg_acc']/100  # I think this is better for tables
+
+    dict_of_df = {k: pd.DataFrame(v).T for k, v in task_eval_log.items()}
+    res_df = pd.concat(dict_of_df).drop(["batch", "epoch", "mode"], axis=1)
+    res_df["avg_acc"] = res_df["avg_acc"] / 100  # I think this is better for tables
     print(res_df)
-    
+
     confusion = {}
-    summary_tab = pd.DataFrame(columns=['Task', 'Model', 'Loss', 'Metric'])
+    summary_tab = pd.DataFrame(columns=["Task", "Model", "Loss", "Metric"])
     for ii, task_name in enumerate(task_names):
         print(task_name)
-        df = (
-            res_df.loc[task_name]
-                .dropna(axis=1)  # removes cols with na in them (not a metric for this task)
-        )
-        if 'confusion_mat' in df.columns:
-            confusion[task_name] = df['confusion_mat']
+        df = res_df.loc[task_name].dropna(
+            axis=1
+        )  # removes cols with na in them (not a metric for this task)
+        if "confusion_mat" in df.columns:
+            confusion[task_name] = df["confusion_mat"]
             for split in splits:
-                confusion_mat = df.loc[split, 'confusion_mat']
+                confusion_mat = df.loc[split, "confusion_mat"]
                 plt.figure(figsize=(5, 5))
                 plot_confusion(
                     confusion_mat,
-                    save_plots=f"{save_plots}/{task_name}__{split}_confusion"
+                    save_plots=f"{save_plots}/{task_name}__{split}_confusion",
                 )
                 if args.show_plots:
                     plt.show()
-                plt.close('all')
-            df.drop('confusion_mat', axis=1, inplace=True)
+                plt.close("all")
+            df.drop("confusion_mat", axis=1, inplace=True)
         for colname in ["p_per_deg", "r_per_deg", "f_per_deg", "avg_acc_per_deg"]:
             if colname in df.columns:
                 array = df[colname]
@@ -403,55 +452,58 @@ def main(args):
                     array = df.loc[split, colname]
                     plt.figure(figsize=(5, 5))
                     plot_1d_array_per_deg(
-                        array,
-                        save_plots=f"{save_plots}/{task_name}__{split}_{colname}"
+                        array, save_plots=f"{save_plots}/{task_name}__{split}_{colname}"
                     )
-                    plt.xticks(
-                        [0], [colname], rotation=45, fontname='serif', ha="left"
-                    )
+                    plt.xticks([0], [colname], rotation=45, fontname="serif", ha="left")
                     if args.show_plots:
                         plt.show()
-                    plt.close('all')
+                    plt.close("all")
                 df.drop(colname, axis=1, inplace=True)
-        df = (
-            df
-                .apply(pd.to_numeric)  # they are strings, convert to int or float
-                .applymap(round_to_n)  # round to 3sf
-        )
+        df = df.apply(
+            pd.to_numeric
+        ).applymap(  # they are strings, convert to int or float
+            round_to_n
+        )  # round to 3sf
         print(df)
-        df.to_latex(f'{output_dir}/{task_name}_table.tex')
-        summary_tab.loc[ii] = [task_desc[task_name], f'{task_name} baseline', 
-                               df.loc['test', 'avg_loss'],
-                               df.loc['test', metrics[task_name]]]
-    
+        df.to_latex(f"{output_dir}/{task_name}_table.tex")
+        summary_tab.loc[ii] = [
+            task_desc[task_name],
+            f"{task_name} baseline",
+            df.loc["test", "avg_loss"],
+            df.loc["test", metrics[task_name]],
+        ]
+
     # Hard coded dumb-baseline results
     rule_based = {
-        'task1': ['ErrorDetection', 'Rule-based', 0.466, 0.00],
-        'task2': ['ErrorClassification', 'Rule-based', 2.197, 0.113],
-        'task3': ['ErrorLocation', 'Rule-based', 0.404, 0.00],
-        'task4': ['ErrorCorrection', 'Rule-based', 0.690, 0.590],
+        "task1": ["ErrorDetection", "Rule-based", 0.466, 0.00],
+        "task2": ["ErrorClassification", "Rule-based", 2.197, 0.113],
+        "task3": ["ErrorLocation", "Rule-based", 0.404, 0.00],
+        "task4": ["ErrorCorrection", "Rule-based", 0.690, 0.590],
     }
     rule_based_df = pd.DataFrame.from_dict(
-        rule_based, orient='index', 
-        columns=['Task', 'Model', 'Loss', 'Metric']
+        rule_based, orient="index", columns=["Task", "Model", "Loss", "Metric"]
     )
-    
-    task_cat = ['ErrorDetection', 'ErrorClassification',
-                'ErrorLocation', 'ErrorCorrection']
+
+    task_cat = [
+        "ErrorDetection",
+        "ErrorClassification",
+        "ErrorLocation",
+        "ErrorCorrection",
+    ]
     summary_tab_ = pd.concat((summary_tab, rule_based_df))
-    summary_tab_['Task'] = pd.Categorical(summary_tab_['Task'], categories=task_cat,
-                                          ordered=True)
-    summary_tab_ = summary_tab_.set_index(['Task', 'Model']).sort_index()
-    summary_tab_.round(3).to_latex(f'{output_dir}/summary_table.tex')
+    summary_tab_["Task"] = pd.Categorical(
+        summary_tab_["Task"], categories=task_cat, ordered=True
+    )
+    summary_tab_ = summary_tab_.set_index(["Task", "Model"]).sort_index()
+    summary_tab_.round(3).to_latex(f"{output_dir}/summary_table.tex")
     print(summary_tab_.round(3))
     # summary_tab_.applymap(round_to_n).to_latex(f'{output_dir}/summary_table.tex')
     # summary_tab_.applymap(round_to_n)
-    
+
     return results, min_idx, task_eval_log, res_df, summary_tab_, confusion
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = construct_parser()
     args = parser.parse_args()
     main(args)

--- a/baselines/rule_based.py
+++ b/baselines/rule_based.py
@@ -1,36 +1,58 @@
 #!/usr/bin/env python
 
-import numpy as np
-import torch.nn
-import mdtk.pytorch_datasets
-from mdtk.formatters import FORMATTERS, create_corpus_csvs
 import argparse
 import os
+
+import numpy as np
+import torch.nn
+
+import mdtk.pytorch_datasets
+from mdtk.formatters import FORMATTERS, create_corpus_csvs
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("-i", "--input", default='acme', help='The '
-                        'base directory of the ACME dataset to use as input.')
-    parser.add_argument("-s", "--seq_len", type=int, default=250,
-                        help="maximum sequence length for a pianoroll.")
-    parser.add_argument("--reformat", action="store_true", help="Force the "
-                        "creation of the pianoroll csvs, even if they "
-                        "already exist.")
+    parser.add_argument(
+        "-i",
+        "--input",
+        default="acme",
+        help="The " "base directory of the ACME dataset to use as input.",
+    )
+    parser.add_argument(
+        "-s",
+        "--seq_len",
+        type=int,
+        default=250,
+        help="maximum sequence length for a pianoroll.",
+    )
+    parser.add_argument(
+        "--reformat",
+        action="store_true",
+        help="Force the "
+        "creation of the pianoroll csvs, even if they "
+        "already exist.",
+    )
 
     args = parser.parse_args()
     return args
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     args = parse_args()
 
-    prefix = FORMATTERS['pianoroll']["prefix"]
-    if (not all([os.path.exists(
-            os.path.join(args.input, f'{split}_{prefix}_corpus.csv')
-        ) for split in ['train', 'test']])) or args.reformat:
-        create_corpus_csvs(args.input, FORMATTERS['pianoroll'])
-    train_dataset = os.path.join(args.input, f'train_{prefix}_corpus.csv')
-    test_dataset = os.path.join(args.input, f'test_{prefix}_corpus.csv')
+    prefix = FORMATTERS["pianoroll"]["prefix"]
+    if (
+        not all(
+            [
+                os.path.exists(os.path.join(args.input, f"{split}_{prefix}_corpus.csv"))
+                for split in ["train", "test"]
+            ]
+        )
+    ) or args.reformat:
+        create_corpus_csvs(args.input, FORMATTERS["pianoroll"])
+    train_dataset = os.path.join(args.input, f"train_{prefix}_corpus.csv")
+    test_dataset = os.path.join(args.input, f"test_{prefix}_corpus.csv")
 
     # Calculate outputs
     seq_len = args.seq_len
@@ -39,17 +61,17 @@ if __name__ == '__main__':
     frame_counts = np.zeros(2)
     pr_outputs = np.zeros((2, 2))
     for data in dataset:
-        deg_counts[data['deg_label']] += 1
-        sum_frames = np.sum(data['changed_frames'])
+        deg_counts[data["deg_label"]] += 1
+        sum_frames = np.sum(data["changed_frames"])
         frame_counts[0] += seq_len - sum_frames
         frame_counts[1] += sum_frames
-        deg_pr = data['deg_pr']
-        clean_pr = data['clean_pr']
+        deg_pr = data["deg_pr"]
+        clean_pr = data["clean_pr"]
         num_pitches = np.shape(clean_pr)[1]
         for deg in [0, 1]:
             for clean in [0, 1]:
-                pr_outputs[clean, deg] += (
-                    np.sum(np.where(np.logical_and(deg_pr == deg, clean_pr == clean), 1, 0))
+                pr_outputs[clean, deg] += np.sum(
+                    np.where(np.logical_and(deg_pr == deg, clean_pr == clean), 1, 0)
                 )
     deg_counts /= np.sum(deg_counts)
     frame_counts /= np.sum(frame_counts)
@@ -64,11 +86,11 @@ if __name__ == '__main__':
     clean_prs = np.zeros((seq_len, num_pitches * len(dataset)))
     deg_prs = np.zeros((seq_len, num_pitches * len(dataset)))
     for i, data in enumerate(dataset):
-        labels.append(data['deg_label'])
-        binary_labels.append(0 if data['deg_label'] == 0 else 1)
-        frame_labels.extend(data['changed_frames'])
-        deg_prs[:, i * num_pitches : (i + 1) * num_pitches] = data['deg_pr']
-        clean_prs[:, i * num_pitches : (i + 1) * num_pitches] = data['clean_pr']
+        labels.append(data["deg_label"])
+        binary_labels.append(0 if data["deg_label"] == 0 else 1)
+        frame_labels.extend(data["changed_frames"])
+        deg_prs[:, i * num_pitches : (i + 1) * num_pitches] = data["deg_pr"]
+        clean_prs[:, i * num_pitches : (i + 1) * num_pitches] = data["clean_pr"]
     labels = np.array(labels)
     binary_labels = np.array(binary_labels)
     frame_labels = np.array(frame_labels)
@@ -78,33 +100,37 @@ if __name__ == '__main__':
     outputs[:] = [deg_counts[0], np.sum(deg_counts[1:])]
 
     loss = torch.nn.CrossEntropyLoss()
-    task1 = loss(torch.from_numpy(outputs).float(), torch.from_numpy(binary_labels).long())
-    print(f'Task 1 loss = {task1}')
+    task1 = loss(
+        torch.from_numpy(outputs).float(), torch.from_numpy(binary_labels).long()
+    )
+    print(f"Task 1 loss = {task1}")
     if deg_counts[0] < 0.5:
-        print(f'Task 1 rev F-measure = 0.0')
+        print(f"Task 1 rev F-measure = 0.0")
     else:
         precision = np.sum(1 - binary_labels) / len(binary_labels)
-        print(f'Task 1 rev F-measure = {(1 + precision) / (2 * precision)}')
+        print(f"Task 1 rev F-measure = {(1 + precision) / (2 * precision)}")
 
     # Task 2
     outputs = np.zeros((len(labels), 9))
     outputs[:] = deg_counts
 
     task2 = loss(torch.from_numpy(outputs).float(), torch.from_numpy(labels).long())
-    print(f'Task 2 loss = {task2}')
-    print(f'Task 2 acc = {np.mean(1 - binary_labels)}')
+    print(f"Task 2 loss = {task2}")
+    print(f"Task 2 acc = {np.mean(1 - binary_labels)}")
 
     # Task 3
     outputs = np.zeros((len(frame_labels), 2))
     outputs[:] = frame_counts
 
-    task3 = loss(torch.from_numpy(outputs).float(), torch.from_numpy(frame_labels).long())
-    print(f'Task 3 loss = {task3}')
+    task3 = loss(
+        torch.from_numpy(outputs).float(), torch.from_numpy(frame_labels).long()
+    )
+    print(f"Task 3 loss = {task3}")
     if frame_counts[0] > 0.5:
-        print(f'Task 3 F-measure = 0.0')
+        print(f"Task 3 F-measure = 0.0")
     else:
         precision = np.sum(frame_labels) / len(frame_labels)
-        print(f'Task 3 F-measure = {(1 + precision) / (2 * precision)}')
+        print(f"Task 3 F-measure = {(1 + precision) / (2 * precision)}")
 
     # Task 4
     outputs = np.zeros(np.shape(clean_prs))
@@ -113,6 +139,8 @@ if __name__ == '__main__':
 
     loss = torch.nn.BCEWithLogitsLoss()
     task4 = loss(torch.from_numpy(outputs).float(), torch.from_numpy(clean_prs).float())
-    helpfulness = (0.5 * np.sum(binary_labels) + np.sum(1 - binary_labels)) / len(binary_labels)
-    print(f'Task 4 loss = {task4}')
-    print(f'Task 4 Helpfulness = {helpfulness}')
+    helpfulness = (0.5 * np.sum(binary_labels) + np.sum(1 - binary_labels)) / len(
+        binary_labels
+    )
+    print(f"Task 4 loss = {task4}")
+    print(f"Task 4 Helpfulness = {helpfulness}")

--- a/baselines/rule_based.py
+++ b/baselines/rule_based.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     )
     print(f"Task 1 loss = {task1}")
     if deg_counts[0] < 0.5:
-        print(f"Task 1 rev F-measure = 0.0")
+        print("Task 1 rev F-measure = 0.0")
     else:
         precision = np.sum(1 - binary_labels) / len(binary_labels)
         print(f"Task 1 rev F-measure = {(1 + precision) / (2 * precision)}")
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     )
     print(f"Task 3 loss = {task3}")
     if frame_counts[0] > 0.5:
-        print(f"Task 3 F-measure = 0.0")
+        print("Task 3 F-measure = 0.0")
     else:
         precision = np.sum(frame_labels) / len(frame_labels)
         print(f"Task 3 F-measure = {(1 + precision) / (2 * precision)}")

--- a/baselines/train_task.py
+++ b/baselines/train_task.py
@@ -2,28 +2,29 @@
 import argparse
 import os
 import sys
-import pandas as pd
-import numpy as np
 import warnings
 
+import numpy as np
+import pandas as pd
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
 import mdtk.pytorch_models
 import mdtk.pytorch_trainers
+from mdtk.degradations import MAX_PITCH_DEFAULT, MIN_PITCH_DEFAULT
+from mdtk.formatters import FORMATTERS, CommandVocab, create_corpus_csvs
 from mdtk.pytorch_datasets import transform_to_torchtensor
-from mdtk.formatters import CommandVocab, FORMATTERS, create_corpus_csvs
-from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
 
 
-def print_warn_msg_only(message, category, filename, lineno, file=None,
-                        line=None):
+def print_warn_msg_only(message, category, filename, lineno, file=None, line=None):
     print(message, file=sys.stderr)
+
 
 warnings.showwarning = print_warn_msg_only
 # TODO: This should ideally be 'once', but it doesn't work for some reason
-warnings.filterwarnings('ignore', message='.* exceeds given seq_len')
+warnings.filterwarnings("ignore", message=".* exceeds given seq_len")
+
 
 def get_inverse_weights(dataset, task, formatter, transform=torch.tensor):
     """
@@ -54,7 +55,7 @@ def get_inverse_weights(dataset, task, formatter, transform=torch.tensor):
         can change.
     """
     print("Calculating label weights")
-    key = formatter['task_labels'][task-1]
+    key = formatter["task_labels"][task - 1]
     if key is None:
         # This error will be caught later
         return np.zeros(0) if transform is None else transform(np.zeros(0))
@@ -71,7 +72,6 @@ def get_inverse_weights(dataset, task, formatter, transform=torch.tensor):
         counts[num] = np.sum(labels == num)
     weights = np.sum(counts) / counts
     return weights if transform is None else transform(weights)
-    
 
 
 # TODO: get formatter out of Trainer
@@ -80,222 +80,313 @@ def parse_args():
     parser = argparse.ArgumentParser()
 
     # Filepath stuff
-    parser.add_argument("-i", "--input", default='acme', help='The '
-                        'base directory of the ACME dataset to use as input.')
-    parser.add_argument("-o", "--output", required=False, type=str,
-                        help="Directory and prefix to which to save model outputs. "
-                        "e.g.: output/model.checkpoint",
-                        default=os.path.join('.', 'model.checkpoint'))
+    parser.add_argument(
+        "-i",
+        "--input",
+        default="acme",
+        help="The " "base directory of the ACME dataset to use as input.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        required=False,
+        type=str,
+        help="Directory and prefix to which to save model outputs. "
+        "e.g.: output/model.checkpoint",
+        default=os.path.join(".", "model.checkpoint"),
+    )
 
     # Basic task setup args
-    parser.add_argument("--format", required=False, choices=FORMATTERS.keys(),
-                        help='The format to use as input to the model. If the '
-                        'format-specific csvs have not yet been created, this '
-                        'will create them. Choices are '
-                        f'{list(FORMATTERS.keys())}. Required if --baseline '
-                        'is not given.')
-    parser.add_argument("--reformat", action="store_true", help="Force the "
-                        "creation of the desired --format csvs, even if they "
-                        "already exist.")
+    parser.add_argument(
+        "--format",
+        required=False,
+        choices=FORMATTERS.keys(),
+        help="The format to use as input to the model. If the "
+        "format-specific csvs have not yet been created, this "
+        "will create them. Choices are "
+        f"{list(FORMATTERS.keys())}. Required if --baseline "
+        "is not given.",
+    )
+    parser.add_argument(
+        "--reformat",
+        action="store_true",
+        help="Force the "
+        "creation of the desired --format csvs, even if they "
+        "already exist.",
+    )
 
-    parser.add_argument("--task", required=True, choices=range(1, 5), help='The '
-                        'task number to train a model for.', type=int)
+    parser.add_argument(
+        "--task",
+        required=True,
+        choices=range(1, 5),
+        help="The " "task number to train a model for.",
+        type=int,
+    )
 
-    parser.add_argument("--baseline", action='store_true', help='Ignore all '
-                        'arguments (besides --input and --output) and run the '
-                        'baseline model for the given --task.')
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help="Ignore all "
+        "arguments (besides --input and --output) and run the "
+        "baseline model for the given --task.",
+    )
 
     # Network structure args
-    parser.add_argument("-hs", "--hidden", type=int, default=100,
-                        help="Hidden size of the model LSTM layers of the model.")
-    parser.add_argument("-d", "--dropout", type=float, default=0.1,
-                        help="Dropout to use.")
-    parser.add_argument("-s", "--seq_len", type=int, default=250,
-                        help="maximum sequence length.")
-    parser.add_argument("--embedding", type=int, default=128,
-                        help="Size of embedding vector. (--format command only)")
-    parser.add_argument("--layers", type=int, default=[], nargs='*',
-                        help='Size of linear (post-LSTM) layers. '
-                        '(--format pianoroll only)')
+    parser.add_argument(
+        "-hs",
+        "--hidden",
+        type=int,
+        default=100,
+        help="Hidden size of the model LSTM layers of the model.",
+    )
+    parser.add_argument(
+        "-d", "--dropout", type=float, default=0.1, help="Dropout to use."
+    )
+    parser.add_argument(
+        "-s", "--seq_len", type=int, default=250, help="maximum sequence length."
+    )
+    parser.add_argument(
+        "--embedding",
+        type=int,
+        default=128,
+        help="Size of embedding vector. (--format command only)",
+    )
+    parser.add_argument(
+        "--layers",
+        type=int,
+        default=[],
+        nargs="*",
+        help="Size of linear (post-LSTM) layers. " "(--format pianoroll only)",
+    )
 
     # Training/DataLoading args
-    parser.add_argument("-b", "--batch_size", type=int, default=64,
-                        help="number of batch_size")
-    parser.add_argument("-e", "--epochs", type=int, default=1000,
-                        help="number of epochs")
-    parser.add_argument("-w", "--num_workers", type=int, default=4,
-                        help="dataloader worker size")
-    parser.add_argument("--with_cpu", action='store_true', default=False,
-                        help="Train with CPU, default is to try and use CUDA. "
-                        "A warning will be thrown if CUDA is not available, "
-                        "and CPU used in that case.")
-    parser.add_argument("--cuda_devices", type=int, nargs='+',
-                        default=None, help="CUDA device ids")
-    parser.add_argument("--batch_log_freq", default='10',
-                        help="printing loss every n batches: setting to None "
-                        "means no logging.")
-    parser.add_argument("--epoch_log_freq", default='1',
-                        help="printing loss every n epochs: setting to None "
-                        "means no logging.")
-    parser.add_argument("--in_memory", type=bool, default=True,
-                        help="Loading on memory: true or false")
-    parser.add_argument("--early_stopping", type=int, default=50,
-                        help="Will stop training after this number of epochs "
-                        "with no improvement to the validation loss")
-    parser.add_argument("--log_file", type=str, default=None,
-                        help="Path to file for logging losses.")
-    parser.add_argument("--weight", action="store_true", help="Weight the "
-                        "target classes inverse to their frequency, to help with"
-                        " the skewed distribution.")
+    parser.add_argument(
+        "-b", "--batch_size", type=int, default=64, help="number of batch_size"
+    )
+    parser.add_argument(
+        "-e", "--epochs", type=int, default=1000, help="number of epochs"
+    )
+    parser.add_argument(
+        "-w", "--num_workers", type=int, default=4, help="dataloader worker size"
+    )
+    parser.add_argument(
+        "--with_cpu",
+        action="store_true",
+        default=False,
+        help="Train with CPU, default is to try and use CUDA. "
+        "A warning will be thrown if CUDA is not available, "
+        "and CPU used in that case.",
+    )
+    parser.add_argument(
+        "--cuda_devices", type=int, nargs="+", default=None, help="CUDA device ids"
+    )
+    parser.add_argument(
+        "--batch_log_freq",
+        default="10",
+        help="printing loss every n batches: setting to None " "means no logging.",
+    )
+    parser.add_argument(
+        "--epoch_log_freq",
+        default="1",
+        help="printing loss every n epochs: setting to None " "means no logging.",
+    )
+    parser.add_argument(
+        "--in_memory", type=bool, default=True, help="Loading on memory: true or false"
+    )
+    parser.add_argument(
+        "--early_stopping",
+        type=int,
+        default=50,
+        help="Will stop training after this number of epochs "
+        "with no improvement to the validation loss",
+    )
+    parser.add_argument(
+        "--log_file", type=str, default=None, help="Path to file for logging losses."
+    )
+    parser.add_argument(
+        "--weight",
+        action="store_true",
+        help="Weight the "
+        "target classes inverse to their frequency, to help with"
+        " the skewed distribution.",
+    )
 
     # Optimizer args
-    parser.add_argument("--lr", type=float, default=1e-4,
-                        help="learning rate of adam")
-    parser.add_argument("--weight_decay", type=float, default=0.01,
-                        help="weight_decay of adam")
-    parser.add_argument("--b1", "--adam_beta1", type=float, default=0.9,
-                        help="adam first beta value")
-    parser.add_argument("--b2", "--adam_beta2", type=float, default=0.999,
-                        help="adam first beta value")
+    parser.add_argument("--lr", type=float, default=1e-4, help="learning rate of adam")
+    parser.add_argument(
+        "--weight_decay", type=float, default=0.01, help="weight_decay of adam"
+    )
+    parser.add_argument(
+        "--b1", "--adam_beta1", type=float, default=0.9, help="adam first beta value"
+    )
+    parser.add_argument(
+        "--b2", "--adam_beta2", type=float, default=0.999, help="adam first beta value"
+    )
 
     # Piano-roll specific size args
-    parser.add_argument("--pr-min-pitch", type=int, default=MIN_PITCH_DEFAULT,
-                        help="Minimum pianoroll pitch")
-    parser.add_argument("--pr-max-pitch", type=int, default=MAX_PITCH_DEFAULT,
-                        help="Maximum pianoroll pitch")
+    parser.add_argument(
+        "--pr-min-pitch",
+        type=int,
+        default=MIN_PITCH_DEFAULT,
+        help="Minimum pianoroll pitch",
+    )
+    parser.add_argument(
+        "--pr-max-pitch",
+        type=int,
+        default=MAX_PITCH_DEFAULT,
+        help="Maximum pianoroll pitch",
+    )
 
     args = parser.parse_args()
     return args
 
 
-
 task_names = [
-    'ErrorDetection',
-    'ErrorClassification',
-    'ErrorLocation',
-    'ErrorCorrection'
+    "ErrorDetection",
+    "ErrorClassification",
+    "ErrorLocation",
+    "ErrorCorrection",
 ]
 
 task_trainers = [
-    getattr(mdtk.pytorch_trainers, f'{task_name}Trainer')
-    for task_name in task_names
+    getattr(mdtk.pytorch_trainers, f"{task_name}Trainer") for task_name in task_names
 ]
 
 task_criteria = [
     nn.CrossEntropyLoss(),
     nn.CrossEntropyLoss(),
     nn.CrossEntropyLoss(),
-    nn.BCEWithLogitsLoss(reduction='mean')
+    nn.BCEWithLogitsLoss(reduction="mean"),
 ]
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parse_args()
-    
+
     if args.baseline:
         # Setup args for the baseline for args.task
         raise NotImplementedError(f"Baseline not created for task {args.task} yet.")
     else:
-        assert args.format is not None, (
-            '--format is a required argument if --baseline is not given.'
-        )
-        
-    
+        assert (
+            args.format is not None
+        ), "--format is a required argument if --baseline is not given."
+
     if os.path.split(args.output)[0]:
         os.makedirs(os.path.dirname(args.output), exist_ok=True)
 
     # Generate (if needed) and load formatted csv
     prefix = FORMATTERS[args.format]["prefix"]
-    if (not all([os.path.exists(
-            os.path.join(args.input, f'{split}_{prefix}_corpus.csv')
-        ) for split in ['train', 'valid', 'test']])) or args.reformat:
+    if (
+        not all(
+            [
+                os.path.exists(os.path.join(args.input, f"{split}_{prefix}_corpus.csv"))
+                for split in ["train", "valid", "test"]
+            ]
+        )
+    ) or args.reformat:
         create_corpus_csvs(args.input, FORMATTERS[args.format])
-    train_dataset = os.path.join(args.input, f'train_{prefix}_corpus.csv')
-    valid_dataset = os.path.join(args.input, f'valid_{prefix}_corpus.csv')
-    test_dataset = os.path.join(args.input, f'test_{prefix}_corpus.csv')
-    
+    train_dataset = os.path.join(args.input, f"train_{prefix}_corpus.csv")
+    valid_dataset = os.path.join(args.input, f"valid_{prefix}_corpus.csv")
+    test_dataset = os.path.join(args.input, f"test_{prefix}_corpus.csv")
+
     task_idx = args.task - 1
     task_name = task_names[task_idx]
-    model_name = FORMATTERS[args.format]['models'][task_idx]
+    model_name = FORMATTERS[args.format]["models"][task_idx]
     if model_name is None:
-        raise NotImplementedError(f"No model implemented for task {task_name} "
-                                  f"with format {args.format}")
+        raise NotImplementedError(
+            f"No model implemented for task {task_name} " f"with format {args.format}"
+        )
     Model = getattr(mdtk.pytorch_models, model_name)
-    Dataset = getattr(mdtk.pytorch_datasets, FORMATTERS[args.format]['dataset'])
+    Dataset = getattr(mdtk.pytorch_datasets, FORMATTERS[args.format]["dataset"])
     Trainer = task_trainers[task_idx]
     Criterion = task_criteria[task_idx]
-    
-    deg_ids_df = pd.read_csv(os.path.join(args.input, 'degradation_ids.csv'))
-    if args.format == 'command':
+
+    deg_ids_df = pd.read_csv(os.path.join(args.input, "degradation_ids.csv"))
+    if args.format == "command":
         vocab = CommandVocab()
         vocab_size = len(vocab)
         dataset_args = [vocab, args.seq_len]
-        dataset_kwargs = {
-        }
+        dataset_kwargs = {}
         model_args = []
         model_kwargs = {
-            'vocab_size': vocab_size,
-            'embedding_dim': args.embedding,
-            'hidden_dim': args.hidden,
-            'output_size': 2 if args.task == 1 else len(deg_ids_df),
-            'dropout_prob': args.dropout
+            "vocab_size": vocab_size,
+            "embedding_dim": args.embedding,
+            "hidden_dim": args.hidden,
+            "output_size": 2 if args.task == 1 else len(deg_ids_df),
+            "dropout_prob": args.dropout,
         }
-    elif args.format == 'pianoroll':
+    elif args.format == "pianoroll":
         dataset_args = [args.seq_len]
         dataset_kwargs = {
-            'min_pitch': args.pr_min_pitch,
-            'max_pitch': args.pr_max_pitch
+            "min_pitch": args.pr_min_pitch,
+            "max_pitch": args.pr_max_pitch,
         }
         model_args = []
         model_kwargs = {
-            'input_dim': 2 * (args.pr_max_pitch - args.pr_min_pitch + 1),
-            'hidden_dim': args.hidden,
-            'output_dim': 2 if args.task in [1, 3] else len(deg_ids_df),
-            'layers': args.layers,
-            'dropout_prob': args.dropout
+            "input_dim": 2 * (args.pr_max_pitch - args.pr_min_pitch + 1),
+            "hidden_dim": args.hidden,
+            "output_dim": 2 if args.task in [1, 3] else len(deg_ids_df),
+            "layers": args.layers,
+            "dropout_prob": args.dropout,
         }
         if args.task == 4:
-            model_kwargs['output_dim'] = model_kwargs['input_dim']
-        
+            model_kwargs["output_dim"] = model_kwargs["input_dim"]
 
     print(f"Loading train {Dataset.__name__} from {train_dataset}")
-    train_dataset = Dataset(train_dataset, *dataset_args, **dataset_kwargs,
-                            in_memory=args.in_memory,
-                            transform=transform_to_torchtensor)
+    train_dataset = Dataset(
+        train_dataset,
+        *dataset_args,
+        **dataset_kwargs,
+        in_memory=args.in_memory,
+        transform=transform_to_torchtensor,
+    )
 
     print(f"Loading validation {Dataset.__name__} from {valid_dataset}")
-    valid_dataset = Dataset(valid_dataset, *dataset_args, **dataset_kwargs,
-                            in_memory=args.in_memory,
-                            transform=transform_to_torchtensor)
+    valid_dataset = Dataset(
+        valid_dataset,
+        *dataset_args,
+        **dataset_kwargs,
+        in_memory=args.in_memory,
+        transform=transform_to_torchtensor,
+    )
 
     print(f"Loading test {Dataset.__name__} from {test_dataset}")
-    test_dataset = Dataset(test_dataset, *dataset_args, **dataset_kwargs,
-                           in_memory=args.in_memory,
-                           transform=transform_to_torchtensor)
+    test_dataset = Dataset(
+        test_dataset,
+        *dataset_args,
+        **dataset_kwargs,
+        in_memory=args.in_memory,
+        transform=transform_to_torchtensor,
+    )
 
     print(f"Creating train, valid, and test DataLoaders")
-    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size,
-                                  num_workers=args.num_workers, shuffle=True)
-    valid_dataloader = DataLoader(valid_dataset, batch_size=args.batch_size,
-                                  num_workers=args.num_workers)
-    test_dataloader = DataLoader(test_dataset, batch_size=args.batch_size,
-                                 num_workers=args.num_workers)
-    
+    train_dataloader = DataLoader(
+        train_dataset,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        shuffle=True,
+    )
+    valid_dataloader = DataLoader(
+        valid_dataset, batch_size=args.batch_size, num_workers=args.num_workers
+    )
+    test_dataloader = DataLoader(
+        test_dataset, batch_size=args.batch_size, num_workers=args.num_workers
+    )
+
     print(f"Building {Model.__name__}")
     model = Model(*model_args, **model_kwargs)
-    
+
     print(f"Using {Criterion.__str__()} as loss function")
-    
-    if args.batch_log_freq.lower() == 'none':
+
+    if args.batch_log_freq.lower() == "none":
         batch_log_freq = None
     else:
         batch_log_freq = int(args.batch_log_freq)
-    if args.epoch_log_freq.lower() == 'none':
+    if args.epoch_log_freq.lower() == "none":
         epoch_log_freq = None
     else:
         epoch_log_freq = int(args.epoch_log_freq)
-        
+
     print("Creating Trainer")
     # TODO: perhaps add a valid_dataloader option and make only function
     #       of test dataloader to be printing the final test loss post
@@ -307,27 +398,26 @@ if __name__ == '__main__':
         print("Attempting to train on GPU")
     else:
         print("Attempting to train on CPU")
-    
+
     if args.log_file is not None:
-        print(f'Writing logs to {args.log_file}')
+        print(f"Writing logs to {args.log_file}")
         if os.path.exists(args.log_file):
-            print(f'Warning: {args.log_file} already exists, overwriting.')
-        log_fh = open(args.log_file, 'w')
+            print(f"Warning: {args.log_file} already exists, overwriting.")
+        log_fh = open(args.log_file, "w")
     else:
-        print('Logging to stdout')
+        print("Logging to stdout")
         log_fh = sys.stdout
-        
+
     if args.weight and args.task in [1, 2, 3]:
-        weights = get_inverse_weights(train_dataset, args.task,
-                                      FORMATTERS[args.format])
+        weights = get_inverse_weights(train_dataset, args.task, FORMATTERS[args.format])
         if with_cuda:
             try:
-                weights = weights.to('cuda')
-            except: # Cuda not available. Leave on cpu.
+                weights = weights.to("cuda")
+            except:  # Cuda not available. Leave on cpu.
                 pass
         weights = weights.float()
         Criterion = nn.CrossEntropyLoss(weight=weights)
-    
+
     trainer = Trainer(
         model=model,
         criterion=Criterion,
@@ -340,30 +430,34 @@ if __name__ == '__main__':
         batch_log_freq=batch_log_freq,
         epoch_log_freq=epoch_log_freq,
         formatter=FORMATTERS[args.format],
-        log_file=log_fh
+        log_file=log_fh,
     )
-    
+
     # Add a header to the log file
-    print(','.join(trainer.log_cols), file=log_fh)
-    
+    print(",".join(trainer.log_cols), file=log_fh)
+
     print("Training Start")
     print(f"Running {args.epochs} epochs")
-    print(f"Will stop training if no improvement in validation loss for "
-          f"{args.early_stopping} epochs.")
+    print(
+        f"Will stop training if no improvement in validation loss for "
+        f"{args.early_stopping} epochs."
+    )
     # TODO: implement a catch for ctrl+c in Trainers which saves current mdl
     best_vld_loss = np.inf
     best_vld_epoch = 0
     for epoch in range(args.epochs):
         trn_log_info = trainer.train(epoch)
         vld_log_info = trainer.test(epoch)
-        if vld_log_info['avg_loss'] < best_vld_loss:
-            best_vld_loss = vld_log_info['avg_loss']
+        if vld_log_info["avg_loss"] < best_vld_loss:
+            best_vld_loss = vld_log_info["avg_loss"]
             best_vld_epoch = epoch
-            trainer.save(f'{args.output}.best')
+            trainer.save(f"{args.output}.best")
         if epoch - best_vld_epoch >= args.early_stopping:
             print("EARLY STOPPING")
-            print(f"No improvement in validation loss for "
-                  f"{args.early_stopping} epochs.")
+            print(
+                f"No improvement in validation loss for "
+                f"{args.early_stopping} epochs."
+            )
             break
     print(f"Best epoch was {best_vld_epoch} with a loss of {best_vld_loss}.")
     print(f"Best model saved at '{args.output}.best'.")

--- a/baselines/train_task.py
+++ b/baselines/train_task.py
@@ -35,13 +35,13 @@ def get_inverse_weights(dataset, task, formatter, transform=torch.tensor):
     ----------
     dataset : torch.Dataset
         The dataset from which we want to set weights.
-        
+
     task : int
         The task number whose weights to return.
-        
+
     formatter : dict
         A formatter dict, from formatters.py.
-        
+
     transform : func
         A function to call on the returned object. If None, the returned
         weights list is a numpy array.
@@ -359,7 +359,7 @@ if __name__ == "__main__":
         transform=transform_to_torchtensor,
     )
 
-    print(f"Creating train, valid, and test DataLoaders")
+    print("Creating train, valid, and test DataLoaders")
     train_dataloader = DataLoader(
         train_dataset,
         batch_size=args.batch_size,
@@ -413,7 +413,7 @@ if __name__ == "__main__":
         if with_cuda:
             try:
                 weights = weights.to("cuda")
-            except:  # Cuda not available. Leave on cpu.
+            except Exception:  # Cuda not available. Leave on cpu.
                 pass
         weights = weights.float()
         Criterion = nn.CrossEntropyLoss(weight=weights)

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -1,31 +1,32 @@
 #!/usr/bin/env python
 """Script to generate Altered and Corrupted Midi Excerpt (ACME) datasets"""
-import os
-import sys
-import json
 import argparse
-import warnings
-import pandas as pd
+import json
+import os
 import shutil
+import sys
+import warnings
 from glob import glob
 from zipfile import BadZipfile
 
 import numpy as np
+import pandas as pd
 from tqdm import tqdm
 
 from mdtk import degradations, downloaders, fileio
 from mdtk.df_utils import get_random_excerpt
 from mdtk.filesystem_utils import make_directory
-from mdtk.formatters import create_corpus_csvs, FORMATTERS
+from mdtk.formatters import FORMATTERS, create_corpus_csvs
 
-def print_warn_msg_only(message, category, filename, lineno, file=None,
-                        line=None):
+
+def print_warn_msg_only(message, category, filename, lineno, file=None, line=None):
     print(message, file=sys.stderr)
+
 
 warnings.showwarning = print_warn_msg_only
 
 
-with open(os.path.join('img', 'logo.txt'), 'r') as ff:
+with open(os.path.join("img", "logo.txt"), "r") as ff:
     LOGO = ff.read()
 
 
@@ -66,10 +67,11 @@ def parse_degradation_kwargs(kwarg_dict):
         return func_kwargs
     for kk, kwarg_value in kwarg_dict.items():
         try:
-            func_name, kwarg_name = kk.split('__', 1)
+            func_name, kwarg_name = kk.split("__", 1)
         except ValueError:
-            raise ValueError(f"Supplied keyword [{kk}] must have a double "
-                             "underscore")
+            raise ValueError(
+                f"Supplied keyword [{kk}] must have a double " "underscore"
+            )
         assert func_name in func_names, f"{func_name} not in {func_names}"
         func_kwargs[func_name][kwarg_name] = kwarg_value
     return func_kwargs
@@ -101,7 +103,7 @@ def clean_download_cache(dir_path=downloaders.DEFAULT_CACHE_PATH, prompt=True):
     if prompt:
         response = input(f"Delete download cache ({dir_path})? [y/N]: ")
 
-    if (not prompt) or response in ['y', 'ye', 'yes']:
+    if (not prompt) or response in ["y", "ye", "yes"]:
         try:
             shutil.rmtree(dir_path)
         except:
@@ -113,85 +115,157 @@ def clean_download_cache(dir_path=downloaders.DEFAULT_CACHE_PATH, prompt=True):
 def parse_args(args_input=None):
     """Convenience function for parsing user supplied command line args"""
     parser = argparse.ArgumentParser(
-        description=DESCRIPTION,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        description=DESCRIPTION, formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    default_outdir = os.path.join(os.getcwd(), 'acme')
-    parser.add_argument('-o', '--output-dir', type=str, default=default_outdir,
-                        help='the directory to write the dataset to.')
-    default_indir = os.path.join(os.getcwd(), 'input_data')
-    parser.add_argument('--config', default=None, help='Load a json config '
-                        'file, in the format created by measure_errors.py. '
-                        'This will override --degradations, --degradation-'
-                        'dist, and --clean-prop.')
-    parser.add_argument('--formats', metavar='format', help='Create '
-                        'custom versions of the acme data for easier loading '
-                        'with our provided pytorch Dataset classes. Choices are'
-                        f' {list(FORMATTERS.keys())}. Specify none to avoid '
-                        'creation', nargs='*', default=list(FORMATTERS.keys()),
-                        choices=FORMATTERS.keys())
-    parser.add_argument('--local-midi-dirs', metavar='midi_dir', type=str,
-                        nargs='*', help='directories containing midi files to '
-                        'include in the dataset', default=[])
-    parser.add_argument('--local-csv-dirs', metavar='csv_dir', type=str,
-                        nargs='*', help='directories containing csv files to '
-                        'include in the dataset', default=[])
-    parser.add_argument('--recursive', action='store_true', help='Search local'
-                        ' dataset directories recursively for all midi or csv '
-                        'files.')
-    parser.add_argument('--datasets', metavar='dataset_name',
-                        nargs='*', default=downloaders.DATASETS,
-                        help='datasets to download and use. Must match names '
-                        'of classes in the downloaders module. By default, '
-                        'will use cached downloaded data if available, see '
-                        '--download-cache-dir and --clear-download-cache. To '
-                        'download no data, provide an input of "None"')
-    parser.add_argument('--degradations', metavar='deg_name', nargs='*',
-                        choices=list(degradations.DEGRADATIONS.keys()),
-                        default=list(degradations.DEGRADATIONS.keys()),
-                        help='degradations to use on the data. Must match '
-                        'names of functions in the degradations module. By '
-                        'default, will use them all.')
-    parser.add_argument('--excerpt-length', metavar='ms', type=int,
-                        help='The length of the excerpt (in ms) to take from '
-                        'each piece. The excerpt will start on a note onset '
-                        'and include all notes whose onset lies within this '
-                        'number of ms after the first note.', default=5000)
-    parser.add_argument('--min-notes', metavar='N', type=int, default=10,
-                        help='The minimum number of notes required for an '
-                        'excerpt to be valid.')
-    parser.add_argument('--degradation-kwargs', metavar='json_file_or_string',
-                        help='json file or json-formatted string with keyword '
-                        'arguments for the degradation functions. First '
-                        'provide the degradation name, then a double '
-                        'underscore, then the keyword argument name, followed '
-                        'by the value to use for the kwarg. e.g. '
-                        '`{"time_shift__align_onset": true, '
-                        '"pitch_shift__min_pitch": 5}`', default=None)
-    parser.add_argument('--degradation-dist', metavar='relative_probability',
-                        nargs='*', default=None, help='A list of relative '
-                        'probabilities that each degradation will used. Must '
-                        'be the same length as --degradations. Defaults to a '
-                        'uniform distribution.', type=float)
-    parser.add_argument('--clean-prop', type=float, help='The proportion of '
-                        'excerpts in the final dataset that should be clean.',
-                        default=1 / (1 + len(degradations.DEGRADATIONS)))
-    parser.add_argument('--splits', metavar=('train', 'valid', 'test'),
-                        nargs=3, type=float, help='The relative sizes of the '
-                        'train, validation, and test sets respectively.',
-                        default=[0.8, 0.1, 0.1])
-    parser.add_argument('--seed', type=int, default=None, help='The numpy seed'
-                        ' to use when creating the dataset.')
-    parser.add_argument('--clean', action='store_true', help='Clear and delete'
-                        f' the download cache {downloaders.DEFAULT_CACHE_PATH}'
-                        ' (and do nothing else).')
-    parser.add_argument('-v', '--verbose', action='store_true', help='Verbose '
-                        'printing.')
+    default_outdir = os.path.join(os.getcwd(), "acme")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=str,
+        default=default_outdir,
+        help="the directory to write the dataset to.",
+    )
+    default_indir = os.path.join(os.getcwd(), "input_data")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Load a json config "
+        "file, in the format created by measure_errors.py. "
+        "This will override --degradations, --degradation-"
+        "dist, and --clean-prop.",
+    )
+    parser.add_argument(
+        "--formats",
+        metavar="format",
+        help="Create "
+        "custom versions of the acme data for easier loading "
+        "with our provided pytorch Dataset classes. Choices are"
+        f" {list(FORMATTERS.keys())}. Specify none to avoid "
+        "creation",
+        nargs="*",
+        default=list(FORMATTERS.keys()),
+        choices=FORMATTERS.keys(),
+    )
+    parser.add_argument(
+        "--local-midi-dirs",
+        metavar="midi_dir",
+        type=str,
+        nargs="*",
+        help="directories containing midi files to " "include in the dataset",
+        default=[],
+    )
+    parser.add_argument(
+        "--local-csv-dirs",
+        metavar="csv_dir",
+        type=str,
+        nargs="*",
+        help="directories containing csv files to " "include in the dataset",
+        default=[],
+    )
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Search local"
+        " dataset directories recursively for all midi or csv "
+        "files.",
+    )
+    parser.add_argument(
+        "--datasets",
+        metavar="dataset_name",
+        nargs="*",
+        default=downloaders.DATASETS,
+        help="datasets to download and use. Must match names "
+        "of classes in the downloaders module. By default, "
+        "will use cached downloaded data if available, see "
+        "--download-cache-dir and --clear-download-cache. To "
+        'download no data, provide an input of "None"',
+    )
+    parser.add_argument(
+        "--degradations",
+        metavar="deg_name",
+        nargs="*",
+        choices=list(degradations.DEGRADATIONS.keys()),
+        default=list(degradations.DEGRADATIONS.keys()),
+        help="degradations to use on the data. Must match "
+        "names of functions in the degradations module. By "
+        "default, will use them all.",
+    )
+    parser.add_argument(
+        "--excerpt-length",
+        metavar="ms",
+        type=int,
+        help="The length of the excerpt (in ms) to take from "
+        "each piece. The excerpt will start on a note onset "
+        "and include all notes whose onset lies within this "
+        "number of ms after the first note.",
+        default=5000,
+    )
+    parser.add_argument(
+        "--min-notes",
+        metavar="N",
+        type=int,
+        default=10,
+        help="The minimum number of notes required for an " "excerpt to be valid.",
+    )
+    parser.add_argument(
+        "--degradation-kwargs",
+        metavar="json_file_or_string",
+        help="json file or json-formatted string with keyword "
+        "arguments for the degradation functions. First "
+        "provide the degradation name, then a double "
+        "underscore, then the keyword argument name, followed "
+        "by the value to use for the kwarg. e.g. "
+        '`{"time_shift__align_onset": true, '
+        '"pitch_shift__min_pitch": 5}`',
+        default=None,
+    )
+    parser.add_argument(
+        "--degradation-dist",
+        metavar="relative_probability",
+        nargs="*",
+        default=None,
+        help="A list of relative "
+        "probabilities that each degradation will used. Must "
+        "be the same length as --degradations. Defaults to a "
+        "uniform distribution.",
+        type=float,
+    )
+    parser.add_argument(
+        "--clean-prop",
+        type=float,
+        help="The proportion of " "excerpts in the final dataset that should be clean.",
+        default=1 / (1 + len(degradations.DEGRADATIONS)),
+    )
+    parser.add_argument(
+        "--splits",
+        metavar=("train", "valid", "test"),
+        nargs=3,
+        type=float,
+        help="The relative sizes of the "
+        "train, validation, and test sets respectively.",
+        default=[0.8, 0.1, 0.1],
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="The numpy seed" " to use when creating the dataset.",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Clear and delete"
+        f" the download cache {downloaders.DEFAULT_CACHE_PATH}"
+        " (and do nothing else).",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Verbose " "printing."
+    )
     args = parser.parse_args(args=args_input)
     return args
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     ARGS = parse_args()
 
     if ARGS.clean:
@@ -199,11 +273,11 @@ if __name__ == '__main__':
         sys.exit(0 if clean_ok else 1)
 
     if ARGS.seed is None:
-        seed = np.random.randint(0, 2**32)
-        print(f'No random seed supplied. Setting to {seed}.')
+        seed = np.random.randint(0, 2 ** 32)
+        print(f"No random seed supplied. Setting to {seed}.")
     else:
         seed = ARGS.seed
-        print(f'Setting random seed to {seed}.')
+        print(f"Setting random seed to {seed}.")
     np.random.seed(seed)
 
     # Load given degradation_kwargs
@@ -211,7 +285,7 @@ if __name__ == '__main__':
     if ARGS.degradation_kwargs is not None:
         if os.path.exists(ARGS.degradation_kwargs):
             # If file exists, assume that is what was passed
-            with open(ARGS.degradation_kwargs, 'r') as json_file:
+            with open(ARGS.degradation_kwargs, "r") as json_file:
                 degradation_kwargs = json.load(json_file)
         else:
             # File doesn't exist, assume json string was passed
@@ -222,20 +296,23 @@ if __name__ == '__main__':
 
     # Load config
     if ARGS.config is not None:
-        with open(ARGS.config, 'r') as file:
+        with open(ARGS.config, "r") as file:
             config = json.load(file)
         if ARGS.verbose:
-            print(f'Loading from config file {ARGS.config}.')
-        if 'degradation_dist' in config:
-            ARGS.degradation_dist = np.array(config['degradation_dist'])
+            print(f"Loading from config file {ARGS.config}.")
+        if "degradation_dist" in config:
+            ARGS.degradation_dist = np.array(config["degradation_dist"])
             ARGS.degradations = list(degradations.DEGRADATIONS.keys())
-        if 'clean_prop' in config:
-            ARGS.clean_prop = config['clean_prop']
+        if "clean_prop" in config:
+            ARGS.clean_prop = config["clean_prop"]
     # Warn user they specified kwargs for degradation not being used
     for deg, args in degradation_kwargs.items():
         if deg not in ARGS.degradations and len(args) > 0:
-            warnings.warn("--degradation_kwargs contains args for unused "
-                          f'degradation "{deg}".', UserWarning)
+            warnings.warn(
+                "--degradation_kwargs contains args for unused "
+                f'degradation "{deg}".',
+                UserWarning,
+            )
 
     # Exit if degradation-dist is a diff length to degradations
     if ARGS.degradation_dist is None:
@@ -246,22 +323,26 @@ if __name__ == '__main__':
     )
 
     # Check that no probabilities are invalid
-    assert min(ARGS.degradation_dist) >= 0, ("--degradation-dist values must "
-                                             "not be negative.")
-    assert sum(ARGS.degradation_dist) > 0, ("Some --degradation-dist value "
-                                            "must be positive.")
-    assert 0 <= ARGS.clean_prop <= 1, ("--clean-prop must be between 0 and 1 "
-                                       "(inclusive).")
+    assert min(ARGS.degradation_dist) >= 0, (
+        "--degradation-dist values must " "not be negative."
+    )
+    assert sum(ARGS.degradation_dist) > 0, (
+        "Some --degradation-dist value " "must be positive."
+    )
+    assert 0 <= ARGS.clean_prop <= 1, (
+        "--clean-prop must be between 0 and 1 " "(inclusive)."
+    )
     assert min(ARGS.splits) >= 0, "--splits values must not be negative."
     assert sum(ARGS.splits) > 0, "Some --splits value must be positive."
 
     # Parse formats
-    if len(ARGS.formats) == 1 and ARGS.formats[0].lower() == 'none':
+    if len(ARGS.formats) == 1 and ARGS.formats[0].lower() == "none":
         formats = []
     else:
         assert all([name in FORMATTERS.keys() for name in ARGS.formats]), (
-                f"all provided formats {ARGS.formats} must be in the "
-                "list of available formats {list(FORMATTERS.keys())}")
+            f"all provided formats {ARGS.formats} must be in the "
+            "list of available formats {list(FORMATTERS.keys())}"
+        )
         formats = ARGS.formats
 
     # These will be tuples of (dataset, relative_path, full_path, note_df).
@@ -278,120 +359,118 @@ if __name__ == '__main__':
     # in such a way that the sorting is identical to previous versions of this
     # script to ensure backwards compatability.
     input_data = []
-    input_kwargs = {
-        'single_track': True,
-        'non_overlapping': True
-    }
-
+    input_kwargs = {"single_track": True, "non_overlapping": True}
 
     # Instantiate downloaders =================================================
     OVERWRITE = None
     ds_names = ARGS.datasets
-    if len(ds_names) == 1 and ds_names[0].lower() == 'none':
+    if len(ds_names) == 1 and ds_names[0].lower() == "none":
         ds_names = []
     else:
         assert all([name in downloaders.DATASETS for name in ds_names]), (
-                f"all provided dataset names {ds_names} must be in the "
-                "list of available datasets for download "
-                f"{downloaders.DATASETS}")
+            f"all provided dataset names {ds_names} must be in the "
+            "list of available datasets for download "
+            f"{downloaders.DATASETS}"
+        )
     # Instantiated downloader classes
     downloader_dict = {
         ds_name: getattr(downloaders, ds_name)(
-                     cache_path=downloaders.DEFAULT_CACHE_PATH
-                 )
+            cache_path=downloaders.DEFAULT_CACHE_PATH
+        )
         for ds_name in ds_names
     }
-
 
     # Clear and set up output dir =============================================
     if os.path.exists(ARGS.output_dir):
         if ARGS.verbose:
-            print(f'Clearing stale data from {ARGS.output_dir}.')
+            print(f"Clearing stale data from {ARGS.output_dir}.")
         shutil.rmtree(ARGS.output_dir)
     os.makedirs(ARGS.output_dir, exist_ok=True)
-    for out_subdir in ['clean', 'altered']:
-        output_dirs = [os.path.join(ARGS.output_dir, out_subdir, name)
-                       for name in ds_names]
+    for out_subdir in ["clean", "altered"]:
+        output_dirs = [
+            os.path.join(ARGS.output_dir, out_subdir, name) for name in ds_names
+        ]
         for path in output_dirs:
             os.makedirs(path, exist_ok=True)
 
-
     # Load data from downloaders ==============================================
-    print('Loading data from downloaders, this could take a while...')
+    print("Loading data from downloaders, this could take a while...")
     for dataset in downloader_dict:
         downloader = downloader_dict[dataset]
 
         dataset_base = os.path.join(downloaders.DEFAULT_CACHE_PATH, dataset)
         dataset_base_len = len(dataset_base) + len(os.path.sep)
-        output_path = os.path.join(dataset_base, 'data')
+        output_path = os.path.join(dataset_base, "data")
 
         try:
             try:
-                downloader.download_csv(output_path=output_path,
-                                        overwrite=OVERWRITE,
-                                        verbose=ARGS.verbose)
-                ext = 'csv'
+                downloader.download_csv(
+                    output_path=output_path, overwrite=OVERWRITE, verbose=ARGS.verbose
+                )
+                ext = "csv"
                 input_func = fileio.csv_to_df
             except NotImplementedError:
-                downloader.download_midi(output_path=output_path,
-                                        overwrite=OVERWRITE,
-                                        verbose=ARGS.verbose)
-                ext = 'mid'
+                downloader.download_midi(
+                    output_path=output_path, overwrite=OVERWRITE, verbose=ARGS.verbose
+                )
+                ext = "mid"
                 input_func = fileio.midi_to_df
         except BadZipfile:
-            print("The download cache contains invalid data. Run "
-                  "`make_dataset.py --clean` to clean the cache, then try to "
-                  "re-create the ACME dataset.", file=sys.stderr)
+            print(
+                "The download cache contains invalid data. Run "
+                "`make_dataset.py --clean` to clean the cache, then try to "
+                "re-create the ACME dataset.",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
-        for filename in tqdm(glob(os.path.join(output_path, '**', f'*.{ext}'),
-                                  recursive=True),
-                             desc=f'Loading data from {dataset}'):
+        for filename in tqdm(
+            glob(os.path.join(output_path, "**", f"*.{ext}"), recursive=True),
+            desc=f"Loading data from {dataset}",
+        ):
 
             note_df = input_func(filename, **input_kwargs)
             if note_df is not None:
-                rel_path = filename[dataset_base_len + 5:]
+                rel_path = filename[dataset_base_len + 5 :]
                 input_data.append((dataset, rel_path, filename, note_df))
 
-
     # Load user data ==========================================================
-    for data_type in ['midi', 'csv']:
-        if data_type == 'midi':
+    for data_type in ["midi", "csv"]:
+        if data_type == "midi":
             local_dirs = ARGS.local_midi_dirs
-            ext = 'mid'
+            ext = "mid"
             df_load_func = fileio.midi_to_df
         else:
             local_dirs = ARGS.local_csv_dirs
-            ext = 'csv'
+            ext = "csv"
             df_load_func = fileio.csv_to_df
 
         for path in local_dirs:
             # Bugfix for paths ending in /
             if len(path) > 1 and path[-1] == os.path.sep:
                 path = path[:-1]
-            dataset = f'local_{os.path.basename(path)}'
+            dataset = f"local_{os.path.basename(path)}"
             dataset_base_len = len(path) + len(os.path.sep)
 
             if ARGS.recursive:
-                path = os.path.join(path, '**')
-            for filepath in tqdm(glob(os.path.join(path, f'*.{ext}'),
-                                    recursive=ARGS.recursive),
-                                 desc=f'Loading user {data_type} from {path}'):
+                path = os.path.join(path, "**")
+            for filepath in tqdm(
+                glob(os.path.join(path, f"*.{ext}"), recursive=ARGS.recursive),
+                desc=f"Loading user {data_type} from {path}",
+            ):
 
                 note_df = df_load_func(filepath, **input_kwargs)
                 if note_df is not None:
                     rel_path = filepath[dataset_base_len:]
                     input_data.append((dataset, rel_path, filepath, note_df))
 
-
     # All data is loaded. Sort and shuffle. ===================================
     # output to output_dir/clean/dataset_name/filename.csv
     # The reason for this is we know there will be no filename duplicates
     input_data.sort()
-    np.random.shuffle(input_data) # This is important for join_notes
+    np.random.shuffle(input_data)  # This is important for join_notes
 
-    meta_file = open(os.path.join(ARGS.output_dir, 'metadata.csv'), 'w')
-
+    meta_file = open(os.path.join(ARGS.output_dir, "metadata.csv"), "w")
 
     # Perform degradations and write degraded data to output ==================
     # output to output_dir/degraded/dataset_name/filename.csv
@@ -409,16 +488,16 @@ if __name__ == '__main__':
 
     # Add none for no degradation
     if 0 < ARGS.clean_prop < 1:
-        deg_choices = np.insert(deg_choices, 0, 'none')
+        deg_choices = np.insert(deg_choices, 0, "none")
         goal_deg_dist *= 1 - ARGS.clean_prop
         goal_deg_dist = np.insert(goal_deg_dist, 0, ARGS.clean_prop)
     elif ARGS.clean_prop == 1:
-        deg_choices = np.array(['none'])
+        deg_choices = np.array(["none"])
         goal_deg_dist = np.array([1])
     nr_degs = len(goal_deg_dist)
 
     # Normalize split proportions and remove 0s
-    split_names = ['train', 'valid', 'test']
+    split_names = ["train", "valid", "test"]
     split_props = np.array(ARGS.splits)
     split_props /= np.sum(split_props)
     non_zero = [i for i, p in enumerate(split_props) if p != 0]
@@ -427,11 +506,10 @@ if __name__ == '__main__':
     nr_splits = len(split_names)
 
     # Write out deg_choices to degradation_ids.csv
-    with open(os.path.join(ARGS.output_dir, 'degradation_ids.csv'),
-              'w') as file:
-        file.write('id,degradation_name\n')
+    with open(os.path.join(ARGS.output_dir, "degradation_ids.csv"), "w") as file:
+        file.write("id,degradation_name\n")
         for i, deg_name in enumerate(deg_choices):
-            file.write(f'{i},{deg_name}\n')
+            file.write(f"{i},{deg_name}\n")
 
     # The idea is to keep track of the current distribution of degradations
     # and then sample in reverse order of the difference between this and
@@ -439,14 +517,15 @@ if __name__ == '__main__':
     deg_counts = np.zeros(nr_degs)
     split_counts = np.zeros(nr_splits)
 
-    meta_file.write('altered_csv_path,degraded,degradation_id,'
-                    'clean_csv_path,split\n')
+    meta_file.write(
+        "altered_csv_path,degraded,degradation_id," "clean_csv_path,split\n"
+    )
     for i, data in enumerate(tqdm(input_data, desc="Degrading data")):
         dataset, rel_path, file_path, note_df = data
-        rel_path = f'{rel_path[:-3]}csv'
+        rel_path = f"{rel_path[:-3]}csv"
         # First, get the degradation order for this iteration.
         # Get the current distribution of degradations
-        if np.sum(deg_counts) == 0: # First iteration, set to uniform
+        if np.sum(deg_counts) == 0:  # First iteration, set to uniform
             current_deg_dist = np.ones(nr_degs) / nr_degs
             current_split_dist = np.ones(nr_splits) / nr_splits
         else:
@@ -454,35 +533,39 @@ if __name__ == '__main__':
             current_split_dist = split_counts / np.sum(split_counts)
 
         # Grab an excerpt from this df
-        excerpt = get_random_excerpt(note_df, min_notes=ARGS.min_notes,
-                                     excerpt_length=ARGS.excerpt_length,
-                                     first_onset_range=(0, 200), iterations=10)
+        excerpt = get_random_excerpt(
+            note_df,
+            min_notes=ARGS.min_notes,
+            excerpt_length=ARGS.excerpt_length,
+            first_onset_range=(0, 200),
+            iterations=10,
+        )
 
         # If no valid excerpt was found, skip this piece
         if excerpt is None:
-            warnings.warn("Unable to find valid excerpt from file "
-                          f"{file_path}. Lengthen --excerpt-length or "
-                          "lower --min-notes. Skipping.", UserWarning)
+            warnings.warn(
+                "Unable to find valid excerpt from file "
+                f"{file_path}. Lengthen --excerpt-length or "
+                "lower --min-notes. Skipping.",
+                UserWarning,
+            )
             continue
 
         # Try degradations in reverse order of the difference between
         # their current distribution and their desired distribution.
         diffs = goal_deg_dist - current_deg_dist
-        degs_sorted = sorted(zip(diffs, deg_choices,
-                                 list(range(len(deg_choices)))))[::-1]
+        degs_sorted = sorted(zip(diffs, deg_choices, list(range(len(deg_choices)))))[
+            ::-1
+        ]
 
         # Calculate split in the same way (but only save the first)
         split_diffs = split_props - current_split_dist
         _, split_name, split_num = sorted(
-            zip(
-                    split_diffs,
-                    split_names,
-                    list(range(nr_splits))
-            )
+            zip(split_diffs, split_names, list(range(nr_splits)))
         )[-1]
 
         # Make default labels for no degradation
-        clean_path = os.path.join('clean', dataset, rel_path)
+        clean_path = os.path.join("clean", dataset, rel_path)
         altered_path = clean_path
         deg_binary = 0
 
@@ -490,13 +573,13 @@ if __name__ == '__main__':
         degraded = None
         for diff, deg_name, deg_num in degs_sorted:
             # Break for no degradation
-            if deg_name == 'none':
+            if deg_name == "none":
                 break
 
             # Try the degradation
             deg_fun = degradations.DEGRADATIONS[deg_name]
-            deg_fun_kwargs = degradation_kwargs[deg_name] # degradation_kwargs
-                                                          # at top of main call
+            deg_fun_kwargs = degradation_kwargs[deg_name]  # degradation_kwargs
+            # at top of main call
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 degraded = deg_fun(excerpt, **deg_fun_kwargs)
@@ -504,7 +587,7 @@ if __name__ == '__main__':
             if degraded is not None:
                 # Update labels
                 deg_binary = 1
-                altered_path = os.path.join('altered', dataset, rel_path)
+                altered_path = os.path.join("altered", dataset, rel_path)
 
                 # Write degraded csv
                 altered_outpath = os.path.join(ARGS.output_dir, altered_path)
@@ -522,12 +605,16 @@ if __name__ == '__main__':
             fileio.df_to_csv(excerpt, clean_outpath)
 
             # Write metadata
-            meta_file.write(f'{altered_path},{deg_binary},{deg_num},'
-                            f'{clean_path},{split_name}\n')
+            meta_file.write(
+                f"{altered_path},{deg_binary},{deg_num}," f"{clean_path},{split_name}\n"
+            )
         else:
-            warnings.warn("Unable to degrade chosen excerpt from "
-                          f"{file_path} and no clean excerpts requested."
-                          " Skipping.", UserWarning)
+            warnings.warn(
+                "Unable to degrade chosen excerpt from "
+                f"{file_path} and no clean excerpts requested."
+                " Skipping.",
+                UserWarning,
+            )
 
     meta_file.close()
 
@@ -535,28 +622,35 @@ if __name__ == '__main__':
         create_corpus_csvs(ARGS.output_dir, FORMATTERS[f])
 
     print(f'\n{10*"="} Finished! {10*"="}\n')
-    print(f'Count of degradations:')
+    print(f"Count of degradations:")
     for deg_name, count in zip(deg_choices, deg_counts):
-        print(f'\t* {deg_name}: {int(count)}')
+        print(f"\t* {deg_name}: {int(count)}")
 
-    print(f'\nYou will find the generated data at {ARGS.output_dir} '
-          'with subdirectories')
-    print(f'\t* clean - contains the extracted clean excerpts')
-    print(f'\t* altered - contains the excerpts altered by the degradations '
-          'described in metadata.csv')
-    print('\nmetadata.csv describes:')
-    print('\t* (the id number for) the type of degradation used for the '
-          'alteration')
-    print('\t* the path for the altered and clean files')
-    print('\t* which split (train, valid, test) the file should be used in')
-    print('\t* in which corpus and on what line the file is located')
+    print(
+        f"\nYou will find the generated data at {ARGS.output_dir} "
+        "with subdirectories"
+    )
+    print(f"\t* clean - contains the extracted clean excerpts")
+    print(
+        f"\t* altered - contains the excerpts altered by the degradations "
+        "described in metadata.csv"
+    )
+    print("\nmetadata.csv describes:")
+    print("\t* (the id number for) the type of degradation used for the " "alteration")
+    print("\t* the path for the altered and clean files")
+    print("\t* which split (train, valid, test) the file should be used in")
+    print("\t* in which corpus and on what line the file is located")
 
-    print('\ndegradation_ids.csv is a mapping of degradation name to the id '
-          'number used in metadata.csv')
+    print(
+        "\ndegradation_ids.csv is a mapping of degradation name to the id "
+        "number used in metadata.csv"
+    )
 
     for f in formats:
         print(f"\n{FORMATTERS[f]['message']}")
 
-    print('\nTo reproduce this dataset again, run the script with argument '
-          f'--seed {seed}')
+    print(
+        "\nTo reproduce this dataset again, run the script with argument "
+        f"--seed {seed}"
+    )
     print(LOGO)

--- a/make_dataset.py
+++ b/make_dataset.py
@@ -10,12 +10,10 @@ from glob import glob
 from zipfile import BadZipfile
 
 import numpy as np
-import pandas as pd
 from tqdm import tqdm
 
 from mdtk import degradations, downloaders, fileio
 from mdtk.df_utils import get_random_excerpt
-from mdtk.filesystem_utils import make_directory
 from mdtk.formatters import FORMATTERS, create_corpus_csvs
 
 
@@ -106,7 +104,7 @@ def clean_download_cache(dir_path=downloaders.DEFAULT_CACHE_PATH, prompt=True):
     if (not prompt) or response in ["y", "ye", "yes"]:
         try:
             shutil.rmtree(dir_path)
-        except:
+        except Exception:
             print("Could not delete download cache. Please do so manually.")
             return False
     return True
@@ -125,7 +123,6 @@ def parse_args(args_input=None):
         default=default_outdir,
         help="the directory to write the dataset to.",
     )
-    default_indir = os.path.join(os.getcwd(), "input_data")
     parser.add_argument(
         "--config",
         default=None,
@@ -431,7 +428,7 @@ if __name__ == "__main__":
 
             note_df = input_func(filename, **input_kwargs)
             if note_df is not None:
-                rel_path = filename[dataset_base_len + 5 :]
+                rel_path = filename[(dataset_base_len + 5) :]
                 input_data.append((dataset, rel_path, filename, note_df))
 
     # Load user data ==========================================================
@@ -622,7 +619,7 @@ if __name__ == "__main__":
         create_corpus_csvs(ARGS.output_dir, FORMATTERS[f])
 
     print(f'\n{10*"="} Finished! {10*"="}\n')
-    print(f"Count of degradations:")
+    print("Count of degradations:")
     for deg_name, count in zip(deg_choices, deg_counts):
         print(f"\t* {deg_name}: {int(count)}")
 
@@ -630,9 +627,9 @@ if __name__ == "__main__":
         f"\nYou will find the generated data at {ARGS.output_dir} "
         "with subdirectories"
     )
-    print(f"\t* clean - contains the extracted clean excerpts")
+    print("\t* clean - contains the extracted clean excerpts")
     print(
-        f"\t* altered - contains the excerpts altered by the degradations "
+        "\t* altered - contains the excerpts altered by the degradations "
         "described in metadata.csv"
     )
     print("\nmetadata.csv describes:")

--- a/mdtk/degradations.py
+++ b/mdtk/degradations.py
@@ -1,12 +1,12 @@
 """Code to perform the degradations i.e. edits to the midi data"""
 import sys
 import warnings
+
 import numpy as np
 import pandas as pd
-from numpy.random import randint, choice
+from numpy.random import choice, randint
 
 from mdtk.df_utils import NOTE_DF_SORT_ORDER
-
 
 MIN_PITCH_DEFAULT = 21
 MAX_PITCH_DEFAULT = 108
@@ -21,9 +21,11 @@ MAX_GAP_DEFAULT = 50
 
 TRIES_DEFAULT = 10
 
-TRIES_WARN_MSG = ("WARNING: Generated invalid (overlapping) degraded excerpt "
-                  "too many times. Try raising tries parameter (default 10). "
-                  "Returning None.")
+TRIES_WARN_MSG = (
+    "WARNING: Generated invalid (overlapping) degraded excerpt "
+    "too many times. Try raising tries parameter (default 10). "
+    "Returning None."
+)
 
 
 def set_random_seed(func, seed=None):
@@ -45,10 +47,12 @@ def set_random_seed(func, seed=None):
         The originally supplied function, but now with an aditional optional
         seed keyword argument.
     """
+
     def seeded_func(*args, seed=seed, **kwargs):
         if seed is not None:
             np.random.seed(seed)
         return func(*args, **kwargs)
+
     return seeded_func
 
 
@@ -71,11 +75,12 @@ def overlaps(df, idx):
         True if the note overlaps some other note. False otherwise.
     """
     note = df.loc[idx]
-    df = df.loc[(df['pitch'] == note.pitch) &
-                (df['track'] == note.track) &
-                (df.index != idx)]
-    overlap = any((note.onset < df['onset'] + df['dur']) &
-                  (note.onset + note.dur > df['onset']))
+    df = df.loc[
+        (df["pitch"] == note.pitch) & (df["track"] == note.track) & (df.index != idx)
+    ]
+    overlap = any(
+        (note.onset < df["onset"] + df["dur"]) & (note.onset + note.dur > df["onset"])
+    )
     return overlap
 
 
@@ -171,9 +176,13 @@ def split_range_sample(split_range, p=None):
 
 
 @set_random_seed
-def pitch_shift(excerpt, min_pitch=MIN_PITCH_DEFAULT,
-                max_pitch=MAX_PITCH_DEFAULT, distribution=None,
-                tries=TRIES_DEFAULT):
+def pitch_shift(
+    excerpt,
+    min_pitch=MIN_PITCH_DEFAULT,
+    max_pitch=MAX_PITCH_DEFAULT,
+    distribution=None,
+    tries=TRIES_DEFAULT,
+):
     """
     Shift the pitch of one note from the given excerpt.
 
@@ -212,8 +221,9 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH_DEFAULT,
         or None if the degradation cannot be performed.
     """
     if len(excerpt) == 0:
-        warnings.warn('WARNING: No notes to pitch shift. Returning None.',
-                      category=UserWarning)
+        warnings.warn(
+            "WARNING: No notes to pitch shift. Returning None.", category=UserWarning
+        )
         return None
 
     excerpt = pre_process(excerpt)
@@ -228,15 +238,18 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH_DEFAULT,
     # A distribution [0, 0, 1] always shifts up one semitone; a note with
     # pitch equal to max_pitch can't be shifted with this distribution.
     if distribution is not None:
-        assert all([dd >= 0 for dd in distribution]), ('A value in supplied '
-                                                       'distribution is negative.')
+        assert all([dd >= 0 for dd in distribution]), (
+            "A value in supplied " "distribution is negative."
+        )
         zero_idx = len(distribution) // 2
         distribution[zero_idx] = 0
 
         if np.sum(distribution) == 0:
-            warnings.warn('WARNING: distribution contains only 0s after '
-                          'setting distribution[zero_idx] value to 0. '
-                          'Returning None.')
+            warnings.warn(
+                "WARNING: distribution contains only 0s after "
+                "setting distribution[zero_idx] value to 0. "
+                "Returning None."
+            )
             return None
 
         nonzero_indices = np.nonzero(distribution)[0]
@@ -250,57 +263,67 @@ def pitch_shift(excerpt, min_pitch=MIN_PITCH_DEFAULT,
         max_to_sample = max_pitch + min_pitch_shift
         min_to_sample = min_pitch - max_pitch_shift
 
-        valid_notes = excerpt.index[excerpt['pitch']
-                                    .between(min_to_sample,
-                                             max_to_sample)].tolist()
+        valid_notes = excerpt.index[
+            excerpt["pitch"].between(min_to_sample, max_to_sample)
+        ].tolist()
 
         if not valid_notes:
-            warnings.warn('WARNING: No valid pitches to shift given '
-                          f'min_pitch {min_pitch}, max_pitch {max_pitch}, '
-                          f'and distribution {distribution} (after setting '
-                          'distribution[zero_idx] to 0). Returning None.')
+            warnings.warn(
+                "WARNING: No valid pitches to shift given "
+                f"min_pitch {min_pitch}, max_pitch {max_pitch}, "
+                f"and distribution {distribution} (after setting "
+                "distribution[zero_idx] to 0). Returning None."
+            )
             return None
 
     degraded = excerpt.copy()
 
     # Sample a random note
     note_index = valid_notes[randint(len(valid_notes))]
-    pitch = degraded.loc[note_index, 'pitch']
+    pitch = degraded.loc[note_index, "pitch"]
 
     # Shift its pitch
     if distribution is None:
         # Uniform distribution
         if min_pitch != max_pitch or min_pitch != pitch:
-            while degraded.loc[note_index, 'pitch'] == pitch:
-                degraded.loc[note_index, 'pitch'] = randint(min_pitch,
-                                                            max_pitch + 1)
+            while degraded.loc[note_index, "pitch"] == pitch:
+                degraded.loc[note_index, "pitch"] = randint(min_pitch, max_pitch + 1)
     else:
         zero_idx = len(distribution) // 2
-        pitches = np.array(range(pitch - zero_idx,
-                                 pitch - zero_idx + len(distribution)))
+        pitches = np.array(
+            range(pitch - zero_idx, pitch - zero_idx + len(distribution))
+        )
         distribution[zero_idx] = 0
         distribution = np.where(pitches < min_pitch, 0, distribution)
         distribution = np.where(pitches > max_pitch, 0, distribution)
         distribution = distribution / np.sum(distribution)
-        degraded.loc[note_index, 'pitch'] = choice(pitches, p=distribution)
+        degraded.loc[note_index, "pitch"] = choice(pitches, p=distribution)
 
     # Check if overlaps
-    if (overlaps(degraded, note_index) or
-        degraded.loc[note_index, 'pitch'] == pitch):
+    if overlaps(degraded, note_index) or degraded.loc[note_index, "pitch"] == pitch:
         if tries == 1:
             warnings.warn(TRIES_WARN_MSG)
             return None
-        return pitch_shift(excerpt, min_pitch=min_pitch, max_pitch=max_pitch,
-                           distribution=orig_dist, tries=tries - 1)
+        return pitch_shift(
+            excerpt,
+            min_pitch=min_pitch,
+            max_pitch=max_pitch,
+            distribution=orig_dist,
+            tries=tries - 1,
+        )
 
     degraded = post_process(degraded)
     return degraded
 
 
 @set_random_seed
-def time_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
-               max_shift=MAX_SHIFT_DEFAULT, align_onset=False,
-               tries=TRIES_DEFAULT):
+def time_shift(
+    excerpt,
+    min_shift=MIN_SHIFT_DEFAULT,
+    max_shift=MAX_SHIFT_DEFAULT,
+    align_onset=False,
+    tries=TRIES_DEFAULT,
+):
     """
     Shift the onset and offset times of one note from the given excerpt,
     leaving its duration unchanged.
@@ -339,8 +362,8 @@ def time_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
 
     min_shift = max(min_shift, 1)
 
-    onset = excerpt['onset']
-    offset = onset + excerpt['dur']
+    onset = excerpt["onset"]
+    offset = onset + excerpt["dur"]
     end_time = offset.max()
 
     # Shift earlier
@@ -348,8 +371,7 @@ def time_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
     latest_earlier_onset = onset - (min_shift - 1)
 
     # Shift later
-    latest_later_onset = onset + (((end_time + 1) - offset)
-                                  .clip(upper=max_shift + 1))
+    latest_later_onset = onset + (((end_time + 1) - offset).clip(upper=max_shift + 1))
     earliest_later_onset = onset + min_shift
 
     if align_onset:
@@ -358,9 +380,14 @@ def time_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
         # This code checks, for every range, whether at least 1 onset
         # lies within that range.
         onset = pd.Series(onset.unique())
-        for i, (eeo, leo, elo, llo) in enumerate(zip(
-            earliest_earlier_onset, latest_earlier_onset,
-            earliest_later_onset, latest_later_onset)):
+        for i, (eeo, leo, elo, llo) in enumerate(
+            zip(
+                earliest_earlier_onset,
+                latest_earlier_onset,
+                earliest_later_onset,
+                latest_later_onset,
+            )
+        ):
             # Go through each range to check there is a valid onset
             earlier_valid = onset.between(eeo, leo - 1).any()
             later_valid = onset.between(elo, llo - 1).any()
@@ -372,13 +399,16 @@ def time_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
                 earliest_later_onset.iloc[i] = llo
 
     # Find valid notes
-    valid = ((earliest_earlier_onset < latest_earlier_onset) |
-             (earliest_later_onset < latest_later_onset))
+    valid = (earliest_earlier_onset < latest_earlier_onset) | (
+        earliest_later_onset < latest_later_onset
+    )
     valid_notes = list(valid.index[valid])
 
     if not valid_notes:
-        warnings.warn('WARNING: No valid notes to time shift. Returning '
-                      'None.', category=UserWarning)
+        warnings.warn(
+            "WARNING: No valid notes to time shift. Returning " "None.",
+            category=UserWarning,
+        )
         return None
 
     # Sample a random note
@@ -390,8 +420,7 @@ def time_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
     llo = max(latest_later_onset[index], elo)
 
     if align_onset:
-        valid_onsets = (onset.between(eeo, leo - 1) |
-                        onset.between(elo, llo - 1))
+        valid_onsets = onset.between(eeo, leo - 1) | onset.between(elo, llo - 1)
         valid_onsets = list(onset[valid_onsets])
         onset = choice(valid_onsets)
     else:
@@ -399,25 +428,36 @@ def time_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
 
     degraded = excerpt.copy()
 
-    degraded.loc[index, 'onset'] = onset
+    degraded.loc[index, "onset"] = onset
 
     # Check if overlaps
     if overlaps(degraded, index):
         if tries == 1:
             warnings.warn(TRIES_WARN_MSG)
             return None
-        return time_shift(excerpt, min_shift=min_shift, max_shift=max_shift,
-                          align_onset=align_onset, tries=tries - 1)
+        return time_shift(
+            excerpt,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            align_onset=align_onset,
+            tries=tries - 1,
+        )
 
     degraded = post_process(degraded)
     return degraded
 
 
 @set_random_seed
-def onset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
-                max_shift=MAX_SHIFT_DEFAULT, min_duration=MIN_DURATION_DEFAULT,
-                max_duration=MAX_DURATION_DEFAULT, align_onset=False,
-                align_dur=False, tries=TRIES_DEFAULT):
+def onset_shift(
+    excerpt,
+    min_shift=MIN_SHIFT_DEFAULT,
+    max_shift=MAX_SHIFT_DEFAULT,
+    min_duration=MIN_DURATION_DEFAULT,
+    max_duration=MAX_DURATION_DEFAULT,
+    align_onset=False,
+    align_dur=False,
+    tries=TRIES_DEFAULT,
+):
     """
     Shift the onset time of one note from the given excerpt.
 
@@ -464,24 +504,23 @@ def onset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
     excerpt = pre_process(excerpt)
 
     min_shift = max(min_shift, 1)
-    min_duration -= 1 # This makes computation below simpler
+    min_duration -= 1  # This makes computation below simpler
 
-    onset = excerpt['onset']
-    offset = onset + excerpt['dur']
-    unique_durs = excerpt['dur'].unique()
+    onset = excerpt["onset"]
+    offset = onset + excerpt["dur"]
+    unique_durs = excerpt["dur"].unique()
 
     # Lengthen bounds (decrease onset)
-    earliest_lengthened_onset = ((offset - max_duration)
-                                 .clip(lower=onset - max_shift)
-                                 .clip(lower=0))
-    latest_lengthened_onset = ((onset - (min_shift - 1))
-                               .clip(upper=offset - min_duration))
+    earliest_lengthened_onset = (
+        (offset - max_duration).clip(lower=onset - max_shift).clip(lower=0)
+    )
+    latest_lengthened_onset = (onset - (min_shift - 1)).clip(
+        upper=offset - min_duration
+    )
 
     # Shorten bounds (increase onset)
-    latest_shortened_onset = ((offset - min_duration)
-                              .clip(upper=onset + (max_shift + 1)))
-    earliest_shortened_onset = ((onset + min_shift)
-                                .clip(lower=offset - max_duration))
+    latest_shortened_onset = (offset - min_duration).clip(upper=onset + (max_shift + 1))
+    earliest_shortened_onset = (onset + min_shift).clip(lower=offset - max_duration)
 
     if align_onset:
         # Find ranges which contain a note to align to
@@ -489,9 +528,14 @@ def onset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
         # This code checks, for every range, whether at least 1 onset
         # lies within that range.
         onset = pd.Series(onset.unique())
-        for i, (elo, llo, eso, lso) in enumerate(zip(
-            earliest_lengthened_onset, latest_lengthened_onset,
-            earliest_shortened_onset, latest_shortened_onset)):
+        for i, (elo, llo, eso, lso) in enumerate(
+            zip(
+                earliest_lengthened_onset,
+                latest_lengthened_onset,
+                earliest_shortened_onset,
+                latest_shortened_onset,
+            )
+        ):
             # Go through each range to check there is a valid onset
             earlier_valid = onset.between(elo, llo - 1)
             later_valid = onset.between(eso, lso - 1)
@@ -520,9 +564,14 @@ def onset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
         # This code checks, for every range, whether at least 1 dur
         # lies within that range.
         durs = pd.Series(unique_durs)
-        for i, (elo, llo, lso, eso) in enumerate(zip(
-            earliest_lengthened_onset, latest_lengthened_onset,
-            latest_shortened_onset, earliest_shortened_onset)):
+        for i, (elo, llo, lso, eso) in enumerate(
+            zip(
+                earliest_lengthened_onset,
+                latest_lengthened_onset,
+                latest_shortened_onset,
+                earliest_shortened_onset,
+            )
+        ):
             # Go through each range to check there is a valid dur
             result = offset[i] - durs
             lengthened_valid = result.between(elo, llo - 1).any()
@@ -535,13 +584,16 @@ def onset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
                 earliest_shortened_onset.iloc[i] = lso
 
     # Find valid notes
-    valid = ((earliest_lengthened_onset < latest_lengthened_onset) |
-             (earliest_shortened_onset < latest_shortened_onset))
+    valid = (earliest_lengthened_onset < latest_lengthened_onset) | (
+        earliest_shortened_onset < latest_shortened_onset
+    )
     valid_notes = list(valid.index[valid])
 
     if not valid_notes:
-        warnings.warn('WARNING: No valid notes to onset shift. Returning '
-                      'None.', category=UserWarning)
+        warnings.warn(
+            "WARNING: No valid notes to onset shift. Returning " "None.",
+            category=UserWarning,
+        )
         return None
 
     # Sample a random note
@@ -554,8 +606,7 @@ def onset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
 
     # Sample onset
     if align_onset:
-        valid_onsets = (onset.between(elo, llo - 1) |
-                        onset.between(eso, lso - 1))
+        valid_onsets = onset.between(elo, llo - 1) | onset.between(eso, lso - 1)
 
         if align_dur:
             # Here, align both
@@ -568,8 +619,7 @@ def onset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
     elif align_dur:
         # Align dur but not onset
         onsets = offset[index] - durs
-        valid_durs = (onsets.between(elo, llo - 1) |
-                      onsets.between(eso, lso - 1))
+        valid_durs = onsets.between(elo, llo - 1) | onsets.between(eso, lso - 1)
         valid_durs = list(durs[valid_durs])
         onset = offset[index] - choice(valid_durs)
 
@@ -579,28 +629,39 @@ def onset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
 
     degraded = excerpt.copy()
 
-    degraded.loc[index, 'onset'] = onset
-    degraded.loc[index, 'dur'] = offset[index] - onset
+    degraded.loc[index, "onset"] = onset
+    degraded.loc[index, "dur"] = offset[index] - onset
 
     # Check if overlaps
     if overlaps(degraded, index):
         if tries == 1:
             warnings.warn(TRIES_WARN_MSG)
             return None
-        return onset_shift(excerpt, min_shift=min_shift, max_shift=max_shift,
-                           min_duration=min_duration + 1, # Changed above
-                           max_duration=max_duration, align_onset=align_onset,
-                           align_dur=align_dur, tries=tries - 1)
+        return onset_shift(
+            excerpt,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration + 1,  # Changed above
+            max_duration=max_duration,
+            align_onset=align_onset,
+            align_dur=align_dur,
+            tries=tries - 1,
+        )
 
     degraded = post_process(degraded)
     return degraded
 
 
 @set_random_seed
-def offset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
-                 max_shift=MAX_SHIFT_DEFAULT, min_duration=MIN_DURATION_DEFAULT,
-                 max_duration=MAX_DURATION_DEFAULT, align_dur=False,
-                 tries=TRIES_DEFAULT):
+def offset_shift(
+    excerpt,
+    min_shift=MIN_SHIFT_DEFAULT,
+    max_shift=MAX_SHIFT_DEFAULT,
+    min_duration=MIN_DURATION_DEFAULT,
+    max_duration=MAX_DURATION_DEFAULT,
+    align_dur=False,
+    tries=TRIES_DEFAULT,
+):
     """
     Shift the offset time of one note from the given excerpt.
 
@@ -647,20 +708,21 @@ def offset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
     min_shift = max(min_shift, 1)
     max_duration += 1
 
-    onset = excerpt['onset']
-    duration = excerpt['dur']
+    onset = excerpt["onset"]
+    duration = excerpt["dur"]
     end_time = (onset + duration).max()
 
     # Lengthen bounds (increase duration)
     shortest_lengthened_dur = (duration + min_shift).clip(lower=min_duration)
-    longest_lengthened_dur = ((duration + (max_shift + 1))
-                              .clip(upper=(end_time + 1) - onset)
-                              .clip(upper=max_duration))
+    longest_lengthened_dur = (
+        (duration + (max_shift + 1))
+        .clip(upper=(end_time + 1) - onset)
+        .clip(upper=max_duration)
+    )
 
     # Shorten bounds (decrease duration)
     shortest_shortened_dur = (duration - max_shift).clip(lower=min_duration)
-    longest_shortened_dur = ((duration - (min_shift - 1))
-                             .clip(upper=max_duration))
+    longest_shortened_dur = (duration - (min_shift - 1)).clip(upper=max_duration)
 
     if align_dur:
         # Find ranges which contain a duration to align to
@@ -668,9 +730,14 @@ def offset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
         # This code checks, for every range, whether at least 1 duration
         # lies within that range.
         durs = pd.Series(duration.unique())
-        for i, (ssd, lsd, sld, lld) in enumerate(zip(
-            shortest_shortened_dur, longest_shortened_dur,
-            shortest_lengthened_dur, longest_lengthened_dur)):
+        for i, (ssd, lsd, sld, lld) in enumerate(
+            zip(
+                shortest_shortened_dur,
+                longest_shortened_dur,
+                shortest_lengthened_dur,
+                longest_lengthened_dur,
+            )
+        ):
             # Go through each range to check there is a valid duration
             shortened_valid = durs.between(ssd, lsd - 1).any()
             lengthened_valid = durs.between(sld, lld - 1).any()
@@ -682,13 +749,16 @@ def offset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
                 shortest_lengthened_dur.iloc[i] = lld
 
     # Find valid notes
-    valid = ((shortest_lengthened_dur < longest_lengthened_dur) |
-             (shortest_shortened_dur < longest_shortened_dur))
+    valid = (shortest_lengthened_dur < longest_lengthened_dur) | (
+        shortest_shortened_dur < longest_shortened_dur
+    )
     valid_notes = list(valid.index[valid])
 
     if not valid_notes:
-        warnings.warn('WARNING: No valid notes to offset shift. Returning '
-                      'None.', category=UserWarning)
+        warnings.warn(
+            "WARNING: No valid notes to offset shift. Returning " "None.",
+            category=UserWarning,
+        )
         return None
 
     # Sample a random note
@@ -701,8 +771,7 @@ def offset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
 
     # Sample new duration
     if align_dur:
-        valid_durs = (durs.between(ssd, lsd - 1) |
-                      durs.between(sld, lld - 1))
+        valid_durs = durs.between(ssd, lsd - 1) | durs.between(sld, lld - 1)
         valid_durs = list(durs[valid_durs])
         duration = choice(valid_durs)
     else:
@@ -710,17 +779,22 @@ def offset_shift(excerpt, min_shift=MIN_SHIFT_DEFAULT,
 
     degraded = excerpt.copy()
 
-    degraded.loc[index, 'dur'] = duration
+    degraded.loc[index, "dur"] = duration
 
     # Check if overlaps
     if overlaps(degraded, index):
         if tries == 1:
             warnings.warn(TRIES_WARN_MSG)
             return None
-        return offset_shift(excerpt, min_shift=min_shift,
-                            max_shift=max_shift, min_duration=min_duration,
-                            max_duration=max_duration - 1, # Changed above
-                            align_dur=align_dur, tries=tries - 1)
+        return offset_shift(
+            excerpt,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration - 1,  # Changed above
+            align_dur=align_dur,
+            tries=tries - 1,
+        )
 
     degraded = post_process(degraded)
     return degraded
@@ -752,8 +826,9 @@ def remove_note(excerpt, tries=TRIES_DEFAULT):
         the degradations cannot be performed.
     """
     if excerpt.shape[0] == 0:
-        warnings.warn('WARNING: No notes to remove. Returning None.',
-                      category=UserWarning)
+        warnings.warn(
+            "WARNING: No notes to remove. Returning None.", category=UserWarning
+        )
         return None
 
     degraded = pre_process(excerpt)
@@ -770,10 +845,16 @@ def remove_note(excerpt, tries=TRIES_DEFAULT):
 
 
 @set_random_seed
-def add_note(excerpt, min_pitch=MIN_PITCH_DEFAULT, max_pitch=MAX_PITCH_DEFAULT,
-             min_duration=MIN_DURATION_DEFAULT,
-             max_duration=MAX_DURATION_DEFAULT, align_pitch=False,
-             align_time=False, tries=TRIES_DEFAULT):
+def add_note(
+    excerpt,
+    min_pitch=MIN_PITCH_DEFAULT,
+    max_pitch=MAX_PITCH_DEFAULT,
+    min_duration=MIN_DURATION_DEFAULT,
+    max_duration=MAX_DURATION_DEFAULT,
+    align_pitch=False,
+    align_time=False,
+    tries=TRIES_DEFAULT,
+):
     """
     Add one note to the given excerpt.
 
@@ -832,15 +913,16 @@ def add_note(excerpt, min_pitch=MIN_PITCH_DEFAULT, max_pitch=MAX_PITCH_DEFAULT,
     if len(excerpt) == 1 and align_pitch and align_time:
         align_pitch = False
 
-    end_time = excerpt[['onset', 'dur']].sum(axis=1).max()
+    end_time = excerpt[["onset", "dur"]].sum(axis=1).max()
 
     if align_pitch:
-        pitch = excerpt['pitch'].between(min_pitch, max_pitch,
-                                         inclusive=True)
-        pitch = excerpt['pitch'][pitch].unique()
+        pitch = excerpt["pitch"].between(min_pitch, max_pitch, inclusive=True)
+        pitch = excerpt["pitch"][pitch].unique()
         if len(pitch) == 0:
-            warnings.warn("WARNING: No valid aligned pitch in given "
-                          "range.", category=UserWarning)
+            warnings.warn(
+                "WARNING: No valid aligned pitch in given " "range.",
+                category=UserWarning,
+            )
             return None
         pitch = choice(pitch)
     else:
@@ -848,48 +930,42 @@ def add_note(excerpt, min_pitch=MIN_PITCH_DEFAULT, max_pitch=MAX_PITCH_DEFAULT,
 
     # Find onset and duration
     if align_time:
-        if (min_duration > excerpt['dur'].max() or
-            max_duration < excerpt['dur'].min()):
-            warnings.warn("WARNING: No valid aligned duration in "
-                          "given range.", category=UserWarning)
+        if min_duration > excerpt["dur"].max() or max_duration < excerpt["dur"].min():
+            warnings.warn(
+                "WARNING: No valid aligned duration in " "given range.",
+                category=UserWarning,
+            )
             return None
 
-        durations = excerpt['dur'].between(min_duration, max_duration,
-                                           inclusive=True)
-        durations = excerpt['dur'][durations]
+        durations = excerpt["dur"].between(min_duration, max_duration, inclusive=True)
+        durations = excerpt["dur"][durations]
         min_dur = durations.min()
-        onset = excerpt['onset'].between(0, end_time - min_dur,
-                                         inclusive=True)
-        onset = choice(excerpt['onset'][onset].unique())
-        dur_unique = durations[durations.between(
-            min_dur, end_time - onset, inclusive=True)].unique()
+        onset = excerpt["onset"].between(0, end_time - min_dur, inclusive=True)
+        onset = choice(excerpt["onset"][onset].unique())
+        dur_unique = durations[
+            durations.between(min_dur, end_time - onset, inclusive=True)
+        ].unique()
         duration = choice(dur_unique)
     elif min_duration > end_time:
         onset = 0
         duration = min_duration
     elif excerpt.shape[0] == 0:
         onset = 0
-        duration = randint(min_duration,
-                           min(max_duration + 1, sys.maxsize))
+        duration = randint(min_duration, min(max_duration + 1, sys.maxsize))
     else:
-        onset = randint(excerpt['onset'].min(),
-                        end_time - min_duration)
-        duration = randint(min_duration,
-                           min(end_time - onset, max_duration + 1))
+        onset = randint(excerpt["onset"].min(), end_time - min_duration)
+        duration = randint(min_duration, min(end_time - onset, max_duration + 1))
 
     # Track is random one of existing tracks
     try:
-        track = choice(excerpt['track'].unique())
+        track = choice(excerpt["track"].unique())
     except KeyError:  # No track col in df
         track = 0
     except ValueError:  # Empty dataframe
         track = 0
 
     # Create and add note
-    note = {'pitch': pitch,
-            'onset': onset,
-            'dur': duration,
-            'track': track}
+    note = {"pitch": pitch, "onset": onset, "dur": duration, "track": track}
 
     degraded = excerpt.copy()
     degraded = degraded.append(note, ignore_index=True)
@@ -899,18 +975,25 @@ def add_note(excerpt, min_pitch=MIN_PITCH_DEFAULT, max_pitch=MAX_PITCH_DEFAULT,
         if tries == 1:
             warnings.warn(TRIES_WARN_MSG)
             return None
-        return add_note(excerpt, min_pitch=min_pitch, max_pitch=max_pitch,
-                        min_duration=min_duration, max_duration=max_duration,
-                        align_pitch=align_pitch, align_time=align_time,
-                        tries=tries - 1)
+        return add_note(
+            excerpt,
+            min_pitch=min_pitch,
+            max_pitch=max_pitch,
+            min_duration=min_duration,
+            max_duration=max_duration,
+            align_pitch=align_pitch,
+            align_time=align_time,
+            tries=tries - 1,
+        )
 
     degraded = post_process(degraded)
     return degraded
 
 
 @set_random_seed
-def split_note(excerpt, min_duration=MIN_DURATION_DEFAULT, num_splits=1,
-               tries=TRIES_DEFAULT):
+def split_note(
+    excerpt, min_duration=MIN_DURATION_DEFAULT, num_splits=1, tries=TRIES_DEFAULT
+):
     """
     Split one note from the excerpt into two or more notes of equal
     duration.
@@ -943,28 +1026,29 @@ def split_note(excerpt, min_duration=MIN_DURATION_DEFAULT, num_splits=1,
         the degradation cannot be performed.
     """
     if excerpt.shape[0] == 0:
-        warnings.warn('WARNING: No notes to split. Returning None.',
-                      category=UserWarning)
+        warnings.warn(
+            "WARNING: No notes to split. Returning None.", category=UserWarning
+        )
         return None
 
     excerpt = pre_process(excerpt)
 
     # Find all splitable notes
-    long_enough = excerpt['dur'] >= min_duration * (num_splits + 1)
+    long_enough = excerpt["dur"] >= min_duration * (num_splits + 1)
     valid_notes = list(long_enough.index[long_enough])
 
     if not valid_notes:
-        warnings.warn('WARNING: No valid notes to split. Returning '
-                      'None.', category=UserWarning)
+        warnings.warn(
+            "WARNING: No valid notes to split. Returning " "None.", category=UserWarning
+        )
         return None
 
     note_index = choice(valid_notes)
 
-    short_duration_float = (excerpt.loc[note_index, 'dur'] /
-                            (num_splits + 1))
-    pitch = excerpt.loc[note_index, 'pitch']
-    track = excerpt.loc[note_index, 'track']
-    this_onset = excerpt.loc[note_index, 'onset']
+    short_duration_float = excerpt.loc[note_index, "dur"] / (num_splits + 1)
+    pitch = excerpt.loc[note_index, "pitch"]
+    track = excerpt.loc[note_index, "track"]
+    this_onset = excerpt.loc[note_index, "onset"]
     next_onset = this_onset + short_duration_float
 
     # Add next notes (taking care to round correctly)
@@ -980,11 +1064,10 @@ def split_note(excerpt, min_duration=MIN_DURATION_DEFAULT, num_splits=1,
         durs[i] = int(round(next_onset)) - int(round(this_onset))
 
     degraded = excerpt.copy()
-    degraded.loc[note_index]['dur'] = int(round(short_duration_float))
-    new_df = pd.DataFrame({'onset': onsets,
-                           'track': tracks,
-                           'pitch': pitches,
-                           'dur': durs})
+    degraded.loc[note_index]["dur"] = int(round(short_duration_float))
+    new_df = pd.DataFrame(
+        {"onset": onsets, "track": tracks, "pitch": pitches, "dur": durs}
+    )
     degraded = degraded.append(new_df, ignore_index=True)
 
     # No need to check for overlap
@@ -993,8 +1076,13 @@ def split_note(excerpt, min_duration=MIN_DURATION_DEFAULT, num_splits=1,
 
 
 @set_random_seed
-def join_notes(excerpt, max_gap=MAX_GAP_DEFAULT, max_notes=20,
-               only_first=False, tries=TRIES_DEFAULT):
+def join_notes(
+    excerpt,
+    max_gap=MAX_GAP_DEFAULT,
+    max_notes=20,
+    only_first=False,
+    tries=TRIES_DEFAULT,
+):
     """
     Combine two notes of the same pitch and track into one.
 
@@ -1034,8 +1122,9 @@ def join_notes(excerpt, max_gap=MAX_GAP_DEFAULT, max_notes=20,
         the degradation cannot be performed.
     """
     if excerpt.shape[0] < 2:
-        warnings.warn('WARNING: No notes to join. Returning None.',
-                      category=UserWarning)
+        warnings.warn(
+            "WARNING: No notes to join. Returning None.", category=UserWarning
+        )
         return None
 
     excerpt = pre_process(excerpt, sort=True)
@@ -1043,14 +1132,14 @@ def join_notes(excerpt, max_gap=MAX_GAP_DEFAULT, max_notes=20,
     valid_starts = []
     valid_nexts = []
 
-    for _, track_df in excerpt.groupby('track'):
-        for _, pitch_df in track_df.groupby('pitch'):
+    for _, track_df in excerpt.groupby("track"):
+        for _, pitch_df in track_df.groupby("pitch"):
             if len(pitch_df) < 2:
                 continue
 
             # Get note gaps
-            onset = pitch_df['onset']
-            offset = onset + pitch_df['dur']
+            onset = pitch_df["onset"]
+            offset = onset + pitch_df["dur"]
             gap_after = onset.shift(-1) - offset
             gap_after.iloc[-1] = np.inf
             gap_before = gap_after.shift(1)
@@ -1068,7 +1157,7 @@ def join_notes(excerpt, max_gap=MAX_GAP_DEFAULT, max_notes=20,
             for start in valid_starts_this:
                 iloc = pitch_df.index.get_loc(start)
                 valid_next = []
-                for i, v in enumerate(valid_next_bool[iloc + 1:]):
+                for i, v in enumerate(valid_next_bool[iloc + 1 :]):
                     if i + 2 > max_notes or not v:
                         break
                     valid_next.append(valid_next_bool.index[iloc + 1 + i])
@@ -1076,8 +1165,9 @@ def join_notes(excerpt, max_gap=MAX_GAP_DEFAULT, max_notes=20,
             valid_starts.extend(valid_starts_this)
 
     if not valid_starts:
-        warnings.warn('WARNING: No valid notes to join. Returning '
-                      'None.', category=UserWarning)
+        warnings.warn(
+            "WARNING: No valid notes to join. Returning " "None.", category=UserWarning
+        )
         return None
 
     index = randint(len(valid_starts))
@@ -1088,9 +1178,11 @@ def join_notes(excerpt, max_gap=MAX_GAP_DEFAULT, max_notes=20,
     degraded = excerpt.copy()
 
     # Extend first note
-    degraded.loc[start]['dur'] = (degraded.loc[nexts[-1]]['onset'] +
-                                  degraded.loc[nexts[-1]]['dur'] -
-                                  degraded.loc[start]['onset'])
+    degraded.loc[start]["dur"] = (
+        degraded.loc[nexts[-1]]["onset"]
+        + degraded.loc[nexts[-1]]["dur"]
+        - degraded.loc[start]["onset"]
+    )
 
     # Drop all following notes note
     degraded = degraded.drop(nexts)
@@ -1101,14 +1193,14 @@ def join_notes(excerpt, max_gap=MAX_GAP_DEFAULT, max_notes=20,
 
 
 DEGRADATIONS = {
-    'pitch_shift': pitch_shift,
-    'time_shift': time_shift,
-    'onset_shift': onset_shift,
-    'offset_shift': offset_shift,
-    'remove_note': remove_note,
-    'add_note': add_note,
-    'split_note': split_note,
-    'join_notes': join_notes
+    "pitch_shift": pitch_shift,
+    "time_shift": time_shift,
+    "onset_shift": onset_shift,
+    "offset_shift": offset_shift,
+    "remove_note": remove_note,
+    "add_note": add_note,
+    "split_note": split_note,
+    "join_notes": join_notes,
 }
 
 

--- a/mdtk/degrader.py
+++ b/mdtk/degrader.py
@@ -22,23 +22,23 @@ class Degrader:
     ):
         """
         Create a new degrader with the given parameters.
-        
+
         Parameters
         ----------
         seed : int
             A random seed for numpy.
-            
+
         degradations : list(string)
             A list of the names of the degradations to use (and in what order
             to label them).
-            
+
         degradation_dist : list(float)
             A list of the probability of each degradation given in
             degradations. This list will be normalized to sum to 1.
-            
+
         clean_prop : float
             The proportion of degrade calls that should return clean excerpts.
-            
+
         config : string
             The path of a json config file (created by measure_errors.py).
             If given, degradations, degradation_dist, and clean_prop will
@@ -81,18 +81,18 @@ class Degrader:
     def degrade(self, note_df):
         """
         Degrade the given note_df.
-        
+
         Parameters
         ----------
         note_df : pd.DataFrame
             A note_df to degrade.
-            
+
         Returns
         -------
         degraded_df : pd.DataFrame
             A degraded version of the given note_df. If self.clean_prop > 0,
             this can be a copy of the given note_df.
-            
+
         deg_label : int
             The label of the degradation that was performed. 0 means none,
             and larger numbers mean the degradation

--- a/mdtk/degrader.py
+++ b/mdtk/degrader.py
@@ -1,18 +1,25 @@
 """A degrader object can be used to easily degrade data points on the fly
 according to some given parameters."""
 import json
-import numpy as np
 import warnings
+
+import numpy as np
 
 import mdtk.degradations as degs
 
-class Degrader():
+
+class Degrader:
     """A Degrade object can be used to easily degrade musical excerpts
     on the fly."""
-    
-    def __init__(self, seed=None, degradations=list(degs.DEGRADATIONS.keys()),
-                 degradation_dist=np.ones(len(degs.DEGRADATIONS)),
-                 clean_prop=1 / (len(degs.DEGRADATIONS) + 1), config=None):
+
+    def __init__(
+        self,
+        seed=None,
+        degradations=list(degs.DEGRADATIONS.keys()),
+        degradation_dist=np.ones(len(degs.DEGRADATIONS)),
+        clean_prop=1 / (len(degs.DEGRADATIONS) + 1),
+        config=None,
+    ):
         """
         Create a new degrader with the given parameters.
         
@@ -39,36 +46,38 @@ class Degrader():
         """
         if seed is not None:
             np.random.seed(seed)
-            
+
         # Load config
         if config is not None:
-            with open(config, 'r') as file:
+            with open(config, "r") as file:
                 config = json.load(file)
-                
-            if 'degradation_dist' in config:
-                degradation_dist = np.array(config['degradation_dist'])
+
+            if "degradation_dist" in config:
+                degradation_dist = np.array(config["degradation_dist"])
                 degradations = list(degs.DEGRADATIONS.keys())
-            if 'clean_prop' in config:
-                clean_prop = config['clean_prop']
-                
+            if "clean_prop" in config:
+                clean_prop = config["clean_prop"]
+
         # Check arg validity
         assert len(degradation_dist) == len(degradations), (
             "Given degradation_dist is not the same length as degradations:"
             f"\nlen({degradation_dist}) != len({degradations})"
         )
-        assert min(degradation_dist) >= 0, ("degradation_dist values must "
-                                            "not be negative.")
-        assert sum(degradation_dist) > 0, ("Some degradation_dist value "
-                                           "must be positive.")
-        assert 0 <= clean_prop <= 1, ("clean_prop must be between 0 and 1 "
-                                      "(inclusive).")
-        
+        assert min(degradation_dist) >= 0, (
+            "degradation_dist values must " "not be negative."
+        )
+        assert sum(degradation_dist) > 0, (
+            "Some degradation_dist value " "must be positive."
+        )
+        assert 0 <= clean_prop <= 1, (
+            "clean_prop must be between 0 and 1 " "(inclusive)."
+        )
+
         self.degradations = degradations
         self.degradation_dist = degradation_dist
         self.clean_prop = clean_prop
         self.failed = np.zeros(len(degradations))
-        
-        
+
     def degrade(self, note_df):
         """
         Degrade the given note_df.
@@ -91,39 +100,37 @@ class Degrader():
         """
         if self.clean_prop > 0 and np.random.rand() <= self.clean_prop:
             return note_df.copy(), 0
-        
+
         degraded_df = None
         this_deg_dist = self.degradation_dist.copy()
         this_failed = self.failed.copy()
-        
+
         # First, sample from failed degradations
         while np.any(this_failed > 0):
             # Select a degradation proportional to how many have failed
             deg_index = np.random.choice(
-                len(self.degradations),
-                p=this_failed / np.sum(this_failed)
+                len(self.degradations), p=this_failed / np.sum(this_failed)
             )
             deg_fun = degs.DEGRADATIONS[self.degradations[deg_index]]
-            
+
             # Try to degrade
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 degraded_df = deg_fun(note_df)
-                
+
             # Check for success!
             if degraded_df is not None:
                 self.failed[deg_index] -= 1
                 return degraded_df, deg_index + 1
-            
+
             # Degradation failed -- 0 out this deg and continue
             this_failed[deg_index] = 0
-            
+
         # No degradations have remaining failures. Draw from standard dist
         while np.any(this_deg_dist > 0):
             # Select a degradation proportional to the distribution
             deg_index = np.random.choice(
-                len(self.degradations),
-                p=this_deg_dist / np.sum(this_deg_dist)
+                len(self.degradations), p=this_deg_dist / np.sum(this_deg_dist)
             )
             # This deg would have already failed in the above loop.
             # But we want to sample it and count it as another failure.
@@ -131,19 +138,18 @@ class Degrader():
                 self.failed[deg_index] += 1
                 continue
             deg_fun = degs.DEGRADATIONS[self.degradations[deg_index]]
-            
+
             # Try to degrade
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 degraded_df = deg_fun(note_df)
-                
+
             # Check for success!
             if degraded_df is not None:
                 return degraded_df, deg_index + 1
-            
+
             # Degradation failed -- add 1 to failure and continue
             self.failed[deg_index] += 1
-            
+
         # Here, all degradations (with dist > 0) failed
         return note_df.copy(), 0
-    

--- a/mdtk/df_utils.py
+++ b/mdtk/df_utils.py
@@ -2,11 +2,10 @@
 """
 import itertools
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
-
-NOTE_DF_SORT_ORDER = ['onset', 'track', 'pitch', 'dur']
+NOTE_DF_SORT_ORDER = ["onset", "track", "pitch", "dur"]
 
 
 def clean_df(df, single_track=False, non_overlapping=False):
@@ -38,7 +37,7 @@ def clean_df(df, single_track=False, non_overlapping=False):
         A cleaned version of the given df, as described.
     """
     if single_track:
-        df = df.assign(track=0) # Assign creates a copy so input is not changed
+        df = df.assign(track=0)  # Assign creates a copy so input is not changed
 
     if non_overlapping:
         df = remove_pitch_overlaps(df)
@@ -76,34 +75,39 @@ def remove_pitch_overlaps(df):
     df = df.sort_values(by=NOTE_DF_SORT_ORDER).reset_index(drop=True)
 
     # We'll work with offsets here, and fix dur at the end
-    df['offset'] = df['onset'] + df['dur']
-    offset = df['offset'].copy()
+    df["offset"] = df["onset"] + df["dur"]
+    offset = df["offset"].copy()
 
-    for track, track_df in df.groupby('track'):
+    for track, track_df in df.groupby("track"):
         if len(track_df) < 2:
             continue
 
-        for pitch, pitch_df in track_df.groupby('pitch'):
+        for pitch, pitch_df in track_df.groupby("pitch"):
             if len(pitch_df) < 2:
                 continue
 
             # Each note's offset will go to the latest offset so far,
             # or be cut at the next note's onset
-            cum_max = pitch_df['offset'].cummax()
+            cum_max = pitch_df["offset"].cummax()
             offset.loc[pitch_df.index] = cum_max.clip(
-                upper=pitch_df['onset'].shift(-1, fill_value=cum_max.iloc[-1])
+                upper=pitch_df["onset"].shift(-1, fill_value=cum_max.iloc[-1])
             )
 
     # Fix dur based on offsets and remove offset column
-    df['dur'] = offset - df['onset']
-    df = df.loc[df['dur'] != 0, ['onset', 'track', 'pitch', 'dur']]
+    df["dur"] = offset - df["onset"]
+    df = df.loc[df["dur"] != 0, ["onset", "track", "pitch", "dur"]]
     df = df.reset_index(drop=True)
 
     return df
 
 
-def get_random_excerpt(note_df, min_notes=10, excerpt_length=5000,
-                       first_onset_range=(0, 200), iterations=10):
+def get_random_excerpt(
+    note_df,
+    min_notes=10,
+    excerpt_length=5000,
+    first_onset_range=(0, 200),
+    iterations=10,
+):
     """
     Take a random excerpt from the given note_df, using np.random. The excerpt
     is created as follows:
@@ -150,12 +154,13 @@ def get_random_excerpt(note_df, min_notes=10, excerpt_length=5000,
         return None
 
     for _ in range(iterations):
-        note_index = np.random.choice(list(note_df.index.values)
-                                      [:-min_notes])
-        first_onset = note_df.loc[note_index]['onset']
+        note_index = np.random.choice(list(note_df.index.values)[:-min_notes])
+        first_onset = note_df.loc[note_index]["onset"]
         excerpt = pd.DataFrame(
-            note_df.loc[note_df['onset'].between(
-                first_onset, first_onset + excerpt_length)])
+            note_df.loc[
+                note_df["onset"].between(first_onset, first_onset + excerpt_length)
+            ]
+        )
 
         # Check for validity of excerpt
         if len(excerpt) < min_notes:
@@ -167,6 +172,6 @@ def get_random_excerpt(note_df, min_notes=10, excerpt_length=5000,
         return None
 
     onset_shift = np.random.randint(first_onset_range[0], first_onset_range[1])
-    excerpt['onset'] += onset_shift - first_onset
+    excerpt["onset"] += onset_shift - first_onset
     excerpt = excerpt.reset_index(drop=True)
     return excerpt

--- a/mdtk/df_utils.py
+++ b/mdtk/df_utils.py
@@ -1,7 +1,4 @@
-"""Utility functions and fields for dealing with note_dfs in mdtk format.
-"""
-import itertools
-
+"""Utility functions and fields for dealing with note_dfs in mdtk format."""
 import numpy as np
 import pandas as pd
 

--- a/mdtk/downloaders.py
+++ b/mdtk/downloaders.py
@@ -7,55 +7,54 @@ new class which extends DataDownloader, and write an accompanying test in
 import os
 import shutil
 from glob import glob
+
 from tqdm import tqdm
-from mdtk.filesystem_utils import (download_file, make_directory, extract_zip,
-                                   copy_file)
 
+from mdtk.filesystem_utils import copy_file, download_file, extract_zip, make_directory
 
-USER_HOME = os.path.expanduser('~')
-DEFAULT_CACHE_PATH = os.path.join(USER_HOME, '.mdtk_cache')
-DATASETS = ['PPDDSep2018Monophonic', 'PPDDSep2018Polyphonic', 'PianoMidi']
-
+USER_HOME = os.path.expanduser("~")
+DEFAULT_CACHE_PATH = os.path.join(USER_HOME, ".mdtk_cache")
+DATASETS = ["PPDDSep2018Monophonic", "PPDDSep2018Polyphonic", "PianoMidi"]
 
 
 # Classes =====================================================================
 class DataDownloader:
     """Base class for data downloaders"""
+
     def __init__(self, cache_path=DEFAULT_CACHE_PATH):
         self.dataset_name = self.__class__.__name__
         self.download_urls = []
         self.midi_paths = []
         self.csv_paths = []
-#        self.downloaded = False
-#        self.extracted = False
+        #        self.downloaded = False
+        #        self.extracted = False
         self.cache_path = cache_path
         self.midi_output_path = None
         self.csv_output_path = None
 
-
     def clear_cache(self):
         path = os.path.join(self.cache_path, self.dataset_name)
-#        warnings.warn(f'Deleting existing directory: {path}')
+        #        warnings.warn(f'Deleting existing directory: {path}')
         shutil.rmtree(path)
-#        self.downloaded = False
-#        self.extracted = False
 
+    #        self.downloaded = False
+    #        self.extracted = False
 
-    def download_midi(self, output_path, cache_path=None, overwrite=None,
-                      verbose=False):
+    def download_midi(
+        self, output_path, cache_path=None, overwrite=None, verbose=False
+    ):
         """Downloads the MIDI data to output_path"""
         cache_path = self.cache_path if cache_path is None else cache_path
-        raise NotImplementedError('In order to download MIDI, you must '
-                                  'implement the download_midi method.')
+        raise NotImplementedError(
+            "In order to download MIDI, you must " "implement the download_midi method."
+        )
 
-
-    def download_csv(self, output_path, cache_path=None, overwrite=None,
-                     verbose=False):
+    def download_csv(self, output_path, cache_path=None, overwrite=None, verbose=False):
         """Downloads the csv data to output_path"""
         cache_path = self.cache_path if cache_path is None else cache_path
-        raise NotImplementedError('In order to download CSV, you must '
-                                  'implement the download_csv method.')
-
+        raise NotImplementedError(
+            "In order to download CSV, you must " "implement the download_csv method."
+        )
 
 
 class PPDDSep2018Monophonic(DataDownloader):
@@ -65,24 +64,29 @@ class PPDDSep2018Monophonic(DataDownloader):
     ----------
     https://www.music-ir.org/mirex/wiki/2019:Patterns_for_Prediction
     """
-    def __init__(self, cache_path=DEFAULT_CACHE_PATH,
-                 sizes=['small', 'medium', 'large'], clean=False):
-        super().__init__(cache_path = cache_path)
+
+    def __init__(
+        self,
+        cache_path=DEFAULT_CACHE_PATH,
+        sizes=["small", "medium", "large"],
+        clean=False,
+    ):
+        super().__init__(cache_path=cache_path)
         self.dataset_name = self.__class__.__name__
-        self.base_url = ('http://tomcollinsresearch.net/research/data/mirex/'
-                         'ppdd/ppdd-sep2018')
+        self.base_url = (
+            "http://tomcollinsresearch.net/research/data/mirex/" "ppdd/ppdd-sep2018"
+        )
         self.download_urls = [
-                f'{self.base_url}/PPDD-Sep2018_sym_mono_{size}.zip'
-                for size in sizes
-            ]
+            f"{self.base_url}/PPDD-Sep2018_sym_mono_{size}.zip" for size in sizes
+        ]
         # location of midi files relative to each unzipped directory
-#        self.midi_paths = ['prime_midi', 'cont_true_midi']
-        self.midi_paths = ['prime_midi']
+        #        self.midi_paths = ['prime_midi', 'cont_true_midi']
+        self.midi_paths = ["prime_midi"]
         self.clean = clean
 
-
-    def download_midi(self, output_path, cache_path=None, overwrite=None,
-                      verbose=False):
+    def download_midi(
+        self, output_path, cache_path=None, overwrite=None, verbose=False
+    ):
         # Cleaning paths, and setting up cache dir ============================
         cache_path = self.cache_path if cache_path is None else cache_path
         base_path = os.path.join(cache_path, self.dataset_name)
@@ -92,7 +96,7 @@ class PPDDSep2018Monophonic(DataDownloader):
         # Downloading the data ================================================
         zip_paths = []
         for url in self.download_urls:
-            filename = url.split('/')[-1]
+            filename = url.split("/")[-1]
             zip_path = os.path.join(base_path, filename)
             zip_paths += [zip_path]
             download_file(url, zip_path, overwrite=overwrite, verbose=verbose)
@@ -100,24 +104,24 @@ class PPDDSep2018Monophonic(DataDownloader):
         # Extracting data from zip files ======================================
         extracted_paths = []
         for zip_path in zip_paths:
-            path = extract_zip(zip_path, base_path, overwrite=overwrite,
-                               verbose=verbose)
+            path = extract_zip(
+                zip_path, base_path, overwrite=overwrite, verbose=verbose
+            )
             extracted_paths += [path]
 
         # Copying midi files to output_path ===================================
         for path in extracted_paths:
-            midi_paths = [glob(os.path.join(path, mp, '*.mid')) for mp
-                          in self.midi_paths]
+            midi_paths = [
+                glob(os.path.join(path, mp, "*.mid")) for mp in self.midi_paths
+            ]
             midi_paths = [pp for sublist in midi_paths for pp in sublist]
-            for filepath in tqdm(midi_paths,
-                                 desc=f"Copying midi to {output_path}"):
+            for filepath in tqdm(midi_paths, desc=f"Copying midi to {output_path}"):
                 copy_file(filepath, output_path)
         self.midi_output_path = output_path
 
         # Delete cache ========================================================
         if self.clean:
             self.clear_cache()
-
 
 
 class PPDDSep2018Polyphonic(PPDDSep2018Monophonic):
@@ -127,45 +131,79 @@ class PPDDSep2018Polyphonic(PPDDSep2018Monophonic):
     ----------
     https://www.music-ir.org/mirex/wiki/2019:Patterns_for_Prediction
     """
-    def __init__(self, cache_path=DEFAULT_CACHE_PATH,
-                 sizes=['small', 'medium', 'large'], clean=False):
+
+    def __init__(
+        self,
+        cache_path=DEFAULT_CACHE_PATH,
+        sizes=["small", "medium", "large"],
+        clean=False,
+    ):
         super().__init__(cache_path=cache_path, sizes=sizes, clean=clean)
         self.download_urls = [
-                f'{self.base_url}/PPDD-Sep2018_sym_poly_{size}.zip'
-                for size in sizes
-            ]
-
+            f"{self.base_url}/PPDD-Sep2018_sym_poly_{size}.zip" for size in sizes
+        ]
 
 
 class PianoMidi(DataDownloader):
     """
     piano-midi dataset from http://www.piano-midi.de/
     """
-    def __init__(self, cache_path=DEFAULT_CACHE_PATH, clean=False,
-                 composers=['albeniz', 'bach', 'balakir', 'beeth',
-                            'borodin', 'brahms', 'burgm', 'chopin',
-                            'clementi', 'debussy', 'godowsky', 'granados',
-                            'grieg', 'haydn', 'liszt', 'mendelssohn',
-                            'moszkowski', 'mozart', 'muss', 'rachmaninov',
-                            'ravel', 'schubert', 'schumann', 'sinding',
-                            'tchai']):
-        super().__init__(cache_path = cache_path)
+
+    def __init__(
+        self,
+        cache_path=DEFAULT_CACHE_PATH,
+        clean=False,
+        composers=[
+            "albeniz",
+            "bach",
+            "balakir",
+            "beeth",
+            "borodin",
+            "brahms",
+            "burgm",
+            "chopin",
+            "clementi",
+            "debussy",
+            "godowsky",
+            "granados",
+            "grieg",
+            "haydn",
+            "liszt",
+            "mendelssohn",
+            "moszkowski",
+            "mozart",
+            "muss",
+            "rachmaninov",
+            "ravel",
+            "schubert",
+            "schumann",
+            "sinding",
+            "tchai",
+        ],
+    ):
+        super().__init__(cache_path=cache_path)
         self.dataset_name = self.__class__.__name__
-        base_url = 'http://www.piano-midi.de/zip'
+        base_url = "http://www.piano-midi.de/zip"
         self.download_urls = []
 
         # Some composers don't have zip files
-        non_zips = ['clementi', 'godowsky', 'moszkowski', 'rachmaninov',
-                    'ravel', 'sinding']
+        non_zips = [
+            "clementi",
+            "godowsky",
+            "moszkowski",
+            "rachmaninov",
+            "ravel",
+            "sinding",
+        ]
 
         for composer in composers:
             if composer in non_zips:
-                self.download_urls.extend(self.get_composer_urls(
-                    'http://www.piano-midi.de/midis', composer))
+                self.download_urls.extend(
+                    self.get_composer_urls("http://www.piano-midi.de/midis", composer)
+                )
             else:
-                self.download_urls.append(f'{base_url}/{composer}.zip')
+                self.download_urls.append(f"{base_url}/{composer}.zip")
         self.clean = clean
-
 
     def get_composer_urls(self, base_url, composer):
         """
@@ -173,52 +211,59 @@ class PianoMidi(DataDownloader):
         each MIDI file must be downloaded individually. This function gets
         the urls for those MIDI files.
         """
-        sub_dir = composer if composer != 'rachmaninov' else 'rachmaninow'
+        sub_dir = composer if composer != "rachmaninov" else "rachmaninow"
 
         midi_names = []
-        if composer == 'clementi':
-            prefix = 'clementi_opus36'
+        if composer == "clementi":
+            prefix = "clementi_opus36"
             for number in range(1, 7):
                 for movement in range(1, 4):
                     if number == 6 and movement == 3:
                         continue
-                    midi_names.append(f'{prefix}_{number}_{movement}')
+                    midi_names.append(f"{prefix}_{number}_{movement}")
 
-        elif composer == 'godowsky':
-            midi_names = ['god_chpn_op10_e01', 'god_alb_esp2']
+        elif composer == "godowsky":
+            midi_names = ["god_chpn_op10_e01", "god_alb_esp2"]
 
-        elif composer == 'moszkowski':
-            midi_names = ['mos_op36_6']
+        elif composer == "moszkowski":
+            midi_names = ["mos_op36_6"]
 
-        elif composer == 'rachmaninov':
-            prefix = 'rac_op'
+        elif composer == "rachmaninov":
+            prefix = "rac_op"
             opus = [3, 23, 32, 33]
             numbers = [[2], [2, 3, 5, 7], [1, 13], [5, 6, 8]]
             for op, nos in zip(opus, numbers):
                 for no in nos:
-                    midi_names.append(f'{prefix}{op}_{no}')
+                    midi_names.append(f"{prefix}{op}_{no}")
 
-        elif composer == 'ravel':
-            midi_names = ['rav_eau', 'ravel_miroirs_1', 'rav_ondi', 'rav_gib',
-                          'rav_scarbo']
+        elif composer == "ravel":
+            midi_names = [
+                "rav_eau",
+                "ravel_miroirs_1",
+                "rav_ondi",
+                "rav_gib",
+                "rav_scarbo",
+            ]
 
-        elif composer == 'sinding':
-            midi_names = ['fruehlingsrauschen']
+        elif composer == "sinding":
+            midi_names = ["fruehlingsrauschen"]
 
         else:
-            raise NotImplementedError(f'Downloading of composer {composer} '
-                                      'not yet implemented in PianoMidi.')
+            raise NotImplementedError(
+                f"Downloading of composer {composer} "
+                "not yet implemented in PianoMidi."
+            )
 
-        urls = [f'{base_url}/{sub_dir}/{midi}.mid' for midi in midi_names]
+        urls = [f"{base_url}/{sub_dir}/{midi}.mid" for midi in midi_names]
         return urls
 
-
-    def download_midi(self, output_path, cache_path=None, overwrite=None,
-                      verbose=False):
+    def download_midi(
+        self, output_path, cache_path=None, overwrite=None, verbose=False
+    ):
         # Cleaning paths, and setting up cache dir ============================
         cache_path = self.cache_path if cache_path is None else cache_path
         base_path = os.path.join(cache_path, self.dataset_name)
-        midi_dl_path = os.path.join(base_path, 'midis')
+        midi_dl_path = os.path.join(base_path, "midis")
         make_directory(base_path, overwrite, verbose=verbose)
         make_directory(output_path, overwrite, verbose=verbose)
         make_directory(midi_dl_path, overwrite, verbose=verbose)
@@ -226,38 +271,33 @@ class PianoMidi(DataDownloader):
         # Downloading the data ================================================
         zip_paths = []
         for url in self.download_urls:
-            filename = url.split('/')[-1]
-            if filename.endswith('.zip'):
+            filename = url.split("/")[-1]
+            if filename.endswith(".zip"):
                 path = os.path.join(base_path, filename)
                 zip_paths += [path]
             else:
                 path = os.path.join(midi_dl_path, filename)
             download_file(url, path, overwrite=overwrite, verbose=verbose)
-#            I removed this sleep because it makes things very slow in the case
-#            of things already having been downloaded, is it really required?
-#            time.sleep(1) # Don't want to overload the server
+        #            I removed this sleep because it makes things very slow in the case
+        #            of things already having been downloaded, is it really required?
+        #            time.sleep(1) # Don't want to overload the server
 
         # Extracting data from zip files ======================================
         extracted_paths = [midi_dl_path]
         for zip_path in zip_paths:
             zip_name = os.path.splitext(os.path.basename(zip_path))[0]
             out_path = os.path.join(base_path, zip_name)
-            extract_zip(zip_path, out_path, overwrite=overwrite,
-                        verbose=verbose)
+            extract_zip(zip_path, out_path, overwrite=overwrite, verbose=verbose)
             extracted_paths += [out_path]
 
         # Copying midi files to output_path ===================================
-        for filepath in tqdm([p for path in extracted_paths for p 
-                              in glob(os.path.join(path, '*.mid'))],
-                             desc=f"Copying midi to {output_path}: "):
+        for filepath in tqdm(
+            [p for path in extracted_paths for p in glob(os.path.join(path, "*.mid"))],
+            desc=f"Copying midi to {output_path}: ",
+        ):
             copy_file(filepath, output_path)
         self.midi_output_path = output_path
 
         # Delete cache ========================================================
         if self.clean:
             self.clear_cache()
-
-
-
-
-

--- a/mdtk/eval.py
+++ b/mdtk/eval.py
@@ -1,6 +1,6 @@
 """Module containing methods to evaluate performance on Error Correction"""
-from mir_eval.transcription import precision_recall_f1_overlap
 import numpy as np
+from mir_eval.transcription import precision_recall_f1_overlap
 
 
 def ErrorDetection(outputs, targets):
@@ -123,15 +123,17 @@ def ErrorCorrection(corrected_df, degraded_df, clean_df, time_increment=40):
         The average of the degraded_df's framewise F-measure and its notewise
         F-measure, when compared to the clean_df.
     """
-    corrected_fm = get_combined_fmeasure(corrected_df, clean_df,
-                                         time_increment=time_increment)
+    corrected_fm = get_combined_fmeasure(
+        corrected_df, clean_df, time_increment=time_increment
+    )
 
     # Quick exit on border cases
     if corrected_fm == 0 or corrected_fm == 1 or degraded_df.equals(clean_df):
         return corrected_fm, corrected_fm
 
-    degraded_fm = get_combined_fmeasure(degraded_df, clean_df,
-                                        time_increment=time_increment)
+    degraded_fm = get_combined_fmeasure(
+        degraded_df, clean_df, time_increment=time_increment
+    )
 
     if corrected_fm < degraded_fm:
         h = 0.5 * corrected_fm / degraded_fm
@@ -139,6 +141,8 @@ def ErrorCorrection(corrected_df, degraded_df, clean_df, time_increment=40):
         h = 1 - 0.5 * (1 - corrected_fm) / (1 - degraded_fm)
 
     return h, corrected_fm
+
+
 helpfulness = ErrorCorrection
 
 
@@ -189,31 +193,34 @@ def get_framewise_f_measure(df, gt_df, time_increment=40):
     f_measure : float
         The framewise f_measure of the given dataframe.
     """
-    gt_quant_df = gt_df.loc[:, ['pitch']]
-    gt_quant_df['onset'] = (gt_df['onset'] / time_increment).round().astype(int)
-    gt_quant_df['offset'] = (((gt_df['onset'] + gt_df['dur']) / time_increment)
-                             .round().astype(int)
-                             .clip(lower=gt_quant_df['onset'] + 1))
+    gt_quant_df = gt_df.loc[:, ["pitch"]]
+    gt_quant_df["onset"] = (gt_df["onset"] / time_increment).round().astype(int)
+    gt_quant_df["offset"] = (
+        ((gt_df["onset"] + gt_df["dur"]) / time_increment)
+        .round()
+        .astype(int)
+        .clip(lower=gt_quant_df["onset"] + 1)
+    )
 
-    quant_df = df.loc[:, ['pitch']]
-    quant_df['onset'] = (df['onset'] / time_increment).round().astype(int)
-    quant_df['offset'] = (((df['onset'] + df['dur']) / time_increment)
-                          .round().astype(int).clip(lower=quant_df['onset'] + 1))
+    quant_df = df.loc[:, ["pitch"]]
+    quant_df["onset"] = (df["onset"] / time_increment).round().astype(int)
+    quant_df["offset"] = (
+        ((df["onset"] + df["dur"]) / time_increment)
+        .round()
+        .astype(int)
+        .clip(lower=quant_df["onset"] + 1)
+    )
 
     # Create piano rolls
-    length = int(max(1,
-                     quant_df['offset'].max(),
-                     gt_quant_df['offset'].max()))
-    max_pitch = int(max(1,
-                        quant_df['pitch'].max(),
-                        gt_quant_df['pitch'].max()) + 1)
+    length = int(max(1, quant_df["offset"].max(), gt_quant_df["offset"].max()))
+    max_pitch = int(max(1, quant_df["pitch"].max(), gt_quant_df["pitch"].max()) + 1)
     pr = np.zeros((length, max_pitch))
     for _, note in quant_df.iterrows():
-        pr[note.onset:note.offset, note.pitch] = 1
+        pr[note.onset : note.offset, note.pitch] = 1
 
     gt_pr = np.zeros((length, max_pitch))
     for _, note in gt_quant_df.iterrows():
-        gt_pr[note.onset:note.offset, note.pitch] = 1
+        gt_pr[note.onset : note.offset, note.pitch] = 1
 
     tp = np.sum(np.logical_and(gt_pr, pr))
     fp = np.sum(pr) - tp
@@ -244,16 +251,21 @@ def get_notewise_f_measure(df, gt_df):
     f_measure : float
         The notewise f_measure of the given dataframe, using mir_eval.
     """
-    gt_pitches = np.array(gt_df['pitch'])
-    gt_times = np.vstack((gt_df['onset'], gt_df['onset'] + gt_df['dur'])).T
+    gt_pitches = np.array(gt_df["pitch"])
+    gt_times = np.vstack((gt_df["onset"], gt_df["onset"] + gt_df["dur"])).T
 
-    pitches = np.array(df['pitch'])
-    times = np.vstack((df['onset'], df['onset'] + df['dur'])).T
+    pitches = np.array(df["pitch"])
+    times = np.vstack((df["onset"], df["onset"] + df["dur"])).T
 
-    _, _, fm, _ = precision_recall_f1_overlap(gt_times, gt_pitches, times,
-                                              pitches, onset_tolerance=50,
-                                              pitch_tolerance=0,
-                                              offset_ratio=None)
+    _, _, fm, _ = precision_recall_f1_overlap(
+        gt_times,
+        gt_pitches,
+        times,
+        pitches,
+        onset_tolerance=50,
+        pitch_tolerance=0,
+        offset_ratio=None,
+    )
     return fm
 
 

--- a/mdtk/fileio.py
+++ b/mdtk/fileio.py
@@ -143,7 +143,7 @@ def midi_to_df(midi_path, single_track=False, non_overlapping=False):
     """
     try:
         midi = pretty_midi.PrettyMIDI(midi_path)
-    except:
+    except Exception:
         warnings.warn(f"Error parsing midi file {midi_path}. Skipping.")
         return None
 

--- a/mdtk/filesystem_utils.py
+++ b/mdtk/filesystem_utils.py
@@ -1,35 +1,36 @@
-"""Utility functions for file manipulation""" 
+"""Utility functions for file manipulation"""
 import os
-import sys
 import shutil
-import urllib.request
+import sys
 import urllib.error
+import urllib.request
 import warnings
 import zipfile
 
 
-
 def download_file(source, dest, verbose=False, overwrite=None):
-        """Get a file from a url and save it locally"""
-        if verbose:
-            print(f'Downloading {source} to {dest}')
-        if os.path.exists(dest):
-            if overwrite is None:
-                if verbose:
-                    warnings.warn(f'WARNING: {dest} already exists, not '
-                                  'downloading', category=UserWarning)
-                return
-            if not overwrite:
-                raise OSError(f'{dest} already exists')
-        try:
-            urllib.request.urlretrieve(source, dest)
-        except urllib.error.HTTPError as e:
-            print(f'Url {source} does not exist', file=sys.stderr)
-            raise e
+    """Get a file from a url and save it locally"""
+    if verbose:
+        print(f"Downloading {source} to {dest}")
+    if os.path.exists(dest):
+        if overwrite is None:
+            if verbose:
+                warnings.warn(
+                    f"WARNING: {dest} already exists, not " "downloading",
+                    category=UserWarning,
+                )
+            return
+        if not overwrite:
+            raise OSError(f"{dest} already exists")
+    try:
+        urllib.request.urlretrieve(source, dest)
+    except urllib.error.HTTPError as e:
+        print(f"Url {source} does not exist", file=sys.stderr)
+        raise e
 
 
 def make_directory(path, overwrite=None, verbose=False):
-        """Convenience function to create a directory and handle cases where
+    """Convenience function to create a directory and handle cases where
         it already exists.
         
         Args
@@ -43,52 +44,57 @@ def make_directory(path, overwrite=None, verbose=False):
         verbose: bool
             Verbosity of printing
         """
-        if verbose:
-            print(f'Making directory at {path}')
-        
-        mkdir = os.makedirs
-        try:
+    if verbose:
+        print(f"Making directory at {path}")
+
+    mkdir = os.makedirs
+    try:
+        mkdir(path)
+    except FileExistsError as e:
+        if overwrite is True:
+            if verbose:
+                print(f"Deleting existing directory: {path}")
+            shutil.rmtree(path)
             mkdir(path)
-        except FileExistsError as e:
-            if overwrite is True:
-                if verbose:
-                    print(f'Deleting existing directory: {path}')
-                shutil.rmtree(path)
-                mkdir(path)
-            elif overwrite is None:
-                if verbose:
-                    warnings.warn(f'WARNING: {path} already exists, writing '
-                                  'files only if they do not already exist.',
-                                  category=UserWarning)
-            elif overwrite is False:
-                raise e
-            else:
-                raise ValueError('overwrite should be boolean or None, not '
-                                 f'"{overwrite}"')
+        elif overwrite is None:
+            if verbose:
+                warnings.warn(
+                    f"WARNING: {path} already exists, writing "
+                    "files only if they do not already exist.",
+                    category=UserWarning,
+                )
+        elif overwrite is False:
+            raise e
+        else:
+            raise ValueError(
+                "overwrite should be boolean or None, not " f'"{overwrite}"'
+            )
 
 
 def extract_zip(zip_path, out_path, overwrite=None, verbose=False):
     """Convenience function to extract zip file to out_path."""
     if verbose:
-        print(f'Extracting {zip_path} to {out_path}')
+        print(f"Extracting {zip_path} to {out_path}")
     dirname = os.path.splitext(os.path.basename(zip_path))[0]
     extracted_path = os.path.join(out_path, dirname)
-    if os.path.exists(extracted_path):     
+    if os.path.exists(extracted_path):
         if overwrite is True:
             if verbose:
-                warnings.warn('Deleting existing directory: '
-                              f'{extracted_path}')
+                warnings.warn("Deleting existing directory: " f"{extracted_path}")
             shutil.rmtree(extracted_path)
         elif overwrite is None:
             if verbose:
-                warnings.warn(f'{extracted_path} already exists. Assuming '
-                              'this zip has already been extracted, not '
-                              'extracting.', category=UserWarning)
+                warnings.warn(
+                    f"{extracted_path} already exists. Assuming "
+                    "this zip has already been extracted, not "
+                    "extracting.",
+                    category=UserWarning,
+                )
             return extracted_path
         elif overwrite is False:
-            raise FileExistsError(f'{extracted_path} already exists')
-    
-    with zipfile.ZipFile(zip_path, 'r') as zz:
+            raise FileExistsError(f"{extracted_path} already exists")
+
+    with zipfile.ZipFile(zip_path, "r") as zz:
         zz.extractall(path=out_path)
     return extracted_path
 
@@ -96,12 +102,12 @@ def extract_zip(zip_path, out_path, overwrite=None, verbose=False):
 def copy_file(filepath, output_path, overwrite=None, mkdir=False):
     """Convenience function to copy a file from filepath to output_path."""
     path = os.path.join(output_path, os.path.basename(filepath))
-    if os.path.exists(path):     
+    if os.path.exists(path):
         if overwrite is True:
             shutil.copy(filepath, output_path)
         elif overwrite is None:
             return
         elif overwrite is False:
-            raise FileExistsError(f'{path} already exists')
+            raise FileExistsError(f"{path} already exists")
     else:
         shutil.copy(filepath, output_path)

--- a/mdtk/filesystem_utils.py
+++ b/mdtk/filesystem_utils.py
@@ -32,13 +32,13 @@ def download_file(source, dest, verbose=False, overwrite=None):
 def make_directory(path, overwrite=None, verbose=False):
     """Convenience function to create a directory and handle cases where
         it already exists.
-        
+
         Args
         ----
         path: str
             The path of the directory to create
         overwrite: boolean or None
-            If the path already exists, if overwrite is: True - delete the 
+            If the path already exists, if overwrite is: True - delete the
             existing path; False - return error; None - leave the existing
             path as it is and throw a warning
         verbose: bool

--- a/mdtk/formatters.py
+++ b/mdtk/formatters.py
@@ -1,19 +1,20 @@
 """Tools to convert from the default acme csvs and metadata.csv to specific
 formats easy for the provided pytorch DataLoaders"""
-import tqdm
-import pandas as pd
-import numpy as np
 import os
 import warnings
 
+import numpy as np
+import pandas as pd
+import tqdm
+
+from mdtk.degradations import MAX_PITCH_DEFAULT, MIN_PITCH_DEFAULT
 from mdtk.df_utils import NOTE_DF_SORT_ORDER
-from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
+
 
 # Convenience function...
 def diff_pd(df1, df2):
     """Identify differences between two pandas DataFrames"""
-    assert (df1.columns == df2.columns).all(), \
-        "DataFrame column names are different"
+    assert (df1.columns == df2.columns).all(), "DataFrame column names are different"
     if any(df1.dtypes != df2.dtypes):
         "Data Types are different, trying to convert"
         df2 = df2.astype(df1.dtypes)
@@ -24,30 +25,38 @@ def diff_pd(df1, df2):
         diff_mask = (df1 != df2) & ~(df1.isnull() & df2.isnull())
         ne_stacked = diff_mask.stack()
         changed = ne_stacked[ne_stacked]
-        changed.index.names = ['id', 'col']
+        changed.index.names = ["id", "col"]
         difference_locations = np.where(diff_mask)
         changed_from = df1.values[difference_locations]
         changed_to = df2.values[difference_locations]
-        return pd.DataFrame({'from': changed_from, 'to': changed_to},
-                            index=changed.index)
+        return pd.DataFrame(
+            {"from": changed_from, "to": changed_to}, index=changed.index
+        )
 
 
 class CommandVocab(object):
-    def __init__(self, min_pitch=MIN_PITCH_DEFAULT,
-                 max_pitch=MAX_PITCH_DEFAULT,
-                 time_increment=40,
-                 max_time_shift=4000,
-                 specials=["<pad>", "<unk>", "<eos>", "<sos>"]):
+    def __init__(
+        self,
+        min_pitch=MIN_PITCH_DEFAULT,
+        max_pitch=MAX_PITCH_DEFAULT,
+        time_increment=40,
+        max_time_shift=4000,
+        specials=["<pad>", "<unk>", "<eos>", "<sos>"],
+    ):
         self.pad_index = 0
         self.unk_index = 1
         self.eos_index = 2
         self.sos_index = 3
         # itos - integer to string
-        self.itos = (list(specials) +  # special tokens
-            [f'o{ii}' for ii in range(min_pitch, max_pitch+1)] +  # note_on
-            [f'f{ii}' for ii in range(min_pitch, max_pitch+1)] +  # note_off
-            [f't{ii}' for ii in range(time_increment, max_time_shift+1,
-                                      time_increment)])  # time_shift
+        self.itos = (
+            list(specials)
+            + [f"o{ii}" for ii in range(min_pitch, max_pitch + 1)]  # special tokens
+            + [f"f{ii}" for ii in range(min_pitch, max_pitch + 1)]  # note_on
+            + [  # note_off
+                f"t{ii}"
+                for ii in range(time_increment, max_time_shift + 1, time_increment)
+            ]
+        )  # time_shift
         self.stoi = {tok: ii for ii, tok in enumerate(self.itos)}
 
     def __len__(self):
@@ -77,39 +86,41 @@ def create_corpus_csvs(acme_dir, format_dict):
             The function to convert from a pandas DataFrame to a string in the
             desired format.
     """
-    name = format_dict['name']
-    prefix = format_dict['prefix']
-    df_converter_func = format_dict['df_to_str']
+    name = format_dict["name"]
+    prefix = format_dict["prefix"]
+    df_converter_func = format_dict["df_to_str"]
     fh_dict = {
-        split: open(
-            os.path.join(acme_dir, f'{split}_{prefix}_corpus.csv'
-        ), 'w') for split in ['train', 'valid', 'test']
+        split: open(os.path.join(acme_dir, f"{split}_{prefix}_corpus.csv"), "w")
+        for split in ["train", "valid", "test"]
     }
-    line_counts = {
-        split: 0 for split in ['train', 'valid', 'test']
-    }
-    meta_df = pd.read_csv(os.path.join(acme_dir, 'metadata.csv'))
-    for idx, row in tqdm.tqdm(meta_df.iterrows(), total=meta_df.shape[0],
-                         desc=f'Creating {name} corpus'):
-        alt_df = pd.read_csv(os.path.join(acme_dir, row.altered_csv_path),
-                             header=None,
-                             names=['onset', 'track', 'pitch', 'dur'])
+    line_counts = {split: 0 for split in ["train", "valid", "test"]}
+    meta_df = pd.read_csv(os.path.join(acme_dir, "metadata.csv"))
+    for idx, row in tqdm.tqdm(
+        meta_df.iterrows(), total=meta_df.shape[0], desc=f"Creating {name} corpus"
+    ):
+        alt_df = pd.read_csv(
+            os.path.join(acme_dir, row.altered_csv_path),
+            header=None,
+            names=["onset", "track", "pitch", "dur"],
+        )
         alt_str = df_converter_func(alt_df)
-        clean_df = pd.read_csv(os.path.join(acme_dir, row.clean_csv_path),
-                               header=None,
-                               names=['onset', 'track', 'pitch', 'dur'])
+        clean_df = pd.read_csv(
+            os.path.join(acme_dir, row.clean_csv_path),
+            header=None,
+            names=["onset", "track", "pitch", "dur"],
+        )
         clean_str = df_converter_func(clean_df)
         deg_num = row.degradation_id
         split = row.split
         fh = fh_dict[split]
-        fh.write(f'{alt_str},{clean_str},{deg_num}\n')
-        meta_df.loc[idx, f'{prefix}_corpus_path'] = os.path.basename(fh.name)
-        meta_df.loc[idx, f'{prefix}_corpus_line_nr'] = line_counts[split]
+        fh.write(f"{alt_str},{clean_str},{deg_num}\n")
+        meta_df.loc[idx, f"{prefix}_corpus_path"] = os.path.basename(fh.name)
+        meta_df.loc[idx, f"{prefix}_corpus_line_nr"] = line_counts[split]
         line_counts[split] += 1
-    meta_df.loc[:, f'{prefix}_corpus_line_nr'] = (
-        meta_df[f'{prefix}_corpus_line_nr'].astype(int)
-    )
-    meta_df.to_csv(os.path.join(acme_dir, 'metadata.csv'), index=False)
+    meta_df.loc[:, f"{prefix}_corpus_line_nr"] = meta_df[
+        f"{prefix}_corpus_line_nr"
+    ].astype(int)
+    meta_df.to_csv(os.path.join(acme_dir, "metadata.csv"), index=False)
 
 
 def df_to_pianoroll_str(df, time_increment=40):
@@ -134,28 +145,34 @@ def df_to_pianoroll_str(df, time_increment=40):
     # Input validation
     assert time_increment > 0, "time_increment must be positive."
 
-    quant_df = df.loc[:, ['pitch']]
-    quant_df['onset'] = (df['onset'] / time_increment).round().astype(int)
-    quant_df['offset'] = (((df['onset'] + df['dur']) / time_increment)
-                          .round().astype(int).clip(lower=quant_df['onset'] + 1))
+    quant_df = df.loc[:, ["pitch"]]
+    quant_df["onset"] = (df["onset"] / time_increment).round().astype(int)
+    quant_df["offset"] = (
+        ((df["onset"] + df["dur"]) / time_increment)
+        .round()
+        .astype(int)
+        .clip(lower=quant_df["onset"] + 1)
+    )
 
     # Create piano rolls
-    length = quant_df['offset'].max()
-    max_pitch = quant_df['pitch'].max() + 1
+    length = quant_df["offset"].max()
+    max_pitch = quant_df["pitch"].max() + 1
     note_pr = np.zeros((length, max_pitch))
     onset_pr = np.zeros((length, max_pitch))
     for _, note in quant_df.iterrows():
         onset_pr[note.onset, note.pitch] = 1
-        note_pr[note.onset:note.offset, note.pitch] = 1
+        note_pr[note.onset : note.offset, note.pitch] = 1
 
     # Pack into format
     strings = []
     for note_frame, onset_frame in zip(note_pr, onset_pr):
-        strings.append(' '.join(map(str, np.where(note_frame == 1)[0])) +
-                       '_' +
-                       ' '.join(map(str, np.where(onset_frame == 1)[0])))
+        strings.append(
+            " ".join(map(str, np.where(note_frame == 1)[0]))
+            + "_"
+            + " ".join(map(str, np.where(onset_frame == 1)[0]))
+        )
 
-    return '/'.join(strings)
+    return "/".join(strings)
 
 
 def pianoroll_str_to_df(pr_str, time_increment=40):
@@ -175,50 +192,53 @@ def pianoroll_str_to_df(pr_str, time_increment=40):
     notes = []
     active = [-1] * 128
 
-    frames = pr_str.split('/')
+    frames = pr_str.split("/")
 
     for frame_num, frame in enumerate(frames):
         time = frame_num * time_increment
-        note_pitches, onset_pitches = frame.split('_')
-        if note_pitches != '':
-            note_pitches = list(map(int, note_pitches.split(' ')))
+        note_pitches, onset_pitches = frame.split("_")
+        if note_pitches != "":
+            note_pitches = list(map(int, note_pitches.split(" ")))
 
             # Check that all pitches continue
             for pitch, idx in enumerate(active):
                 if idx >= 0 and pitch not in note_pitches:
                     # Pitch doesn't continue
-                    notes[idx]['dur'] = time - notes[idx]['onset']
+                    notes[idx]["dur"] = time - notes[idx]["onset"]
                     active[pitch] = -1
 
-        if onset_pitches == '':
+        if onset_pitches == "":
             continue
 
         # Check onsets for new notes/breaks in existing notes
-        for pitch in map(int, onset_pitches.split(' ')):
+        for pitch in map(int, onset_pitches.split(" ")):
             if active[pitch] >= 0:
                 # Pitch was active. Stop it here.
-                notes[active[pitch]]['dur'] = time - notes[active[pitch]]['onset']
+                notes[active[pitch]]["dur"] = time - notes[active[pitch]]["onset"]
 
             # Start new note
             active[pitch] = len(notes)
-            notes.append({'onset': time,
-                          'pitch': pitch,
-                          'track': 0,
-                          'dur': None})
+            notes.append({"onset": time, "pitch": pitch, "track": 0, "dur": None})
 
     # Close any still open notes
     for idx in active:
         if idx >= 0:
-            notes[idx]['dur'] = len(frames) * time_increment - notes[idx]['onset']
+            notes[idx]["dur"] = len(frames) * time_increment - notes[idx]["onset"]
 
     # Create df
     df = pd.DataFrame(notes)
-    df = df.sort_values(by=NOTE_DF_SORT_ORDER)[NOTE_DF_SORT_ORDER].reset_index(drop=True)
+    df = df.sort_values(by=NOTE_DF_SORT_ORDER)[NOTE_DF_SORT_ORDER].reset_index(
+        drop=True
+    )
     return df
 
 
-def double_pianoroll_to_df(pianoroll, min_pitch=MIN_PITCH_DEFAULT,
-                           max_pitch=MAX_PITCH_DEFAULT, time_increment=40):
+def double_pianoroll_to_df(
+    pianoroll,
+    min_pitch=MIN_PITCH_DEFAULT,
+    max_pitch=MAX_PITCH_DEFAULT,
+    time_increment=40,
+):
     """
     Convert a double pianoroll (sustain and onset, as output by a task 4 model),
     into a DataFrame for use in evaluation.
@@ -246,17 +266,20 @@ def double_pianoroll_to_df(pianoroll, min_pitch=MIN_PITCH_DEFAULT,
     """
 
     if max_pitch != pianoroll.shape[1] / 2 + min_pitch - 1:
-        warnings.warn("max_pitch doesn't match pianoroll shape and min_pitch. "
-                      "Setting max_pitch to "
-                      f"{int(pianoroll.shape[1] / 2 + min_pitch - 1)}.")
+        warnings.warn(
+            "max_pitch doesn't match pianoroll shape and min_pitch. "
+            "Setting max_pitch to "
+            f"{int(pianoroll.shape[1] / 2 + min_pitch - 1)}."
+        )
         max_pitch = int(pianoroll.shape[1] / 2 + min_pitch - 1)
 
     df_notes = []
-    active = [-1] * (max_pitch - min_pitch + 1) # Index of active note in notes
+    active = [-1] * (max_pitch - min_pitch + 1)  # Index of active note in notes
     midpoint = int(pianoroll.shape[1] / 2)
 
-    for frame_num, (notes, onsets) in enumerate(zip(pianoroll[:, :midpoint],
-                                                    pianoroll[:, midpoint:])):
+    for frame_num, (notes, onsets) in enumerate(
+        zip(pianoroll[:, :midpoint], pianoroll[:, midpoint:])
+    ):
         time = frame_num * time_increment
         note_pitches = np.where(notes == 1)[0]
         onset_pitches = np.where(onsets == 1)[0]
@@ -265,23 +288,20 @@ def double_pianoroll_to_df(pianoroll, min_pitch=MIN_PITCH_DEFAULT,
         for pitch, idx in enumerate(active):
             if idx >= 0 and pitch not in note_pitches:
                 # Pitch doesn't continue
-                df_notes[idx]['dur'] = time - df_notes[idx]['onset']
+                df_notes[idx]["dur"] = time - df_notes[idx]["onset"]
                 active[pitch] = -1
 
         # Check onsets for new notes/breaks in existing notes
         for pitch in onset_pitches:
             if active[pitch] >= 0:
                 # Pitch was active. Stop it here.
-                df_notes[active[pitch]]['dur'] = (
-                    time -df_notes[active[pitch]]['onset']
-                )
+                df_notes[active[pitch]]["dur"] = time - df_notes[active[pitch]]["onset"]
 
             # Start new note
             active[pitch] = len(df_notes)
-            df_notes.append({'onset': time,
-                             'pitch': pitch + min_pitch,
-                             'track': 0,
-                             'dur': None})
+            df_notes.append(
+                {"onset": time, "pitch": pitch + min_pitch, "track": 0, "dur": None}
+            )
 
         # Find pitch presences that should've been onsets but weren't
         for pitch in note_pitches:
@@ -289,30 +309,34 @@ def double_pianoroll_to_df(pianoroll, min_pitch=MIN_PITCH_DEFAULT,
                 # Pitch is supposed to be inactive, but there is a sustain
                 # Treat this as an onset
                 active[pitch] = len(df_notes)
-                df_notes.append({'onset': time,
-                                 'pitch': pitch + min_pitch,
-                                 'track': 0,
-                                 'dur': None})
+                df_notes.append(
+                    {"onset": time, "pitch": pitch + min_pitch, "track": 0, "dur": None}
+                )
 
     # Close any still open notes
     frames = pianoroll.shape[0]
     for idx in active:
         if idx >= 0:
-            df_notes[idx]['dur'] = (frames * time_increment -
-                                    df_notes[idx]['onset'])
+            df_notes[idx]["dur"] = frames * time_increment - df_notes[idx]["onset"]
 
     # Create df
     if len(df_notes) > 0:
         df = pd.DataFrame(df_notes)
-        df = (df.sort_values(by=NOTE_DF_SORT_ORDER)[NOTE_DF_SORT_ORDER]
-              .reset_index(drop=True))
+        df = df.sort_values(by=NOTE_DF_SORT_ORDER)[NOTE_DF_SORT_ORDER].reset_index(
+            drop=True
+        )
     else:
         df = pd.DataFrame(columns=NOTE_DF_SORT_ORDER).reset_index(drop=True)
     return df
 
 
-def df_to_command_str(df, min_pitch=MIN_PITCH_DEFAULT, max_pitch=MAX_PITCH_DEFAULT,
-                      time_increment=40, max_time_shift=4000):
+def df_to_command_str(
+    df,
+    min_pitch=MIN_PITCH_DEFAULT,
+    max_pitch=MAX_PITCH_DEFAULT,
+    time_increment=40,
+    max_time_shift=4000,
+):
     """
     Convert a given pandas DataFrame into a sequence commands, note_on (o),
     note_off (f), and time_shift (t). Each command is followed by a number:
@@ -343,35 +367,38 @@ def df_to_command_str(df, min_pitch=MIN_PITCH_DEFAULT, max_pitch=MAX_PITCH_DEFAU
         The string containing a space separated list of commands.
     """
     # Input validation
-    assert max_time_shift % time_increment == 0, ("max_time_shift must be "
-        "divisible by time_increment.")
+    assert max_time_shift % time_increment == 0, (
+        "max_time_shift must be " "divisible by time_increment."
+    )
     assert max_pitch >= min_pitch, "max_pitch must be >= min_pitch."
     assert time_increment > 0, "time_increment must be positive."
     assert max_time_shift > 0, "max_time_shift must be positive."
 
-    note_off = df.loc[:, ['onset', 'pitch']]
-    note_off['onset'] = note_off['onset'] + df['dur']
-    note_off['cmd'] = note_off['pitch'].apply(lambda x: f'f{x}')
-    note_off['cmd_type'] = 'f'
-    note_on = df.loc[:, ['onset', 'pitch']]
-    note_on['cmd'] = note_off['pitch'].apply(lambda x: f'o{x}')
-    note_on['cmd_type'] = 'o'
+    note_off = df.loc[:, ["onset", "pitch"]]
+    note_off["onset"] = note_off["onset"] + df["dur"]
+    note_off["cmd"] = note_off["pitch"].apply(lambda x: f"f{x}")
+    note_off["cmd_type"] = "f"
+    note_on = df.loc[:, ["onset", "pitch"]]
+    note_on["cmd"] = note_off["pitch"].apply(lambda x: f"o{x}")
+    note_on["cmd_type"] = "o"
     commands = pd.concat((note_on, note_off))
-    commands['onset'] = ((commands['onset'] / time_increment)
-                         .round().astype(int) * time_increment)
-    commands = commands.sort_values(['onset', 'cmd_type', 'pitch'],
-                                    ascending=[True, True, True])
+    commands["onset"] = (commands["onset"] / time_increment).round().astype(
+        int
+    ) * time_increment
+    commands = commands.sort_values(
+        ["onset", "cmd_type", "pitch"], ascending=[True, True, True]
+    )
 
     command_list = []
     current_onset = commands.onset.iloc[0]
     for idx, row in commands.iterrows():
         while current_onset != row.onset:
             time_shift = min(row.onset - current_onset, max_time_shift)
-            command_list += [f't{time_shift}']
+            command_list += [f"t{time_shift}"]
             current_onset += time_shift
-        command_list += [f'{row.cmd}']
+        command_list += [f"{row.cmd}"]
 
-    return ' '.join(command_list)
+    return " ".join(command_list)
 
 
 def command_str_to_df(cmd_str):
@@ -397,17 +424,17 @@ def command_str_to_df(cmd_str):
     for cmd_str in commands:
         cmd = cmd_str[0]
         value = int(cmd_str[1:])
-        if cmd == 'o':
+        if cmd == "o":
             note_on_pitch += [value]
             note_on_time += [curr_time]
-        elif cmd == 'f':
+        elif cmd == "f":
             note_off_pitch += [value]
             note_off_time += [curr_time]
-        elif cmd == 't':
+        elif cmd == "t":
             curr_time += value
         else:
-            raise ValueError(f'Invalid command {cmd}')
-    df = pd.DataFrame(columns=['onset', 'track', 'pitch', 'dur'], dtype=int)
+            raise ValueError(f"Invalid command {cmd}")
+    df = pd.DataFrame(columns=["onset", "track", "pitch", "dur"], dtype=int)
     for ii, (pitch, onset) in enumerate(zip(note_on_pitch, note_on_time)):
         note_off_idx = note_off_pitch.index(pitch)  # gets first instance
         note_off_pitch.pop(note_off_idx)
@@ -420,40 +447,48 @@ def command_str_to_df(cmd_str):
 
 
 FORMATTERS = {
-    'command': {
-        'name': 'command',
-        'prefix': 'cmd',
-        'df_to_str': df_to_command_str,
-        'str_to_df': command_str_to_df,
-        'model_to_df': None,
-        'message': ('The {train,valid,test}_cmd_corpus.csv are command-based '
-                    '(note_on, note_off, shift) versions of the acme data more '
-                    'convenient for our provided pytorch Dataset classes.'),
-        'deg_label': 'deg_cmd',
-        'clean_label': 'clean_cmd',
-        'task_labels': ['deg_label', 'deg_label', None, 'clean_cmd'],
-        'dataset': 'CommandDataset',
-        'models': ['Command_ErrorDetectionNet',
-                   'Command_ErrorClassificationNet',
-                   None, # Probably won't implement. Ground truth is not created.
-                   None]
+    "command": {
+        "name": "command",
+        "prefix": "cmd",
+        "df_to_str": df_to_command_str,
+        "str_to_df": command_str_to_df,
+        "model_to_df": None,
+        "message": (
+            "The {train,valid,test}_cmd_corpus.csv are command-based "
+            "(note_on, note_off, shift) versions of the acme data more "
+            "convenient for our provided pytorch Dataset classes."
+        ),
+        "deg_label": "deg_cmd",
+        "clean_label": "clean_cmd",
+        "task_labels": ["deg_label", "deg_label", None, "clean_cmd"],
+        "dataset": "CommandDataset",
+        "models": [
+            "Command_ErrorDetectionNet",
+            "Command_ErrorClassificationNet",
+            None,  # Probably won't implement. Ground truth is not created.
+            None,
+        ],
     },
-    'pianoroll': {
-        'name': 'pianoroll',
-        'prefix': 'pr',
-        'df_to_str': df_to_pianoroll_str,
-        'str_to_df': pianoroll_str_to_df,
-        'model_to_df': double_pianoroll_to_df,
-        'message': ('The {train,valid,test}_pr_corpus.csv are piano-roll-based '
-                    'versions of the acme data more convenient for our provided '
-                    'pytorch Dataset classes.'),
-        'deg_label': 'deg_pr',
-        'clean_label': 'clean_pr',
-        'task_labels': ['deg_label', 'deg_label', 'changed_frames', 'clean_pr'],
-        'dataset': 'PianorollDataset',
-        'models': [None,
-                   None,
-                   'Pianoroll_ErrorLocationNet',
-                   'Pianoroll_ErrorCorrectionNet']
-    }
+    "pianoroll": {
+        "name": "pianoroll",
+        "prefix": "pr",
+        "df_to_str": df_to_pianoroll_str,
+        "str_to_df": pianoroll_str_to_df,
+        "model_to_df": double_pianoroll_to_df,
+        "message": (
+            "The {train,valid,test}_pr_corpus.csv are piano-roll-based "
+            "versions of the acme data more convenient for our provided "
+            "pytorch Dataset classes."
+        ),
+        "deg_label": "deg_pr",
+        "clean_label": "clean_pr",
+        "task_labels": ["deg_label", "deg_label", "changed_frames", "clean_pr"],
+        "dataset": "PianorollDataset",
+        "models": [
+            None,
+            None,
+            "Pianoroll_ErrorLocationNet",
+            "Pianoroll_ErrorCorrectionNet",
+        ],
+    },
 }

--- a/mdtk/pytorch_datasets.py
+++ b/mdtk/pytorch_datasets.py
@@ -1,27 +1,34 @@
 """classes to use in conjunction with pytorch dataloaders"""
-from torch.utils.data import Dataset
-import tqdm
-import torch
-import random
-import pandas as pd
-import numpy as np
 import os
+import random
 import warnings
 
-from mdtk.formatters import FORMATTERS
-from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
+import numpy as np
+import pandas as pd
+import torch
+import tqdm
+from torch.utils.data import Dataset
 
+from mdtk.degradations import MAX_PITCH_DEFAULT, MIN_PITCH_DEFAULT
+from mdtk.formatters import FORMATTERS
 
 
 def transform_to_torchtensor(output):
     return {key: torch.tensor(value) for key, value in output.items()}
 
 
-
 # This is adapted from https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/dataset/dataset.py
 class CommandDataset(Dataset):
-    def __init__(self, corpus_path, vocab, seq_len, encoding="utf-8",
-                 corpus_lines=None, in_memory=True, transform=None):
+    def __init__(
+        self,
+        corpus_path,
+        vocab,
+        seq_len,
+        encoding="utf-8",
+        corpus_lines=None,
+        in_memory=True,
+        transform=None,
+    ):
         """
         Returns command-based data for ACME tasks.
 
@@ -69,7 +76,7 @@ class CommandDataset(Dataset):
         self.encoding = encoding
 
         self.transform = transform
-        self.formatter = FORMATTERS['command']
+        self.formatter = FORMATTERS["command"]
 
         with open(corpus_path, "r", encoding=encoding) as f:
             if self.corpus_lines is None and not in_memory:
@@ -77,9 +84,10 @@ class CommandDataset(Dataset):
                     self.corpus_lines += 1
 
             if in_memory:
-                self.lines = [line[:-1].split(",")
-                              for line in tqdm.tqdm(f, desc="Loading Dataset",
-                                                    total=corpus_lines)]
+                self.lines = [
+                    line[:-1].split(",")
+                    for line in tqdm.tqdm(f, desc="Loading Dataset", total=corpus_lines)
+                ]
                 self.corpus_lines = len(self.lines)
 
         if not in_memory:
@@ -99,39 +107,45 @@ class CommandDataset(Dataset):
         # Deg length and clipping
         deg_len = len(deg_cmd)
         if self.in_memory:
-            item_nr_str = f' {item}'
+            item_nr_str = f" {item}"
         else:
-            item_nr_str = ' <unknown>'
+            item_nr_str = " <unknown>"
         if deg_len > self.seq_len:
-            warnings.warn(f"Degraded command data point {item_nr_str} exceeds "
-                          f"given seq_len: {deg_len} > {self.seq_len}. "
-                          "Clipping.")
+            warnings.warn(
+                f"Degraded command data point {item_nr_str} exceeds "
+                f"given seq_len: {deg_len} > {self.seq_len}. "
+                "Clipping."
+            )
             deg_len = self.seq_len
-            deg_cmd = deg_cmd[:self.seq_len]
+            deg_cmd = deg_cmd[: self.seq_len]
         # Clean length and clipping
         clean_len = len(clean_cmd)
         if clean_len > self.seq_len:
-            warnings.warn(f"Clean command data point {item_nr_str} exceeds "
-                          f"given seq_len: {clean_len} > {self.seq_len}. "
-                          "Clipping.")
+            warnings.warn(
+                f"Clean command data point {item_nr_str} exceeds "
+                f"given seq_len: {clean_len} > {self.seq_len}. "
+                "Clipping."
+            )
             clean_len = self.seq_len
-            clean_cmd = clean_cmd[:self.seq_len]
+            clean_cmd = clean_cmd[: self.seq_len]
 
         # Command padding
-        deg_cmd += [self.vocab.pad_index for _ in 
-                    range(self.seq_len - len(deg_cmd))]
-        clean_cmd += [self.vocab.pad_index for _ in 
-                      range(self.seq_len - len(clean_cmd))]
+        deg_cmd += [self.vocab.pad_index for _ in range(self.seq_len - len(deg_cmd))]
+        clean_cmd += [
+            self.vocab.pad_index for _ in range(self.seq_len - len(clean_cmd))
+        ]
 
-        output = {self.formatter['deg_label']: deg_cmd,
-                  self.formatter['clean_label']: clean_cmd,
-                  self.formatter['task_labels'][0]: deg_num,
-                  'deg_len': deg_len,
-                  'clean_len': clean_len}
+        output = {
+            self.formatter["deg_label"]: deg_cmd,
+            self.formatter["clean_label"]: clean_cmd,
+            self.formatter["task_labels"][0]: deg_num,
+            "deg_len": deg_len,
+            "clean_len": clean_len,
+        }
 
         if self.transform is not None:
             output = self.transform(output)
-        return output 
+        return output
 
     def tokenize_sentence(self, sentence):
         tokens = sentence.split()
@@ -154,12 +168,19 @@ class CommandDataset(Dataset):
             return deg_cmd, clean_cmd, deg_num
 
 
-
 # This is adapted from https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/dataset/dataset.py
 class PianorollDataset(Dataset):
-    def __init__(self, corpus_path, seq_len, min_pitch=MIN_PITCH_DEFAULT,
-                 max_pitch=MAX_PITCH_DEFAULT, encoding="utf-8",
-                 corpus_lines=None, in_memory=True, transform=None):
+    def __init__(
+        self,
+        corpus_path,
+        seq_len,
+        min_pitch=MIN_PITCH_DEFAULT,
+        max_pitch=MAX_PITCH_DEFAULT,
+        encoding="utf-8",
+        corpus_lines=None,
+        in_memory=True,
+        transform=None,
+    ):
         """
         Returns piano-roll-based data for ACME tasks.
 
@@ -209,7 +230,7 @@ class PianorollDataset(Dataset):
         self.encoding = encoding
 
         self.transform = transform
-        self.formatter = FORMATTERS['pianoroll']
+        self.formatter = FORMATTERS["pianoroll"]
 
         with open(corpus_path, "r", encoding=encoding) as f:
             if self.corpus_lines is None and not in_memory:
@@ -217,9 +238,10 @@ class PianorollDataset(Dataset):
                     self.corpus_lines += 1
 
             if in_memory:
-                self.lines = [line[:-1].split(",")
-                              for line in tqdm.tqdm(f, desc="Loading Dataset",
-                                                    total=corpus_lines)]
+                self.lines = [
+                    line[:-1].split(",")
+                    for line in tqdm.tqdm(f, desc="Loading Dataset", total=corpus_lines)
+                ]
                 self.corpus_lines = len(self.lines)
 
         if not in_memory:
@@ -233,36 +255,48 @@ class PianorollDataset(Dataset):
         deg_num = int(deg_num)
         deg_len, deg_pr = self.get_full_pr(deg_pr)
         clean_len, clean_pr = self.get_full_pr(clean_pr)
-        changed_frames = np.array([int(np.any(deg != clean))
-                                   for deg, clean in zip(deg_pr, clean_pr)])
+        changed_frames = np.array(
+            [int(np.any(deg != clean)) for deg, clean in zip(deg_pr, clean_pr)]
+        )
 
-        output = {self.formatter['deg_label']: deg_pr,
-                  self.formatter['clean_label']: clean_pr,
-                  self.formatter['task_labels'][0]: deg_num,
-                  self.formatter['task_labels'][2]: changed_frames,
-                  'deg_len': deg_len,
-                  'clean_len': clean_len}
+        output = {
+            self.formatter["deg_label"]: deg_pr,
+            self.formatter["clean_label"]: clean_pr,
+            self.formatter["task_labels"][0]: deg_num,
+            self.formatter["task_labels"][2]: changed_frames,
+            "deg_len": deg_len,
+            "clean_len": clean_len,
+        }
 
         if self.transform is not None:
             output = self.transform(output)
-        return output 
+        return output
 
     def get_full_pr(self, pr):
         note_pr = np.zeros((self.seq_len, 128))
         onset_pr = np.zeros((self.seq_len, 128))
-        frames = pr.split('/')
+        frames = pr.split("/")
         if len(frames) > self.seq_len:
-            warnings.warn("Pianoroll data point exceeds given seq_len: "
-                          f"{len(frames)} > {self.seq_len}. Clipping.")
-            frames = frames[:self.seq_len]
+            warnings.warn(
+                "Pianoroll data point exceeds given seq_len: "
+                f"{len(frames)} > {self.seq_len}. Clipping."
+            )
+            frames = frames[: self.seq_len]
         for frame_num, frame in enumerate(frames):
-            note_pitches, onset_pitches = frame.split('_')
-            if note_pitches != '':
-                note_pr[frame_num, list(map(int, note_pitches.split(' ')))] = 1
-            if onset_pitches != '':
-                onset_pr[frame_num, list(map(int, onset_pitches.split(' ')))] = 1
-        return len(frames), np.hstack((note_pr[:, self.min_pitch:self.max_pitch+1],
-                                       onset_pr[:, self.min_pitch:self.max_pitch+1]))
+            note_pitches, onset_pitches = frame.split("_")
+            if note_pitches != "":
+                note_pr[frame_num, list(map(int, note_pitches.split(" ")))] = 1
+            if onset_pitches != "":
+                onset_pr[frame_num, list(map(int, onset_pitches.split(" ")))] = 1
+        return (
+            len(frames),
+            np.hstack(
+                (
+                    note_pr[:, self.min_pitch : self.max_pitch + 1],
+                    onset_pr[:, self.min_pitch : self.max_pitch + 1],
+                )
+            ),
+        )
 
     def get_corpus_line(self, item):
         if self.in_memory:

--- a/mdtk/pytorch_datasets.py
+++ b/mdtk/pytorch_datasets.py
@@ -1,10 +1,7 @@
 """classes to use in conjunction with pytorch dataloaders"""
-import os
-import random
 import warnings
 
 import numpy as np
-import pandas as pd
 import torch
 import tqdm
 from torch.utils.data import Dataset
@@ -17,7 +14,8 @@ def transform_to_torchtensor(output):
     return {key: torch.tensor(value) for key, value in output.items()}
 
 
-# This is adapted from https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/dataset/dataset.py
+# This is adapted from:
+# https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/dataset/dataset.py
 class CommandDataset(Dataset):
     def __init__(
         self,
@@ -168,7 +166,8 @@ class CommandDataset(Dataset):
             return deg_cmd, clean_cmd, deg_num
 
 
-# This is adapted from https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/dataset/dataset.py
+# This is adapted from
+# https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/dataset/dataset.py
 class PianorollDataset(Dataset):
     def __init__(
         self,

--- a/mdtk/pytorch_models.py
+++ b/mdtk/pytorch_models.py
@@ -1,8 +1,7 @@
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import numpy as np
-
 
 
 class Command_ErrorDetectionNet(nn.Module):
@@ -20,8 +19,16 @@ class Command_ErrorDetectionNet(nn.Module):
     the output, then Negative log likelihood calculation (this is more
     efficient and therefore I exclude a softmax layer from the model)
     """
-    def __init__(self, vocab_size, embedding_dim, hidden_dim, output_size=2,
-                 dropout_prob=0.1, num_lstm_layers=1):
+
+    def __init__(
+        self,
+        vocab_size,
+        embedding_dim,
+        hidden_dim,
+        output_size=2,
+        dropout_prob=0.1,
+        num_lstm_layers=1,
+    ):
         super().__init__()
 
         self.embedding_dim = embedding_dim
@@ -29,16 +36,17 @@ class Command_ErrorDetectionNet(nn.Module):
         self.vocab_size = vocab_size
 
         self.embedding = nn.Embedding(vocab_size, embedding_dim)
-        self.lstm = nn.LSTM(embedding_dim, hidden_dim,
-                            num_layers=num_lstm_layers)
+        self.lstm = nn.LSTM(embedding_dim, hidden_dim, num_layers=num_lstm_layers)
 
         self.hidden2out = nn.Linear(hidden_dim, output_size)
 
         self.dropout_layer = nn.Dropout(p=dropout_prob)
 
     def init_hidden(self, batch_size, device):
-        return (torch.randn(1, batch_size, self.hidden_dim, device=device),
-                torch.randn(1, batch_size, self.hidden_dim, device=device))
+        return (
+            torch.randn(1, batch_size, self.hidden_dim, device=device),
+            torch.randn(1, batch_size, self.hidden_dim, device=device),
+        )
 
     def forward(self, batch, input_lengths=None):
         if input_lengths is not None:
@@ -48,7 +56,7 @@ class Command_ErrorDetectionNet(nn.Module):
         device = batch.device
         self.hidden = self.init_hidden(batch_size, device=device)
         embeds = self.embedding(batch).permute(1, 0, 2)
-#        embeds = self.embedding(batch)
+        #        embeds = self.embedding(batch)
         outputs, (ht, ct) = self.lstm(embeds, self.hidden)
         # ht is the last hidden state of the sequences
         # ht = (1 x batch_size x hidden_dim)
@@ -61,7 +69,6 @@ class Command_ErrorDetectionNet(nn.Module):
         output = self.hidden2out(output)
 
         return output
-        
 
 
 class Command_ErrorClassificationNet(Command_ErrorDetectionNet):
@@ -72,13 +79,24 @@ class Command_ErrorClassificationNet(Command_ErrorDetectionNet):
     It's precisely the same network design as for task 1 - error detection,
     except this has a number of output classes (9 for ACME1.0).
     """
-    def __init__(self, vocab_size, embedding_dim, hidden_dim, output_size=9,
-                 dropout_prob=0.1, num_lstm_layers=1):
-        super().__init__(vocab_size=vocab_size, embedding_dim=embedding_dim,
-                         hidden_dim=hidden_dim, output_size=output_size,
-                         dropout_prob=dropout_prob,
-                         num_lstm_layers=num_lstm_layers)
 
+    def __init__(
+        self,
+        vocab_size,
+        embedding_dim,
+        hidden_dim,
+        output_size=9,
+        dropout_prob=0.1,
+        num_lstm_layers=1,
+    ):
+        super().__init__(
+            vocab_size=vocab_size,
+            embedding_dim=embedding_dim,
+            hidden_dim=hidden_dim,
+            output_size=output_size,
+            dropout_prob=dropout_prob,
+            num_lstm_layers=num_lstm_layers,
+        )
 
 
 class Pianoroll_ErrorLocationNet(nn.Module):
@@ -95,14 +113,27 @@ class Pianoroll_ErrorLocationNet(nn.Module):
     
     The outputs and labels should be flattened when computing the CE Loss.
     """
-    def __init__(self, input_dim, hidden_dim, output_dim, layers=[],
-                 dropout_prob=0.1, num_lstm_layers=1):
+
+    def __init__(
+        self,
+        input_dim,
+        hidden_dim,
+        output_dim,
+        layers=[],
+        dropout_prob=0.1,
+        num_lstm_layers=1,
+    ):
         super().__init__()
-        
+
         self.hidden_dim = hidden_dim
-        self.lstm = nn.LSTM(input_dim, hidden_dim, num_layers=num_lstm_layers,
-                            bidirectional=True, batch_first=True)
-        
+        self.lstm = nn.LSTM(
+            input_dim,
+            hidden_dim,
+            num_layers=num_lstm_layers,
+            bidirectional=True,
+            batch_first=True,
+        )
+
         current_dim = 2 * hidden_dim
         linear_list = []
         for dim in layers:
@@ -110,30 +141,30 @@ class Pianoroll_ErrorLocationNet(nn.Module):
             linear_list.append(nn.Linear(current_dim, dim))
             linear_list.append(nn.ELU())
             current_dim = dim
-        
+
         self.linears = nn.ModuleList(linear_list)
-        
+
         self.hidden2out = nn.Linear(current_dim, output_dim)
         self.dropout_layer = nn.Dropout(p=dropout_prob)
-        
+
     def init_hidden(self, batch_size, device):
-        return (torch.randn(2, batch_size, self.hidden_dim, device=device),
-                torch.randn(2, batch_size, self.hidden_dim, device=device))
-        
+        return (
+            torch.randn(2, batch_size, self.hidden_dim, device=device),
+            torch.randn(2, batch_size, self.hidden_dim, device=device),
+        )
+
     def forward(self, batch):
         batch_size = batch.shape[0]
         device = batch.device
-        output, _ = self.lstm(batch.float(),
-                              self.init_hidden(batch_size, device))
-        
+        output, _ = self.lstm(batch.float(), self.init_hidden(batch_size, device))
+
         for module in self.linears:
             output = module(output)
-        
+
         output = self.dropout_layer(output)
         output = self.hidden2out(output)
 
         return output
-
 
 
 class Pianoroll_ErrorCorrectionNet(nn.Module):
@@ -147,22 +178,38 @@ class Pianoroll_ErrorCorrectionNet(nn.Module):
     3) A 2nd Bi-LSTM to decode.
     4) Final output layers.
     """
-    def __init__(self, input_dim, hidden_dim, output_dim, layers=[],
-                 dropout_prob=0.1, num_lstm_layers=1):
+
+    def __init__(
+        self,
+        input_dim,
+        hidden_dim,
+        output_dim,
+        layers=[],
+        dropout_prob=0.1,
+        num_lstm_layers=1,
+    ):
         super().__init__()
-        
+
         self.hidden_dim = hidden_dim
-        self.encoder = nn.LSTM(input_dim, hidden_dim,
-                               num_layers=num_lstm_layers,
-                               bidirectional=True, batch_first=True)
-        
+        self.encoder = nn.LSTM(
+            input_dim,
+            hidden_dim,
+            num_layers=num_lstm_layers,
+            bidirectional=True,
+            batch_first=True,
+        )
+
         self.connector = nn.Linear(hidden_dim * 2, hidden_dim)
         self.connector_do = nn.Dropout(p=dropout_prob)
-        
-        self.decoder = nn.LSTM(hidden_dim, hidden_dim,
-                               num_layers=num_lstm_layers,
-                               bidirectional=True, batch_first=True)
-        
+
+        self.decoder = nn.LSTM(
+            hidden_dim,
+            hidden_dim,
+            num_layers=num_lstm_layers,
+            bidirectional=True,
+            batch_first=True,
+        )
+
         current_dim = 2 * hidden_dim
         linear_list = []
         for dim in layers:
@@ -170,31 +217,31 @@ class Pianoroll_ErrorCorrectionNet(nn.Module):
             linear_list.append(nn.Linear(current_dim, dim))
             linear_list.append(nn.ELU())
             current_dim = dim
-        
+
         self.linears = nn.ModuleList(linear_list)
-        
+
         self.hidden2out = nn.Linear(current_dim, output_dim)
         self.dropout_layer = nn.Dropout(p=dropout_prob)
 
     def init_hidden(self, batch_size, device):
-        return (torch.randn(2, batch_size, self.hidden_dim, device=device),
-                torch.randn(2, batch_size, self.hidden_dim, device=device))
+        return (
+            torch.randn(2, batch_size, self.hidden_dim, device=device),
+            torch.randn(2, batch_size, self.hidden_dim, device=device),
+        )
 
     def forward(self, batch, input_lengths):
         batch_size = batch.shape[0]
         device = batch.device
-        output, _ = self.encoder(batch.float(),
-                                 self.init_hidden(batch_size, device))
-        
+        output, _ = self.encoder(batch.float(), self.init_hidden(batch_size, device))
+
         output = self.connector_do(F.elu(self.connector(output)))
-        
-        output, _ = self.decoder(output,
-                                 self.init_hidden(batch_size, device))
-        
+
+        output, _ = self.decoder(output, self.init_hidden(batch_size, device))
+
         for module in self.linears:
             output = module(output)
-        
+
         output = self.dropout_layer(output)
         output = self.hidden2out(output)
-        
+
         return torch.sigmoid(output)

--- a/mdtk/pytorch_models.py
+++ b/mdtk/pytorch_models.py
@@ -14,7 +14,7 @@ class Command_ErrorDetectionNet(nn.Module):
     2)    passes this through a standard LSTM with one hidden layer
     3)    passes the final hidden state from the lstm through a dropout layer
     4)    then puts this through a linear layer and returns the output
-    
+
     You should use nn.CrossEntropyLoss which will perform both a softmax on
     the output, then Negative log likelihood calculation (this is more
     efficient and therefore I exclude a softmax layer from the model)
@@ -75,7 +75,7 @@ class Command_ErrorClassificationNet(Command_ErrorDetectionNet):
     """
     Baseline model for the Error Classification task, in which the label for
     each data point is a degradation_id (with 0 = not degraded).
-    
+
     It's precisely the same network design as for task 1 - error detection,
     except this has a number of output classes (9 for ACME1.0).
     """
@@ -104,13 +104,13 @@ class Pianoroll_ErrorLocationNet(nn.Module):
     Baseline model for the Error Location task, in which the label for
     each data point is a binary label for each frame of input, with  0 = not
     degraded and 1 = degraded.
-    
+
     The model consists of:
     1) A bidirectional LSTM.
     2) A sequence of dropout layers followed by linear layers.
     3) A final dropout layer.
     4) A final output layer of dim 2.
-    
+
     The outputs and labels should be flattened when computing the CE Loss.
     """
 
@@ -171,7 +171,7 @@ class Pianoroll_ErrorCorrectionNet(nn.Module):
     """
     Baseline model for the Error Correction task, in which the label for each
     data point is the clean data.
-    
+
     The model consists of:
     1) Bi-LSTM to embed the input.
     2) A linear connection layer.

--- a/mdtk/pytorch_trainers.py
+++ b/mdtk/pytorch_trainers.py
@@ -1,25 +1,36 @@
 import sys
 import warnings
 from collections import defaultdict
+
+import numpy as np
 import torch
+import tqdm
 from torch.optim import Adam
 from torch.utils.data import DataLoader
-import numpy as np
-import tqdm
-from mdtk.eval import helpfulness, get_f1
-from mdtk.degradations import MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT
 
+from mdtk.degradations import MAX_PITCH_DEFAULT, MIN_PITCH_DEFAULT
+from mdtk.eval import get_f1, helpfulness
 
 
 class BaseTrainer:
     """Provides methods to train pytorch models. Adapted from:
     https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/trainer/pretrain.py"""
-    def __init__(self, model, criterion, train_dataloader: DataLoader,
-                 test_dataloader: DataLoader = None,
-                 lr: float = 1e-4, betas=(0.9, 0.999),
-                 weight_decay: float=0.01, with_cuda: bool=True,
-                 batch_log_freq=None, epoch_log_freq=1, formatter=None,
-                 log_file=None):
+
+    def __init__(
+        self,
+        model,
+        criterion,
+        train_dataloader: DataLoader,
+        test_dataloader: DataLoader = None,
+        lr: float = 1e-4,
+        betas=(0.9, 0.999),
+        weight_decay: float = 0.01,
+        with_cuda: bool = True,
+        batch_log_freq=None,
+        epoch_log_freq=1,
+        formatter=None,
+        log_file=None,
+    ):
         """
         Parameters
         ----------
@@ -65,26 +76,27 @@ class BaseTrainer:
         cuda_condition = torch.cuda.is_available()
         if with_cuda:
             if not cuda_condition:
-                print('You set with_cuda to True, but cuda was not available')
-                print('Using cpu')
+                print("You set with_cuda to True, but cuda was not available")
+                print("Using cpu")
             else:
                 self.device = torch.device("cuda:0")
 
         # This model will be saved every epoch
         self.model = model.to(self.device)
 
-#        # Distributed GPU training if CUDA can detect more than 1 GPU
-#        if with_cuda and torch.cuda.device_count() > 1:
-#            print(f"Using {torch.cuda.device_count()} GPUS for training")
-#            self.model = nn.DataParallel(self.model, device_ids=cuda_devices)
+        #        # Distributed GPU training if CUDA can detect more than 1 GPU
+        #        if with_cuda and torch.cuda.device_count() > 1:
+        #            print(f"Using {torch.cuda.device_count()} GPUS for training")
+        #            self.model = nn.DataParallel(self.model, device_ids=cuda_devices)
 
         # Setting the train and test data loader
         self.train_data = train_dataloader
         self.test_data = test_dataloader
 
         # Setting the Adam optimizer with hyper-param
-        self.optimizer = Adam(self.model.parameters(), lr=lr, betas=betas,
-                              weight_decay=weight_decay)
+        self.optimizer = Adam(
+            self.model.parameters(), lr=lr, betas=betas, weight_decay=weight_decay
+        )
 
         self.criterion = criterion
 
@@ -97,8 +109,7 @@ class BaseTrainer:
 
         self.formatter = formatter
 
-        print("Total Parameters:",
-              sum([p.nelement() for p in self.model.parameters()]))
+        print("Total Parameters:", sum([p.nelement() for p in self.model.parameters()]))
 
     def train(self, epoch):
         log_info = self.iteration(epoch, self.train_data)
@@ -107,8 +118,9 @@ class BaseTrainer:
 
     def test(self, epoch, evaluate=False):
         with torch.no_grad():
-            log_info = self.iteration(epoch, self.test_data, train=False,
-                                      evaluate=evaluate)
+            log_info = self.iteration(
+                epoch, self.test_data, train=False, evaluate=evaluate
+            )
         self.log_file.flush()
         return log_info
 
@@ -136,20 +148,31 @@ class BaseTrainer:
         return output_path
 
 
-
 class ErrorDetectionTrainer(BaseTrainer):
     """Trains Task 1 - Error detection. The model provided is expected to be
     an mdtk.pytorch_models.ErrorDetectionNet. Expects a DataLoader using an
     mdtk.pytorch_datasets.CommandDataset."""
-    def __init__(self, model, criterion, train_dataloader: DataLoader,
-                 test_dataloader: DataLoader = None,
-                 lr: float = 1e-4, betas=(0.9, 0.999),
-                 weight_decay: float=0.01, with_cuda: bool=True,
-                 batch_log_freq=None, epoch_log_freq=1, formatter=None,
-                 log_file=None):
-        if formatter['task_labels'][0] is None:
-            raise NotImplementedError('Formatter ' + formatter['name'] + ' has not'
-                                      ' implemented a ground truth for this task.')
+
+    def __init__(
+        self,
+        model,
+        criterion,
+        train_dataloader: DataLoader,
+        test_dataloader: DataLoader = None,
+        lr: float = 1e-4,
+        betas=(0.9, 0.999),
+        weight_decay: float = 0.01,
+        with_cuda: bool = True,
+        batch_log_freq=None,
+        epoch_log_freq=1,
+        formatter=None,
+        log_file=None,
+    ):
+        if formatter["task_labels"][0] is None:
+            raise NotImplementedError(
+                "Formatter " + formatter["name"] + " has not"
+                " implemented a ground truth for this task."
+            )
         super().__init__(
             model=model,
             criterion=criterion,
@@ -162,9 +185,9 @@ class ErrorDetectionTrainer(BaseTrainer):
             batch_log_freq=batch_log_freq,
             epoch_log_freq=epoch_log_freq,
             formatter=formatter,
-            log_file=log_file
+            log_file=log_file,
         )
-        self.log_cols = ['epoch', 'batch', 'mode', 'avg_loss', 'avg_acc']
+        self.log_cols = ["epoch", "batch", "mode", "avg_loss", "avg_acc"]
 
     def iteration(self, epoch, data_loader, train=True, evaluate=False):
         """
@@ -208,19 +231,21 @@ class ErrorDetectionTrainer(BaseTrainer):
         total_element_per_deg = defaultdict(lambda: 0)
 
         # Setting the tqdm progress bar
-        data_iter = tqdm.tqdm(enumerate(data_loader),
-                              desc=f"{str_code} epoch {epoch}",
-                              postfix={'avg_loss': 0},
-                              bar_format='{l_bar}{bar} batch {r_bar}',
-                              total=len(data_loader))
+        data_iter = tqdm.tqdm(
+            enumerate(data_loader),
+            desc=f"{str_code} epoch {epoch}",
+            postfix={"avg_loss": 0},
+            bar_format="{l_bar}{bar} batch {r_bar}",
+            total=len(data_loader),
+        )
 
         for ii, data in data_iter:
-            input_lengths = np.array(data['deg_len']) if 'deg_len' in data else None
+            input_lengths = np.array(data["deg_len"]) if "deg_len" in data else None
             # N tensors of integers representing (potentially) degraded midi
-            input_data = data[self.formatter['deg_label']].to(self.device)
+            input_data = data[self.formatter["deg_label"]].to(self.device)
             # N integers of the labels - 0 assumed to be no degradation
             # N.B. CrossEntropy expects this to be of type long
-            labels = (data[self.formatter['task_labels'][0]] > 0).long().to(self.device)
+            labels = (data[self.formatter["task_labels"][0]] > 0).long().to(self.device)
             model_output = self.model.forward(input_data, input_lengths)
             loss = self.criterion(model_output, labels)
 
@@ -235,14 +260,14 @@ class ErrorDetectionTrainer(BaseTrainer):
             correct = predictions.eq(labels).sum().item()
             true_pos = (predictions & labels).sum().item()
             total_loss += loss.item() * labels.nelement()
-                                     # N.B. if loss is using reduction='mean'
-                                     # summing the average losses over the
-                                     # batches and then dividing by the number
-                                     # of batches does not give you the true
-                                     # mean loss (though it is at least an
-                                     # unbiased estimate...)
-                                     # Using total rather than sum to account
-                                     # For the last batch being a different size
+            # N.B. if loss is using reduction='mean'
+            # summing the average losses over the
+            # batches and then dividing by the number
+            # of batches does not give you the true
+            # mean loss (though it is at least an
+            # unbiased estimate...)
+            # Using total rather than sum to account
+            # For the last batch being a different size
             total_correct += correct
             total_element += labels.nelement()
             total_positive += predictions.sum().item()
@@ -254,14 +279,14 @@ class ErrorDetectionTrainer(BaseTrainer):
                 "batch": ii,
                 "mode": str_code,
                 "avg_loss": total_loss / total_element,
-                "avg_acc": total_correct / total_element * 100
+                "avg_acc": total_correct / total_element * 100,
             }
 
             # I'm only calculating avg acc per deg_type if evaluating so as not to
             # affect training speed
             if evaluate:
                 avg_acc_per_deg = {}
-                degradation_type_labels = data[self.formatter['task_labels'][0]]
+                degradation_type_labels = data[self.formatter["task_labels"][0]]
                 for deg_label_value in degradation_type_labels.unique():
                     idx = degradation_type_labels == deg_label_value
                     deg_labels = labels[idx]
@@ -270,14 +295,14 @@ class ErrorDetectionTrainer(BaseTrainer):
                     total_correct_per_deg[deg_label_value] += deg_correct
                     total_element_per_deg[deg_label_value] += deg_labels.nelement()
                     avg_acc_per_deg[deg_label_value] = (
-                        total_correct_per_deg[deg_label_value] /
-                        total_element_per_deg[deg_label_value]
+                        total_correct_per_deg[deg_label_value]
+                        / total_element_per_deg[deg_label_value]
                     )
                 log_info["avg_acc_per_deg"] = avg_acc_per_deg
 
             if evaluate:
                 # labels are 0, 1 for task1, rather than the deg type
-                degradation_type_labels = data[self.formatter['task_labels'][0]]
+                degradation_type_labels = data[self.formatter["task_labels"][0]]
                 for label, pred, deg_label in zip(
                     labels.cpu(),
                     predictions.cpu().data.numpy(),
@@ -290,17 +315,19 @@ class ErrorDetectionTrainer(BaseTrainer):
 
             if self.batch_log_freq is not None:
                 if ii % self.batch_log_freq == 0:
-                    print(','.join([str(log_info[kk]) for kk in self.log_cols]),
-                          file=self.log_file)
+                    print(
+                        ",".join([str(log_info[kk]) for kk in self.log_cols]),
+                        file=self.log_file,
+                    )
 
-            data_iter.set_postfix(
-                avg_loss=round(log_info['avg_loss'], ndigits=3)
-            )
+            data_iter.set_postfix(avg_loss=round(log_info["avg_loss"], ndigits=3))
 
         if self.epoch_log_freq is not None:
             if epoch % self.epoch_log_freq == 0:
-                print(','.join([str(log_info[kk]) for kk in self.log_cols]),
-                      file=self.log_file)
+                print(
+                    ",".join([str(log_info[kk]) for kk in self.log_cols]),
+                    file=self.log_file,
+                )
 
         if evaluate:
             tp = total_true_pos
@@ -309,42 +336,54 @@ class ErrorDetectionTrainer(BaseTrainer):
             tn = total_element - tp - fn - fp
             p, r, f = get_f1(tp, fp, fn)
             rev_p, rev_r, rev_f = get_f1(tn, fn, fp)
-            log_info['p'] = p
-            log_info['r'] = r
-            log_info['f'] = f
-            log_info['rev_p'] = rev_p
-            log_info['rev_r'] = rev_r
-            log_info['rev_f'] = rev_f
+            log_info["p"] = p
+            log_info["r"] = r
+            log_info["f"] = f
+            log_info["rev_p"] = rev_p
+            log_info["rev_r"] = rev_r
+            log_info["rev_f"] = rev_f
             print(f"P, R, F-measure: {p}, {r}, {f}")
             print(f"Reverse P, R, F-measure: {rev_p}, {rev_r}, {rev_f}")
             print(f"Avg loss: {total_loss / total_element}")
-            log_info['avg_acc_per_deg'] = np.array(
+            log_info["avg_acc_per_deg"] = np.array(
                 [
-                    total_correct_per_deg[deg]/total_element_per_deg[deg]
+                    total_correct_per_deg[deg] / total_element_per_deg[deg]
                     for deg in sorted(total_element_per_deg.keys())
                 ]
             )
 
         return log_info
 
+
 #        print("EP%d_%s, avg_loss=" % (epoch, str_code), avg_loss / len(data_iter), "total_acc=",
 #              total_correct * 100.0 / total_element)
-
 
 
 class ErrorClassificationTrainer(BaseTrainer):
     """Trains Task 2 - Error classification. The model provided is expected to be
     an mdtk.pytorch_models.ErrorClassificationNet. Expects a DataLoader using an
     mdtk.pytorch_datasets.CommandDataset."""
-    def __init__(self, model, criterion, train_dataloader: DataLoader,
-                 test_dataloader: DataLoader = None,
-                 lr: float = 1e-4, betas=(0.9, 0.999),
-                 weight_decay: float=0.01, with_cuda: bool=True,
-                 batch_log_freq=None, epoch_log_freq=1, formatter=None,
-                 log_file=None):
-        if formatter['task_labels'][1] is None:
-            raise NotImplementedError('Formatter ' + formatter['name'] + ' has not'
-                                      ' implemented a ground truth for this task.')
+
+    def __init__(
+        self,
+        model,
+        criterion,
+        train_dataloader: DataLoader,
+        test_dataloader: DataLoader = None,
+        lr: float = 1e-4,
+        betas=(0.9, 0.999),
+        weight_decay: float = 0.01,
+        with_cuda: bool = True,
+        batch_log_freq=None,
+        epoch_log_freq=1,
+        formatter=None,
+        log_file=None,
+    ):
+        if formatter["task_labels"][1] is None:
+            raise NotImplementedError(
+                "Formatter " + formatter["name"] + " has not"
+                " implemented a ground truth for this task."
+            )
         super().__init__(
             model=model,
             criterion=criterion,
@@ -357,9 +396,9 @@ class ErrorClassificationTrainer(BaseTrainer):
             batch_log_freq=batch_log_freq,
             epoch_log_freq=epoch_log_freq,
             formatter=formatter,
-            log_file=log_file
+            log_file=log_file,
         )
-        self.log_cols = ['epoch', 'batch', 'mode', 'avg_loss', 'avg_acc']
+        self.log_cols = ["epoch", "batch", "mode", "avg_loss", "avg_acc"]
 
     def iteration(self, epoch, data_loader, train=True, evaluate=False):
         """
@@ -401,19 +440,21 @@ class ErrorClassificationTrainer(BaseTrainer):
         total_element_per_deg = defaultdict(lambda: 0)
 
         # Setting the tqdm progress bar
-        data_iter = tqdm.tqdm(enumerate(data_loader),
-                              desc=f"{str_code} epoch {epoch}",
-                              postfix={'avg_loss': 0},
-                              bar_format='{l_bar}{bar} batch {r_bar}',
-                              total=len(data_loader))
+        data_iter = tqdm.tqdm(
+            enumerate(data_loader),
+            desc=f"{str_code} epoch {epoch}",
+            postfix={"avg_loss": 0},
+            bar_format="{l_bar}{bar} batch {r_bar}",
+            total=len(data_loader),
+        )
 
         for ii, data in data_iter:
-            input_lengths = np.array(data['deg_len']) if 'deg_len' in data else None
+            input_lengths = np.array(data["deg_len"]) if "deg_len" in data else None
             # N tensors of integers representing (potentially) degraded midi
-            input_data = data[self.formatter['deg_label']].to(self.device)
+            input_data = data[self.formatter["deg_label"]].to(self.device)
             # N integers of the labels - 0 assumed to be no degradation
             # N.B. CrossEntropy expects this to be of type long
-            labels = (data[self.formatter['task_labels'][1]]).long().to(self.device)
+            labels = (data[self.formatter["task_labels"][1]]).long().to(self.device)
             model_output = self.model.forward(input_data, input_lengths)
             loss = self.criterion(model_output, labels)
 
@@ -427,14 +468,14 @@ class ErrorClassificationTrainer(BaseTrainer):
             predictions = model_output.argmax(dim=-1)
             correct = predictions.eq(labels).sum().item()
             total_loss += loss.item() * labels.nelement()
-                                     # N.B. if loss is using reduction='mean'
-                                     # summing the average losses over the
-                                     # batches and then dividing by the number
-                                     # of batches does not give you the true
-                                     # mean loss (though it is at least an
-                                     # unbiased estimate...)
-                                     # Using total rather than sum to account
-                                     # For the last batch being a different size
+            # N.B. if loss is using reduction='mean'
+            # summing the average losses over the
+            # batches and then dividing by the number
+            # of batches does not give you the true
+            # mean loss (though it is at least an
+            # unbiased estimate...)
+            # Using total rather than sum to account
+            # For the last batch being a different size
             total_correct += correct
             total_element += labels.nelement()
 
@@ -443,11 +484,10 @@ class ErrorClassificationTrainer(BaseTrainer):
                 if confusion_mat is None:
                     num_degs = model_output.shape[1]
                     confusion_mat = np.zeros((num_degs, num_degs))
-                for label, output in zip(labels.cpu(),
-                                         model_output.cpu().data.numpy()):
+                for label, output in zip(labels.cpu(), model_output.cpu().data.numpy()):
                     confusion_mat[label, np.argmax(output)] += 1
 
-                degradation_type_labels = data[self.formatter['task_labels'][0]]
+                degradation_type_labels = data[self.formatter["task_labels"][0]]
                 for label, pred, deg_label in zip(
                     labels.cpu(),
                     predictions.cpu().data.numpy(),
@@ -463,56 +503,70 @@ class ErrorClassificationTrainer(BaseTrainer):
                 "batch": ii,
                 "mode": str_code,
                 "avg_loss": total_loss / total_element,
-                "avg_acc": total_correct / total_element * 100
+                "avg_acc": total_correct / total_element * 100,
             }
 
             if self.batch_log_freq is not None:
                 if ii % self.batch_log_freq == 0:
-                    print(','.join([str(log_info[kk]) for kk in self.log_cols]),
-                          file=self.log_file)
+                    print(
+                        ",".join([str(log_info[kk]) for kk in self.log_cols]),
+                        file=self.log_file,
+                    )
 
-            data_iter.set_postfix(
-                avg_loss=round(log_info['avg_loss'], ndigits=3)
-            )
+            data_iter.set_postfix(avg_loss=round(log_info["avg_loss"], ndigits=3))
 
         if self.epoch_log_freq is not None:
             if epoch % self.epoch_log_freq == 0:
-                print(','.join([str(log_info[kk]) for kk in self.log_cols]),
-                      file=self.log_file)
+                print(
+                    ",".join([str(log_info[kk]) for kk in self.log_cols]),
+                    file=self.log_file,
+                )
 
         if evaluate:
             confusion_mat /= np.sum(confusion_mat, axis=1, keepdims=True)
-            log_info['confusion_mat'] = confusion_mat
+            log_info["confusion_mat"] = confusion_mat
             print(f"Accuracy: {total_correct / total_element * 100}")
             print(f"Avg loss: {total_loss / total_element}")
             print(f"Confusion matrix (as [label, output]):\n{confusion_mat}")
             # Not required since in confusion matrix - here for verification / same accross classes
-            log_info['avg_acc_per_deg'] = np.array(
+            log_info["avg_acc_per_deg"] = np.array(
                 [
-                    total_correct_per_deg[deg]/total_element_per_deg[deg]
+                    total_correct_per_deg[deg] / total_element_per_deg[deg]
                     for deg in sorted(total_element_per_deg.keys())
                 ]
             )
         return log_info
 
+
 #        print("EP%d_%s, avg_loss=" % (epoch, str_code), avg_loss / len(data_iter), "total_acc=",
 #              total_correct * 100.0 / total_element)
-
 
 
 class ErrorLocationTrainer(BaseTrainer):
     """Trains Task 3 - Error Location. The model provided is expected to be
     an mdtk.pytorch_models.ErrorLocationNet. Expects a DataLoader using an
     mdtk.pytorch_datasets.CommandDataset."""
-    def __init__(self, model, criterion, train_dataloader: DataLoader,
-                 test_dataloader: DataLoader = None,
-                 lr: float = 1e-4, betas=(0.9, 0.999),
-                 weight_decay: float=0.01, with_cuda: bool=True,
-                 batch_log_freq=None, epoch_log_freq=1, formatter=None,
-                 log_file=None):
-        if formatter['task_labels'][2] is None:
-            raise NotImplementedError('Formatter ' + formatter['name'] + ' has not'
-                                      ' implemented a ground truth for this task.')
+
+    def __init__(
+        self,
+        model,
+        criterion,
+        train_dataloader: DataLoader,
+        test_dataloader: DataLoader = None,
+        lr: float = 1e-4,
+        betas=(0.9, 0.999),
+        weight_decay: float = 0.01,
+        with_cuda: bool = True,
+        batch_log_freq=None,
+        epoch_log_freq=1,
+        formatter=None,
+        log_file=None,
+    ):
+        if formatter["task_labels"][2] is None:
+            raise NotImplementedError(
+                "Formatter " + formatter["name"] + " has not"
+                " implemented a ground truth for this task."
+            )
         super().__init__(
             model=model,
             criterion=criterion,
@@ -525,9 +579,9 @@ class ErrorLocationTrainer(BaseTrainer):
             batch_log_freq=batch_log_freq,
             epoch_log_freq=epoch_log_freq,
             formatter=formatter,
-            log_file=log_file
+            log_file=log_file,
         )
-        self.log_cols = ['epoch', 'batch', 'mode', 'avg_loss', 'avg_acc']
+        self.log_cols = ["epoch", "batch", "mode", "avg_loss", "avg_acc"]
 
     def iteration(self, epoch, data_loader, train=True, evaluate=False):
         """
@@ -574,18 +628,20 @@ class ErrorLocationTrainer(BaseTrainer):
         total_element_per_deg = defaultdict(lambda: 0)
 
         # Setting the tqdm progress bar
-        data_iter = tqdm.tqdm(enumerate(data_loader),
-                              desc=f"{str_code} epoch {epoch}",
-                              postfix={'avg_loss': 0},
-                              bar_format='{l_bar}{bar} batch {r_bar}',
-                              total=len(data_loader))
+        data_iter = tqdm.tqdm(
+            enumerate(data_loader),
+            desc=f"{str_code} epoch {epoch}",
+            postfix={"avg_loss": 0},
+            bar_format="{l_bar}{bar} batch {r_bar}",
+            total=len(data_loader),
+        )
 
         for ii, data in data_iter:
             # N tensors of integers representing (potentially) degraded midi
-            input_data = data[self.formatter['deg_label']].to(self.device)
+            input_data = data[self.formatter["deg_label"]].to(self.device)
             # N integers of the labels - 0 assumed to be no degradation
             # N.B. CrossEntropy expects this to be of type long
-            labels = (data[self.formatter['task_labels'][2]]).long().to(self.device)
+            labels = (data[self.formatter["task_labels"][2]]).long().to(self.device)
             labels = labels.reshape(labels.shape[0] * labels.shape[1])
             model_output = self.model.forward(input_data)
             model_output = model_output.reshape(
@@ -604,14 +660,14 @@ class ErrorLocationTrainer(BaseTrainer):
             correct = predictions.eq(labels).sum().item()
             true_pos = (predictions & labels).sum().item()
             total_loss += loss.item() * labels.nelement()
-                                     # N.B. if loss is using reduction='mean'
-                                     # summing the average losses over the
-                                     # batches and then dividing by the number
-                                     # of batches does not give you the true
-                                     # mean loss (though it is at least an
-                                     # unbiased estimate...)
-                                     # Using total rather than sum to account
-                                     # For the last batch being a different size
+            # N.B. if loss is using reduction='mean'
+            # summing the average losses over the
+            # batches and then dividing by the number
+            # of batches does not give you the true
+            # mean loss (though it is at least an
+            # unbiased estimate...)
+            # Using total rather than sum to account
+            # For the last batch being a different size
             total_correct += correct
             total_element += labels.nelement()
             total_positive += predictions.sum().item()
@@ -623,16 +679,15 @@ class ErrorLocationTrainer(BaseTrainer):
                 "batch": ii,
                 "mode": str_code,
                 "avg_loss": total_loss / total_element,
-                "avg_acc": total_correct / total_element * 100
+                "avg_acc": total_correct / total_element * 100,
             }
 
             if evaluate:
                 # we are considering each time point seperately, so we must repeat
                 # the deg_type labels for the length of the sequences
-                seq_len = data[self.formatter['task_labels'][2]].shape[1]
+                seq_len = data[self.formatter["task_labels"][2]].shape[1]
                 degradation_type_labels = np.repeat(
-                    data[self.formatter['task_labels'][0]],
-                    seq_len,
+                    data[self.formatter["task_labels"][0]], seq_len,
                 )
 
                 for label, pred, deg_label in zip(
@@ -653,26 +708,28 @@ class ErrorLocationTrainer(BaseTrainer):
 
             if self.batch_log_freq is not None:
                 if ii % self.batch_log_freq == 0:
-                    print(','.join([str(log_info[kk]) for kk in self.log_cols]),
-                          file=self.log_file)
+                    print(
+                        ",".join([str(log_info[kk]) for kk in self.log_cols]),
+                        file=self.log_file,
+                    )
 
-            data_iter.set_postfix(
-                avg_loss=round(log_info['avg_loss'], ndigits=3)
-            )
+            data_iter.set_postfix(avg_loss=round(log_info["avg_loss"], ndigits=3))
 
         if self.epoch_log_freq is not None:
             if epoch % self.epoch_log_freq == 0:
-                print(','.join([str(log_info[kk]) for kk in self.log_cols]),
-                      file=self.log_file)
+                print(
+                    ",".join([str(log_info[kk]) for kk in self.log_cols]),
+                    file=self.log_file,
+                )
 
         if evaluate:
             tp = total_true_pos
             fn = total_positive_labels - tp
             fp = total_positive - tp
             p, r, f = get_f1(tp, fp, fn)
-            log_info['p'] = p
-            log_info['r'] = r
-            log_info['f'] = f
+            log_info["p"] = p
+            log_info["r"] = r
+            log_info["f"] = f
             print(f"P, R, F-measure: {p}, {r}, {f}")
 
             p_per_deg = []
@@ -686,38 +743,50 @@ class ErrorLocationTrainer(BaseTrainer):
                 p_per_deg += [p]
                 r_per_deg += [r]
                 f_per_deg += [f]
-            log_info['p_per_deg'] = np.array(p_per_deg)
-            log_info['r_per_deg'] = np.array(r_per_deg)
-            log_info['f_per_deg'] = np.array(f_per_deg)
+            log_info["p_per_deg"] = np.array(p_per_deg)
+            log_info["r_per_deg"] = np.array(r_per_deg)
+            log_info["f_per_deg"] = np.array(f_per_deg)
 
             print(f"Avg loss: {total_loss / total_element}")
-            log_info['avg_acc_per_deg'] = np.array(
+            log_info["avg_acc_per_deg"] = np.array(
                 [
-                    total_correct_per_deg[deg]/total_element_per_deg[deg]
+                    total_correct_per_deg[deg] / total_element_per_deg[deg]
                     for deg in sorted(total_element_per_deg.keys())
                 ]
             )
 
         return log_info
 
+
 #        print("EP%d_%s, avg_loss=" % (epoch, str_code), avg_loss / len(data_iter), "total_acc=",
 #              total_correct * 100.0 / total_element)
-
 
 
 class ErrorCorrectionTrainer(BaseTrainer):
     """Trains Task 4 - Error Correction. The model provided is expected to be
     an mdtk.pytorch_models.ErrorCorrectionNet. Expects a DataLoader using an
     mdtk.pytorch_datasets.CommandDataset."""
-    def __init__(self, model, criterion, train_dataloader: DataLoader,
-                 test_dataloader: DataLoader = None,
-                 lr: float = 1e-4, betas=(0.9, 0.999),
-                 weight_decay: float=0.01, with_cuda: bool=True,
-                 batch_log_freq=None, epoch_log_freq=1, formatter=None,
-                 log_file=None):
-        if formatter['task_labels'][3] is None:
-            raise NotImplementedError('Formatter ' + formatter['name'] + ' has not'
-                                      ' implemented a ground truth for this task.')
+
+    def __init__(
+        self,
+        model,
+        criterion,
+        train_dataloader: DataLoader,
+        test_dataloader: DataLoader = None,
+        lr: float = 1e-4,
+        betas=(0.9, 0.999),
+        weight_decay: float = 0.01,
+        with_cuda: bool = True,
+        batch_log_freq=None,
+        epoch_log_freq=1,
+        formatter=None,
+        log_file=None,
+    ):
+        if formatter["task_labels"][3] is None:
+            raise NotImplementedError(
+                "Formatter " + formatter["name"] + " has not"
+                " implemented a ground truth for this task."
+            )
         super().__init__(
             model=model,
             criterion=criterion,
@@ -730,9 +799,9 @@ class ErrorCorrectionTrainer(BaseTrainer):
             batch_log_freq=batch_log_freq,
             epoch_log_freq=epoch_log_freq,
             formatter=formatter,
-            log_file=log_file
+            log_file=log_file,
         )
-        self.log_cols = ['epoch', 'batch', 'mode', 'avg_loss', 'avg_acc']
+        self.log_cols = ["epoch", "batch", "mode", "avg_loss", "avg_acc"]
 
     def iteration(self, epoch, data_loader, train=True, evaluate=False):
         """
@@ -776,19 +845,21 @@ class ErrorCorrectionTrainer(BaseTrainer):
         total_element_per_deg = defaultdict(lambda: 0)
 
         # Setting the tqdm progress bar
-        data_iter = tqdm.tqdm(enumerate(data_loader),
-                              desc=f"{str_code} epoch {epoch}",
-                              postfix={'avg_loss': 0},
-                              bar_format='{l_bar}{bar} batch {r_bar}',
-                              total=len(data_loader))
+        data_iter = tqdm.tqdm(
+            enumerate(data_loader),
+            desc=f"{str_code} epoch {epoch}",
+            postfix={"avg_loss": 0},
+            bar_format="{l_bar}{bar} batch {r_bar}",
+            total=len(data_loader),
+        )
 
         for ii, data in data_iter:
-            input_lengths = np.array(data['deg_len']) if 'deg_len' in data else None
+            input_lengths = np.array(data["deg_len"]) if "deg_len" in data else None
             # N tensors of integers representing (potentially) degraded midi
-            input_data = data[self.formatter['deg_label']].to(self.device)
+            input_data = data[self.formatter["deg_label"]].to(self.device)
             # N integers of the labels - 0 assumed to be no degradation
             # N.B. CrossEntropy expects this to be of type long
-            labels = (data[self.formatter['task_labels'][3]]).float().to(self.device)
+            labels = (data[self.formatter["task_labels"][3]]).float().to(self.device)
             model_output = self.model.forward(input_data, input_lengths)
             loss = self.criterion(model_output, labels)
 
@@ -802,14 +873,14 @@ class ErrorCorrectionTrainer(BaseTrainer):
             predictions = model_output.round()
             correct = predictions.eq(labels).sum().item()
             total_loss += loss.item() * labels.nelement()
-                                     # N.B. if loss is using reduction='mean'
-                                     # summing the average losses over the
-                                     # batches and then dividing by the number
-                                     # of batches does not give you the true
-                                     # mean loss (though it is at least an
-                                     # unbiased estimate...)
-                                     # Using total rather than sum to account
-                                     # For the last batch being a different size
+            # N.B. if loss is using reduction='mean'
+            # summing the average losses over the
+            # batches and then dividing by the number
+            # of batches does not give you the true
+            # mean loss (though it is at least an
+            # unbiased estimate...)
+            # Using total rather than sum to account
+            # For the last batch being a different size
             total_correct += correct
             total_element += labels.nelement()
 
@@ -818,56 +889,65 @@ class ErrorCorrectionTrainer(BaseTrainer):
                 "batch": ii,
                 "mode": str_code,
                 "avg_loss": total_loss / total_element,
-                "avg_acc": total_correct / total_element * 100
+                "avg_acc": total_correct / total_element * 100,
             }
 
             if evaluate:
                 total_data_points += len(input_data)
-                for in_data, out_data, clean_data in \
-                        zip(input_data, model_output, labels):
+                for in_data, out_data, clean_data in zip(
+                    input_data, model_output, labels
+                ):
                     with warnings.catch_warnings():
                         warnings.simplefilter("ignore")
-                        deg_df = self.formatter['model_to_df'](
+                        deg_df = self.formatter["model_to_df"](
                             in_data.cpu().data.numpy(),
                             min_pitch=MIN_PITCH_DEFAULT,
-                            max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
-                        model_out_df = self.formatter['model_to_df'](
+                            max_pitch=MAX_PITCH_DEFAULT,
+                            time_increment=40,
+                        )
+                        model_out_df = self.formatter["model_to_df"](
                             out_data.round().cpu().data.numpy(),
                             min_pitch=MIN_PITCH_DEFAULT,
-                            max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
-                        clean_df = self.formatter['model_to_df'](
+                            max_pitch=MAX_PITCH_DEFAULT,
+                            time_increment=40,
+                        )
+                        clean_df = self.formatter["model_to_df"](
                             clean_data.cpu().data.numpy(),
                             min_pitch=MIN_PITCH_DEFAULT,
-                            max_pitch=MAX_PITCH_DEFAULT, time_increment=40)
+                            max_pitch=MAX_PITCH_DEFAULT,
+                            time_increment=40,
+                        )
                     h, f = helpfulness(model_out_df, deg_df, clean_df)
                     total_help += h
                     total_fm += f
 
-
             if self.batch_log_freq is not None:
                 if ii % self.batch_log_freq == 0:
-                    print(','.join([str(log_info[kk]) for kk in self.log_cols]),
-                          file=self.log_file)
+                    print(
+                        ",".join([str(log_info[kk]) for kk in self.log_cols]),
+                        file=self.log_file,
+                    )
 
-            data_iter.set_postfix(
-                avg_loss=round(log_info['avg_loss'], ndigits=3)
-            )
+            data_iter.set_postfix(avg_loss=round(log_info["avg_loss"], ndigits=3))
 
         if self.epoch_log_freq is not None:
             if epoch % self.epoch_log_freq == 0:
-                print(','.join([str(log_info[kk]) for kk in self.log_cols]),
-                      file=self.log_file)
+                print(
+                    ",".join([str(log_info[kk]) for kk in self.log_cols]),
+                    file=self.log_file,
+                )
 
         if evaluate:
             helpfulness_val = total_help / total_data_points
             fmeasure = total_fm / total_data_points
-            log_info['helpfulness'] = helpfulness_val
-            log_info['fmeasure'] = fmeasure
+            log_info["helpfulness"] = helpfulness_val
+            log_info["fmeasure"] = fmeasure
             print(f"Helpfulness: {helpfulness_val}")
             print(f"F-measure: {fmeasure}")
             print(f"Avg loss: {total_loss / total_element}")
 
         return log_info
+
 
 #        print("EP%d_%s, avg_loss=" % (epoch, str_code), avg_loss / len(data_iter), "total_acc=",
 #              total_correct * 100.0 / total_element)

--- a/mdtk/pytorch_trainers.py
+++ b/mdtk/pytorch_trainers.py
@@ -14,7 +14,7 @@ from mdtk.eval import get_f1, helpfulness
 
 class BaseTrainer:
     """Provides methods to train pytorch models. Adapted from:
-    https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/trainer/pretrain.py"""
+    https://github.com/codertimo/BERT-pytorch/blob/master/bert_pytorch/trainer/pretrain.py"""  # noqa:E501
 
     def __init__(
         self,
@@ -355,10 +355,6 @@ class ErrorDetectionTrainer(BaseTrainer):
         return log_info
 
 
-#        print("EP%d_%s, avg_loss=" % (epoch, str_code), avg_loss / len(data_iter), "total_acc=",
-#              total_correct * 100.0 / total_element)
-
-
 class ErrorClassificationTrainer(BaseTrainer):
     """Trains Task 2 - Error classification. The model provided is expected to be
     an mdtk.pytorch_models.ErrorClassificationNet. Expects a DataLoader using an
@@ -528,7 +524,8 @@ class ErrorClassificationTrainer(BaseTrainer):
             print(f"Accuracy: {total_correct / total_element * 100}")
             print(f"Avg loss: {total_loss / total_element}")
             print(f"Confusion matrix (as [label, output]):\n{confusion_mat}")
-            # Not required since in confusion matrix - here for verification / same accross classes
+            # Not required since in confusion matrix - here for verification / same
+            # accross classes
             log_info["avg_acc_per_deg"] = np.array(
                 [
                     total_correct_per_deg[deg] / total_element_per_deg[deg]
@@ -536,10 +533,6 @@ class ErrorClassificationTrainer(BaseTrainer):
                 ]
             )
         return log_info
-
-
-#        print("EP%d_%s, avg_loss=" % (epoch, str_code), avg_loss / len(data_iter), "total_acc=",
-#              total_correct * 100.0 / total_element)
 
 
 class ErrorLocationTrainer(BaseTrainer):
@@ -758,10 +751,6 @@ class ErrorLocationTrainer(BaseTrainer):
         return log_info
 
 
-#        print("EP%d_%s, avg_loss=" % (epoch, str_code), avg_loss / len(data_iter), "total_acc=",
-#              total_correct * 100.0 / total_element)
-
-
 class ErrorCorrectionTrainer(BaseTrainer):
     """Trains Task 4 - Error Correction. The model provided is expected to be
     an mdtk.pytorch_models.ErrorCorrectionNet. Expects a DataLoader using an
@@ -840,9 +829,6 @@ class ErrorCorrectionTrainer(BaseTrainer):
         total_help = 0
         total_fm = 0
         total_data_points = 0
-
-        total_correct_per_deg = defaultdict(lambda: 0)
-        total_element_per_deg = defaultdict(lambda: 0)
 
         # Setting the tqdm progress bar
         data_iter = tqdm.tqdm(
@@ -947,7 +933,3 @@ class ErrorCorrectionTrainer(BaseTrainer):
             print(f"Avg loss: {total_loss / total_element}")
 
         return log_info
-
-
-#        print("EP%d_%s, avg_loss=" % (epoch, str_code), avg_loss / len(data_iter), "total_acc=",
-#              total_correct * 100.0 / total_element)

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -1105,12 +1105,9 @@ def test_add_note():
         )
 
         diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
-        assert (
-            diff.shape[0] == 1
-        ), "Adding a note changed an existing note, or added note is a " "duplicate." + "\n" + str(
-            BASIC_DF
-        ) + "\n" + str(
-            res
+        assert diff.shape[0] == 1, (
+            "Adding a note changed an existing note, or added note is a duplicate.\n"
+            f"{BASIC_DF}\n{res}"
         )
         assert res.shape[0] == BASIC_DF.shape[0] + 1, "No note was added."
 

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -1,37 +1,35 @@
-import pandas as pd
-import numpy as np
-import re
-import pytest
 import itertools
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
 
 import mdtk.degradations as deg
 
-EMPTY_DF = pd.DataFrame({
-    'onset': [],
-    'track': [],
-    'pitch': [],
-    'dur': []
-})
+EMPTY_DF = pd.DataFrame({"onset": [], "track": [], "pitch": [], "dur": []})
 
 # test_join_notes() uses its own df, defined in the function
 # Create a garbled df with indices: [0, 2, 2, 4]
-BASIC_DF = pd.DataFrame({
-    'onset': [0, 100, 200, 200, 200],
-    'track': [0, 1, 0, 1, 1],
-    'pitch': [10, 20, 30, 40, 40],
-    'dur': [100, 100, 100, 100, 100]
-})
-BASIC_DF = pd.concat([BASIC_DF.iloc[[0,2]], BASIC_DF.iloc[[2,4]]])
-BASIC_DF.iloc[1]['onset'] = 100
-BASIC_DF.iloc[1]['track'] = 1
-BASIC_DF.iloc[1]['pitch'] = 20
-BASIC_DF.iloc[1]['dur'] = 100
+BASIC_DF = pd.DataFrame(
+    {
+        "onset": [0, 100, 200, 200, 200],
+        "track": [0, 1, 0, 1, 1],
+        "pitch": [10, 20, 30, 40, 40],
+        "dur": [100, 100, 100, 100, 100],
+    }
+)
+BASIC_DF = pd.concat([BASIC_DF.iloc[[0, 2]], BASIC_DF.iloc[[2, 4]]])
+BASIC_DF.iloc[1]["onset"] = 100
+BASIC_DF.iloc[1]["track"] = 1
+BASIC_DF.iloc[1]["pitch"] = 20
+BASIC_DF.iloc[1]["dur"] = 100
 
 # This version will not change
 BASIC_DF_FINAL = BASIC_DF
 
 # Create an unsorted BASIC_DF
-UNSORTED_DF = BASIC_DF.iloc[[0,2,3,1]]
+UNSORTED_DF = BASIC_DF.iloc[[0, 2, 3, 1]]
 
 
 def assert_none(res, msg=""):
@@ -39,19 +37,23 @@ def assert_none(res, msg=""):
 
 
 def test_pre_process():
-    basic_res = pd.DataFrame({
-        'onset': [0, 100, 200, 200],
-        'track': [0, 1, 0, 1],
-        'pitch': [10, 20, 30, 40],
-        'dur': [100, 100, 100, 100]
-    })
+    basic_res = pd.DataFrame(
+        {
+            "onset": [0, 100, 200, 200],
+            "track": [0, 1, 0, 1],
+            "pitch": [10, 20, 30, 40],
+            "dur": [100, 100, 100, 100],
+        }
+    )
 
-    unsorted_res = pd.DataFrame({
-        'onset': [0, 200, 200, 100],
-        'track': [0, 0, 1, 1],
-        'pitch': [10, 30, 40, 20],
-        'dur': [100, 100, 100, 100]
-    })
+    unsorted_res = pd.DataFrame(
+        {
+            "onset": [0, 200, 200, 100],
+            "track": [0, 0, 1, 1],
+            "pitch": [10, 30, 40, 20],
+            "dur": [100, 100, 100, 100],
+        }
+    )
 
     res = deg.pre_process(UNSORTED_DF)
     assert res.equals(unsorted_res), (
@@ -64,20 +66,24 @@ def test_pre_process():
         f"Pre-processing \n{UNSORTED_DF}\n with sort=True resulted in "
         f"\n{res}\ninstead of \n{basic_res}"
     )
-    
-    float_df = pd.DataFrame({
-        'track': [0, 1, 0, 1.5],
-        'onset': [0.5, 100.5, 200.5, 200.5],
-        'pitch': [10, 20, 30.5, 40],
-        'dur': [100, 100, 100.5, 100],
-        'extra': [5, 5, 'apple', None]
-    })
-    float_res = pd.DataFrame({
-        'onset': [0, 100, 200, 200],
-        'track': [0, 1, 0, 2],
-        'pitch': [10, 20, 30, 40],
-        'dur': [100, 100, 100, 100]
-    })
+
+    float_df = pd.DataFrame(
+        {
+            "track": [0, 1, 0, 1.5],
+            "onset": [0.5, 100.5, 200.5, 200.5],
+            "pitch": [10, 20, 30.5, 40],
+            "dur": [100, 100, 100.5, 100],
+            "extra": [5, 5, "apple", None],
+        }
+    )
+    float_res = pd.DataFrame(
+        {
+            "onset": [0, 100, 200, 200],
+            "track": [0, 1, 0, 2],
+            "pitch": [10, 20, 30, 40],
+            "dur": [100, 100, 100, 100],
+        }
+    )
     res = deg.pre_process(float_df)
     assert res.equals(float_res), (
         f"Pre-processing \n{float_df}\n resulted in \n{res}\n"
@@ -86,19 +92,23 @@ def test_pre_process():
 
 
 def test_post_process():
-    basic_res = pd.DataFrame({
-        'onset': [0, 100, 200, 200],
-        'track': [0, 1, 0, 1],
-        'pitch': [10, 20, 30, 40],
-        'dur': [100, 100, 100, 100]
-    })
+    basic_res = pd.DataFrame(
+        {
+            "onset": [0, 100, 200, 200],
+            "track": [0, 1, 0, 1],
+            "pitch": [10, 20, 30, 40],
+            "dur": [100, 100, 100, 100],
+        }
+    )
 
-    unsorted_res = pd.DataFrame({
-        'onset': [0, 200, 200, 100],
-        'track': [0, 0, 1, 1],
-        'pitch': [10, 30, 40, 20],
-        'dur': [100, 100, 100, 100]
-    })
+    unsorted_res = pd.DataFrame(
+        {
+            "onset": [0, 200, 200, 100],
+            "track": [0, 0, 1, 1],
+            "pitch": [10, 30, 40, 20],
+            "dur": [100, 100, 100, 100],
+        }
+    )
 
     res = deg.post_process(UNSORTED_DF, sort=False)
     assert res.equals(unsorted_res), (
@@ -115,52 +125,52 @@ def test_post_process():
 
 def test_overlaps():
     fixed_basic = deg.pre_process(BASIC_DF)
-    assert not deg.overlaps(fixed_basic, 0), (
-        f"Overlaps incorrectly returned True for:\n{fixed_basic}."
-    )
+    assert not deg.overlaps(
+        fixed_basic, 0
+    ), f"Overlaps incorrectly returned True for:\n{fixed_basic}."
 
-    fixed_basic.loc[0, 'onset'] = 50
-    assert not deg.overlaps(fixed_basic, 0), (
-        f"Overlaps incorrectly returned True for:\n{fixed_basic}."
-    )
+    fixed_basic.loc[0, "onset"] = 50
+    assert not deg.overlaps(
+        fixed_basic, 0
+    ), f"Overlaps incorrectly returned True for:\n{fixed_basic}."
 
-    fixed_basic.loc[0, 'pitch'] = 20
-    assert not deg.overlaps(fixed_basic, 0), (
-        f"Overlaps incorrectly returned True for:\n{fixed_basic}."
-    )
+    fixed_basic.loc[0, "pitch"] = 20
+    assert not deg.overlaps(
+        fixed_basic, 0
+    ), f"Overlaps incorrectly returned True for:\n{fixed_basic}."
 
-    fixed_basic.loc[0, 'track'] = 1
-    fixed_basic.loc[0, 'onset'] = 0
-    assert not deg.overlaps(fixed_basic, 0), (
-        f"Overlaps incorrectly returned True for:\n{fixed_basic}."
-    )
+    fixed_basic.loc[0, "track"] = 1
+    fixed_basic.loc[0, "onset"] = 0
+    assert not deg.overlaps(
+        fixed_basic, 0
+    ), f"Overlaps incorrectly returned True for:\n{fixed_basic}."
 
-    fixed_basic.loc[0, 'onset'] = 50
-    assert deg.overlaps(fixed_basic, 0), (
-        f"Overlaps incorrectly returned False for:\n{fixed_basic}."
-    )
+    fixed_basic.loc[0, "onset"] = 50
+    assert deg.overlaps(
+        fixed_basic, 0
+    ), f"Overlaps incorrectly returned False for:\n{fixed_basic}."
 
-    fixed_basic.loc[0, 'onset'] = 150
-    assert deg.overlaps(fixed_basic, 0), (
-        f"Overlaps incorrectly returned False for:\n{fixed_basic}."
-    )
+    fixed_basic.loc[0, "onset"] = 150
+    assert deg.overlaps(
+        fixed_basic, 0
+    ), f"Overlaps incorrectly returned False for:\n{fixed_basic}."
 
-    fixed_basic.loc[0, 'dur'] = 25
-    assert deg.overlaps(fixed_basic, 0), (
-        f"Overlaps incorrectly returned False for:\n{fixed_basic}."
-    )
+    fixed_basic.loc[0, "dur"] = 25
+    assert deg.overlaps(
+        fixed_basic, 0
+    ), f"Overlaps incorrectly returned False for:\n{fixed_basic}."
 
-    fixed_basic.loc[0, 'dur'] = 150
-    fixed_basic.loc[0, 'onset'] = 75
-    assert deg.overlaps(fixed_basic, 0), (
-        f"Overlaps incorrectly returned False for:\n{fixed_basic}."
-    )
+    fixed_basic.loc[0, "dur"] = 150
+    fixed_basic.loc[0, "onset"] = 75
+    assert deg.overlaps(
+        fixed_basic, 0
+    ), f"Overlaps incorrectly returned False for:\n{fixed_basic}."
 
 
 def test_unsorted():
     global BASIC_DF
     BASIC_DF = UNSORTED_DF
-    
+
     test_pitch_shift()
     test_time_shift()
     test_onset_shift()
@@ -168,26 +178,32 @@ def test_unsorted():
     test_remove_note()
     test_add_note()
     test_split_note()
-    
+
     BASIC_DF = BASIC_DF_FINAL
 
 
 def test_pitch_shift():
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to pitch"
-                                                   " shift. Returning None.")):
-        assert deg.pitch_shift(EMPTY_DF) is None, (
-            "Pitch shifting with empty data frame did not return None."
-        )
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("WARNING: No notes to pitch" " shift. Returning None."),
+    ):
+        assert (
+            deg.pitch_shift(EMPTY_DF) is None
+        ), "Pitch shifting with empty data frame did not return None."
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
         # Deterministic testing
         for i in range(2):
             res = deg.pitch_shift(BASIC_DF, seed=1)
 
-            basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
-                                      'track': [0, 1, 0, 1],
-                                      'pitch': [10, 33, 30, 40],
-                                      'dur': [100, 100, 100, 100]})
+            basic_res = pd.DataFrame(
+                {
+                    "onset": [0, 100, 200, 200],
+                    "track": [0, 1, 0, 1],
+                    "pitch": [10, 33, 30, 40],
+                    "dur": [100, 100, 100, 100],
+                }
+            )
 
             assert res.equals(basic_res), (
                 f"Pitch shifting \n{BASIC_DF}\n resulted in \n{res}\n"
@@ -197,7 +213,7 @@ def test_pitch_shift():
             assert not BASIC_DF.equals(res), "Note_df was not copied."
 
     # Test if tries works
-    df = pd.DataFrame({'onset': [0], 'pitch': [10], 'track': [0], 'dur': [100]})
+    df = pd.DataFrame({"onset": [0], "pitch": [10], "track": [0], "dur": [100]})
     with pytest.warns(UserWarning, match=re.escape(deg.TRIES_WARN_MSG)):
         res = deg.pitch_shift(df, min_pitch=10, max_pitch=10)
         assert_none(res, msg="Pitch shift should run out of tries.")
@@ -206,32 +222,30 @@ def test_pitch_shift():
     for i in range(10):
         np.random.seed()
 
-        res = deg.pitch_shift(BASIC_DF, min_pitch=100 * i,
-                              max_pitch=100 * (i + 1))
+        res = deg.pitch_shift(BASIC_DF, min_pitch=100 * i, max_pitch=100 * (i + 1))
 
         # Check that only things that should have changed have changed
         diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
         assert diff.shape[0] == 2, "Pitch shift changed more than 1 note."
-        assert diff.iloc[0]['onset'] == diff.iloc[1]['onset'], (
-            "Pitch shift changed some onset time."
-        )
-        assert diff.iloc[0]['track'] == diff.iloc[1]['track'], (
-            "Pitch shift changed some track."
-        )
-        assert diff.iloc[0]['dur'] == diff.iloc[1]['dur'], (
-            "Pitch shift changed some duration."
-        )
-        assert diff.iloc[0]['pitch'] != diff.iloc[1]['pitch'], (
-            "Pitch shift did not change pitch."
-        )
+        assert (
+            diff.iloc[0]["onset"] == diff.iloc[1]["onset"]
+        ), "Pitch shift changed some onset time."
+        assert (
+            diff.iloc[0]["track"] == diff.iloc[1]["track"]
+        ), "Pitch shift changed some track."
+        assert (
+            diff.iloc[0]["dur"] == diff.iloc[1]["dur"]
+        ), "Pitch shift changed some duration."
+        assert (
+            diff.iloc[0]["pitch"] != diff.iloc[1]["pitch"]
+        ), "Pitch shift did not change pitch."
 
         # Check that changed pitch is within given range
-        changed_pitch = diff.iloc[0]['pitch']
-        #changed_pitch = res[(res['pitch'] !=
+        changed_pitch = diff.iloc[0]["pitch"]
+        # changed_pitch = res[(res['pitch'] !=
         #                     BASIC_DF['pitch'])]['pitch'].iloc[0]
         assert 100 * i <= changed_pitch <= 100 * (i + 1), (
-            f"Pitch {changed_pitch} outside of range "
-            f"[{100 * i}, {100 * (i + 1)}]"
+            f"Pitch {changed_pitch} outside of range " f"[{100 * i}, {100 * (i + 1)}]"
         )
 
         # Check a simple setting of the distribution parameter
@@ -245,8 +259,8 @@ def test_pitch_shift():
         res = deg.pitch_shift(BASIC_DF, distribution=distribution)
 
         diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
-        changed_pitch = diff.iloc[0]['pitch']
-        original_pitch = diff.iloc[1]['pitch']
+        changed_pitch = diff.iloc[0]["pitch"]
+        original_pitch = diff.iloc[1]["pitch"]
         diff = original_pitch - changed_pitch
 
         assert diff == correct_diff, (
@@ -258,63 +272,89 @@ def test_pitch_shift():
     # Check for distribution warnings
     with pytest.warns(
         UserWarning,
-        match=re.escape('WARNING: distribution contains only 0s after '
-                        'setting distribution[zero_idx] value to 0. '
-                        'Returning None.')
+        match=re.escape(
+            "WARNING: distribution contains only 0s after "
+            "setting distribution[zero_idx] value to 0. "
+            "Returning None."
+        ),
     ):
         res = deg.pitch_shift(BASIC_DF, distribution=[0, 1, 0])
-        assert res is None, (
-            "Pitch shifting with distribution of 0s returned something."
-        )
+        assert res is None, "Pitch shifting with distribution of 0s returned something."
 
-    with pytest.warns(UserWarning, match=re.escape('WARNING: No valid pitches '
-                                                   'to shift given min_pitch')):
-        res = deg.pitch_shift(BASIC_DF, min_pitch=-50,
-                              max_pitch=-20, distribution=[1, 0, 1])
-        assert res is None, (
-            "Pitch shifting with invalid distribution returned something."
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("WARNING: No valid pitches " "to shift given min_pitch"),
+    ):
+        res = deg.pitch_shift(
+            BASIC_DF, min_pitch=-50, max_pitch=-20, distribution=[1, 0, 1]
         )
+        assert (
+            res is None
+        ), "Pitch shifting with invalid distribution returned something."
 
-    res = deg.pitch_shift(BASIC_DF, min_pitch=BASIC_DF['pitch'].min() - 1,
-                          max_pitch=BASIC_DF['pitch'].min() - 1,
-                          distribution=[1, 0, 0])
+    res = deg.pitch_shift(
+        BASIC_DF,
+        min_pitch=BASIC_DF["pitch"].min() - 1,
+        max_pitch=BASIC_DF["pitch"].min() - 1,
+        distribution=[1, 0, 0],
+    )
     assert res is not None, "Valid shift down of 1 pitch returned None."
 
-    with pytest.warns(UserWarning, match=re.escape('WARNING: No valid pitches to shift '
-                                                   'given min_pitch')):
-        res = deg.pitch_shift(BASIC_DF, min_pitch=BASIC_DF['pitch'].min() - 2,
-                              max_pitch=BASIC_DF['pitch'].min() - 2,
-                              distribution=[1, 0, 0])
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("WARNING: No valid pitches to shift " "given min_pitch"),
+    ):
+        res = deg.pitch_shift(
+            BASIC_DF,
+            min_pitch=BASIC_DF["pitch"].min() - 2,
+            max_pitch=BASIC_DF["pitch"].min() - 2,
+            distribution=[1, 0, 0],
+        )
         assert res is None, "Invalid shift down of 2 pitch returned something."
 
-    res = deg.pitch_shift(BASIC_DF, min_pitch=BASIC_DF['pitch'].max() + 1,
-                          max_pitch=BASIC_DF['pitch'].max() + 1,
-                          distribution=[0, 0, 1])
+    res = deg.pitch_shift(
+        BASIC_DF,
+        min_pitch=BASIC_DF["pitch"].max() + 1,
+        max_pitch=BASIC_DF["pitch"].max() + 1,
+        distribution=[0, 0, 1],
+    )
     assert res is not None, "Valid shift up of 1 pitch returned None."
 
-    with pytest.warns(UserWarning, match=re.escape('WARNING: No valid pitches to shift '
-                                                   'given min_pitch')):
-        res = deg.pitch_shift(BASIC_DF, min_pitch=BASIC_DF['pitch'].max() + 2,
-                              max_pitch=BASIC_DF['pitch'].max() + 2,
-                              distribution=[0, 0, 1])
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("WARNING: No valid pitches to shift " "given min_pitch"),
+    ):
+        res = deg.pitch_shift(
+            BASIC_DF,
+            min_pitch=BASIC_DF["pitch"].max() + 2,
+            max_pitch=BASIC_DF["pitch"].max() + 2,
+            distribution=[0, 0, 1],
+        )
         assert res is None, "Invalid shift up of 2 pitch returned something."
 
 
 def test_time_shift():
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to time "
-                                                   "shift. Returning None.")):
-        assert deg.time_shift(EMPTY_DF) is None, ("Time shifting with empty data "
-                                                  "frame did not return None.")
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("WARNING: No valid notes to time " "shift. Returning None."),
+    ):
+        assert deg.time_shift(EMPTY_DF) is None, (
+            "Time shifting with empty data " "frame did not return None."
+        )
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
         # Deterministic testing
         for i in range(2):
             res = deg.time_shift(BASIC_DF, seed=1)
 
-            basic_res = pd.DataFrame({'onset': [0, 200, 200, 200],
-                                      'track': [0, 0, 1, 1],
-                                      'pitch': [10, 30, 20, 40],
-                                      'dur': [100, 100, 100, 100]})
+            basic_res = pd.DataFrame(
+                {
+                    "onset": [0, 200, 200, 200],
+                    "track": [0, 0, 1, 1],
+                    "pitch": [10, 30, 20, 40],
+                    "dur": [100, 100, 100, 100],
+                }
+            )
 
             assert res.equals(basic_res), (
                 f"Time shifting \n{BASIC_DF}\nresulted in \n{res}\n"
@@ -329,72 +369,77 @@ def test_time_shift():
 
         min_shift = 10 * i
         max_shift = 10 * (i + 1)
-        res = deg.time_shift(BASIC_DF, min_shift=min_shift,
-                             max_shift=max_shift)
+        res = deg.time_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift)
 
         # Check that only things that should have changed have changed
         diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
         assert diff.shape[0] == 2, "Time shift changed more than 1 note."
-        assert diff.iloc[0]['onset'] != diff.iloc[1]['onset'], (
-            "Time shift did not change any onset time."
-        )
-        assert diff.iloc[0]['track'] == diff.iloc[1]['track'], (
-            "Time shift changed some track."
-        )
-        assert diff.iloc[0]['dur'] == diff.iloc[1]['dur'], (
-            "Time shift changed some duration."
-        )
-        assert diff.iloc[0]['pitch'] == diff.iloc[1]['pitch'], (
-            "Time shift changed some pitch."
-        )
+        assert (
+            diff.iloc[0]["onset"] != diff.iloc[1]["onset"]
+        ), "Time shift did not change any onset time."
+        assert (
+            diff.iloc[0]["track"] == diff.iloc[1]["track"]
+        ), "Time shift changed some track."
+        assert (
+            diff.iloc[0]["dur"] == diff.iloc[1]["dur"]
+        ), "Time shift changed some duration."
+        assert (
+            diff.iloc[0]["pitch"] == diff.iloc[1]["pitch"]
+        ), "Time shift changed some pitch."
 
         # Check that changed onset is within given range
-        changed_onset = diff.iloc[0]['onset']
-        original_onset = diff.iloc[1]['onset']
+        changed_onset = diff.iloc[0]["onset"]
+        original_onset = diff.iloc[1]["onset"]
         shift = abs(changed_onset - original_onset)
-        assert min_shift <= shift <= max_shift, (
-            f"Shift {shift} outside of range [{min_shift}, {max_shift}]."
-        )
+        assert (
+            min_shift <= shift <= max_shift
+        ), f"Shift {shift} outside of range [{min_shift}, {max_shift}]."
 
         # Check with align_onset=True
         if min_shift <= 200 and max_shift >= 100:
-            res = deg.time_shift(BASIC_DF, min_shift=min_shift,
-                                 max_shift=max_shift, align_onset=True)
+            res = deg.time_shift(
+                BASIC_DF, min_shift=min_shift, max_shift=max_shift, align_onset=True
+            )
 
             # Check that only things that should have changed have changed
             diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
-            assert diff.shape[0] == 2, "Time shift changed more than 1 note." + f"\n{BASIC_DF}\n{res}\n{min_shift}_{max_shift}"
-            assert diff.iloc[0]['onset'] != diff.iloc[1]['onset'], (
-                "Time shift did not change any onset time."
+            assert diff.shape[0] == 2, (
+                "Time shift changed more than 1 note."
+                + f"\n{BASIC_DF}\n{res}\n{min_shift}_{max_shift}"
             )
-            assert diff.iloc[0]['track'] == diff.iloc[1]['track'], (
-                "Time shift changed some track."
-            )
-            assert diff.iloc[0]['dur'] == diff.iloc[1]['dur'], (
-                "Time shift changed some duration."
-            )
-            assert diff.iloc[0]['pitch'] == diff.iloc[1]['pitch'], (
-                "Time shift changed some pitch."
-            )
-            assert diff.iloc[0]['onset'] in BASIC_DF['onset'].unique(), (
-                "Time shift didn't change to an aligned onset."
-            )
+            assert (
+                diff.iloc[0]["onset"] != diff.iloc[1]["onset"]
+            ), "Time shift did not change any onset time."
+            assert (
+                diff.iloc[0]["track"] == diff.iloc[1]["track"]
+            ), "Time shift changed some track."
+            assert (
+                diff.iloc[0]["dur"] == diff.iloc[1]["dur"]
+            ), "Time shift changed some duration."
+            assert (
+                diff.iloc[0]["pitch"] == diff.iloc[1]["pitch"]
+            ), "Time shift changed some pitch."
+            assert (
+                diff.iloc[0]["onset"] in BASIC_DF["onset"].unique()
+            ), "Time shift didn't change to an aligned onset."
 
             # Check that changed onset is within given range
-            changed_onset = diff.iloc[0]['onset']
-            original_onset = diff.iloc[1]['onset']
+            changed_onset = diff.iloc[0]["onset"]
+            original_onset = diff.iloc[1]["onset"]
             shift = abs(changed_onset - original_onset)
-            assert min_shift <= shift <= max_shift, (
-                f"Shift {shift} outside of range [{min_shift}, {max_shift}]."
-            )
+            assert (
+                min_shift <= shift <= max_shift
+            ), f"Shift {shift} outside of range [{min_shift}, {max_shift}]."
         else:
-            with pytest.warns(UserWarning, match=re.escape('WARNING:')):
-                res = deg.time_shift(BASIC_DF, min_shift=min_shift,
-                                     max_shift=max_shift, align_onset=True)
+            with pytest.warns(UserWarning, match=re.escape("WARNING:")):
+                res = deg.time_shift(
+                    BASIC_DF, min_shift=min_shift, max_shift=max_shift, align_onset=True
+                )
 
     # Check for range too large warning
-    with pytest.warns(UserWarning, match=re.escape('WARNING: No valid notes to '
-                                                   'time shift.')):
+    with pytest.warns(
+        UserWarning, match=re.escape("WARNING: No valid notes to " "time shift.")
+    ):
         res = deg.time_shift(BASIC_DF, min_shift=201, max_shift=202)
         assert res is None, "Invalid time shift of 201 returned something."
 
@@ -403,8 +448,9 @@ def test_time_shift():
 
 
 def test_onset_shift():
-    def check_onset_shift_result(df, res, min_shift, max_shift,
-                                 min_duration, max_duration):
+    def check_onset_shift_result(
+        df, res, min_shift, max_shift, min_duration, max_duration
+    ):
         assert res is not None, "Onset shift returned None unexpectedly."
 
         diff = pd.concat([res, df]).drop_duplicates(keep=False)
@@ -412,53 +458,58 @@ def test_onset_shift():
         changed_note = pd.merge(diff, df).reset_index()
         unchanged_notes = pd.merge(res, df).reset_index()
 
-        assert unchanged_notes.shape[0] == df.shape[0] - 1, (
-            "More or less than 1 note changed when shifting onset."
-        )
-        assert changed_note.shape[0] == 1, (
-            "More than 1 note changed when shifting onset."
-        )
-        assert new_note.shape[0] == 1, (
-            "More than 1 new note added when shifting onset."
-        )
-        assert min_duration <= new_note.loc[0]['dur'] <= max_duration, (
-            "Note duration not within bounds when onset shifting."
-        )
-        assert (min_shift <=
-                abs(new_note.loc[0]['onset'] - changed_note.loc[0]['onset'])
-                <= max_shift), (
-            "Note shifted outside of bounds when onset shifting."
-        )
-        assert new_note.loc[0]['pitch'] == changed_note.loc[0]['pitch'], (
-            "Pitch changed when onset shifting."
-        )
-        assert new_note.loc[0]['track'] == changed_note.loc[0]['track'], (
-            "Track changed when onset shifting."
-        )
-        assert (changed_note.loc[0]['onset'] + changed_note.loc[0]['dur']
-                == new_note.loc[0]['onset'] + new_note.loc[0]['dur']), (
-            "Offset changed when onset shifting."
-        )
-        assert changed_note.loc[0]['onset'] >= 0, (
-            "Changed note given negative onset time."
-        )
+        assert (
+            unchanged_notes.shape[0] == df.shape[0] - 1
+        ), "More or less than 1 note changed when shifting onset."
+        assert (
+            changed_note.shape[0] == 1
+        ), "More than 1 note changed when shifting onset."
+        assert new_note.shape[0] == 1, "More than 1 new note added when shifting onset."
+        assert (
+            min_duration <= new_note.loc[0]["dur"] <= max_duration
+        ), "Note duration not within bounds when onset shifting."
+        assert (
+            min_shift
+            <= abs(new_note.loc[0]["onset"] - changed_note.loc[0]["onset"])
+            <= max_shift
+        ), "Note shifted outside of bounds when onset shifting."
+        assert (
+            new_note.loc[0]["pitch"] == changed_note.loc[0]["pitch"]
+        ), "Pitch changed when onset shifting."
+        assert (
+            new_note.loc[0]["track"] == changed_note.loc[0]["track"]
+        ), "Track changed when onset shifting."
+        assert (
+            changed_note.loc[0]["onset"] + changed_note.loc[0]["dur"]
+            == new_note.loc[0]["onset"] + new_note.loc[0]["dur"]
+        ), "Offset changed when onset shifting."
+        assert (
+            changed_note.loc[0]["onset"] >= 0
+        ), "Changed note given negative onset time."
 
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                   " onset shift. Returning "
-                                                   "None.")):
-        assert deg.onset_shift(EMPTY_DF) is None, (
-            "Onset shifting with empty data frame did not return None."
-        )
+    with pytest.warns(
+        UserWarning,
+        match=re.escape(
+            "WARNING: No valid notes to" " onset shift. Returning " "None."
+        ),
+    ):
+        assert (
+            deg.onset_shift(EMPTY_DF) is None
+        ), "Onset shifting with empty data frame did not return None."
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
         # Deterministic testing
         for i in range(2):
             res = deg.onset_shift(BASIC_DF, seed=1)
 
-            basic_res = pd.DataFrame({'onset': [0, 72, 100, 200],
-                                      'track': [0, 0, 1, 1],
-                                      'pitch': [10, 30, 20, 40],
-                                      'dur': [100, 228, 100, 100]})
+            basic_res = pd.DataFrame(
+                {
+                    "onset": [0, 72, 100, 200],
+                    "track": [0, 0, 1, 1],
+                    "pitch": [10, 30, 20, 40],
+                    "dur": [100, 228, 100, 100],
+                }
+            )
 
             assert res.equals(basic_res), (
                 f"Onset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
@@ -477,83 +528,133 @@ def test_onset_shift():
         # Cut min/max shift in half towards less shift
         min_duration = 100 - min_shift - 5
         max_duration = 100 + min_shift + 5
-        res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                              min_duration=min_duration, max_duration=max_duration)
-        check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                 max_duration)
+        res = deg.onset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_onset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Duration is too short
         min_duration = 0
         max_duration = 100 - max_shift - 1
 
-        with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                       " onset shift. Returning "
-                                                       "None.")):
-            res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                  min_duration=min_duration, max_duration=max_duration)
-            assert res is None, (
-                "Onset shift with max_duration too short didn't return None."
+        with pytest.warns(
+            UserWarning,
+            match=re.escape(
+                "WARNING: No valid notes to" " onset shift. Returning " "None."
+            ),
+        ):
+            res = deg.onset_shift(
+                BASIC_DF,
+                min_shift=min_shift,
+                max_shift=max_shift,
+                min_duration=min_duration,
+                max_duration=max_duration,
             )
+            assert (
+                res is None
+            ), "Onset shift with max_duration too short didn't return None."
 
         # Duration is barely short enough
         min_duration = 0
         max_duration = 100 - max_shift
-        res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                              min_duration=min_duration, max_duration=max_duration)
-        check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                 max_duration)
+        res = deg.onset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_onset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Duration is too long
         min_duration = 100 + max_shift + 1
         max_duration = np.inf
 
-        with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                       " onset shift. Returning "
-                                                       "None.")):
-            res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                                  min_duration=min_duration, max_duration=max_duration)
-            assert res is None, (
-                "Onset shift with min_duration too long didn't return None."
+        with pytest.warns(
+            UserWarning,
+            match=re.escape(
+                "WARNING: No valid notes to" " onset shift. Returning " "None."
+            ),
+        ):
+            res = deg.onset_shift(
+                BASIC_DF,
+                min_shift=min_shift,
+                max_shift=max_shift,
+                min_duration=min_duration,
+                max_duration=max_duration,
             )
+            assert (
+                res is None
+            ), "Onset shift with min_duration too long didn't return None."
 
         # Duration is barely short enough
         min_duration = 100 + max_shift
         max_duration = np.inf
-        res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                              min_duration=min_duration, max_duration=max_duration)
-        check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                 max_duration)
+        res = deg.onset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_onset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Duration is shortest half of shift
         min_duration = 0
         max_duration = 100 - min_shift - 5
-        res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                              min_duration=min_duration, max_duration=max_duration)
-        check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                 max_duration)
+        res = deg.onset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_onset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Duration is longest half of shift
         min_duration = 100 + min_shift + 5
         max_duration = np.inf
-        res = deg.onset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                              min_duration=min_duration, max_duration=max_duration)
-        check_onset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                 max_duration)
+        res = deg.onset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_onset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Test with various alignments
-        align_df = pd.DataFrame({'onset': [0, 50, 100, 150, 200],
-                                 'track': [0, 1, 0, 0, 1],
-                                 'pitch': [10, 20, 25, 30, 40],
-                                 'dur': [100, 100, 50, 150, 100]})
+        align_df = pd.DataFrame(
+            {
+                "onset": [0, 50, 100, 150, 200],
+                "track": [0, 1, 0, 0, 1],
+                "pitch": [10, 20, 25, 30, 40],
+                "dur": [100, 100, 50, 150, 100],
+            }
+        )
         # Test with align_dur
         res = deg.onset_shift(align_df, align_dur=True)
         check_onset_shift_result(align_df, res, 50, np.inf, 50, np.inf)
 
-        assert (100 in list(res['dur']) and
-                (50 in list(res['dur']) or 150 in list(res['dur'])) and
-                res['dur'].isin([50, 100, 150]).all()), (
-            "Onset with align_dur didn't align duration."
-        )
+        assert (
+            100 in list(res["dur"])
+            and (50 in list(res["dur"]) or 150 in list(res["dur"]))
+            and res["dur"].isin([50, 100, 150]).all()
+        ), "Onset with align_dur didn't align duration."
 
         with pytest.warns(UserWarning, match=re.escape("WARNING:")):
             res = deg.onset_shift(align_df, align_dur=True, min_shift=101)
@@ -572,10 +673,10 @@ def test_onset_shift():
         res = deg.onset_shift(align_df, align_onset=True)
         check_onset_shift_result(align_df, res, 50, np.inf, 50, np.inf)
 
-        assert (len(set([0, 50, 100, 150, 200]) - set(res['onset'])) == 1 and
-                len(set(res['onset'])) == 4), (
-            "Onset with align_onset didn't align onset."
-        )
+        assert (
+            len(set([0, 50, 100, 150, 200]) - set(res["onset"])) == 1
+            and len(set(res["onset"])) == 4
+        ), "Onset with align_onset didn't align onset."
 
         with pytest.warns(UserWarning, match=re.escape("WARNING:")):
             res = deg.onset_shift(align_df, align_dur=True, min_shift=201)
@@ -594,15 +695,15 @@ def test_onset_shift():
         res = deg.onset_shift(align_df, align_onset=True, align_dur=True)
         check_onset_shift_result(align_df, res, 50, np.inf, 50, np.inf)
 
-        assert (100 in list(res['dur']) and
-                (50 in list(res['dur']) or 150 in list(res['dur'])) and
-                res['dur'].isin([50, 100, 150]).all()), (
-            "Onset with align_dur and align_onset didn't align duration."
-        )
-        assert (len(set([0, 50, 100, 150, 200]) - set(res['onset'])) == 1 and
-                len(set(res['onset'])) == 4), (
-            "Onset with align_dur and align_onset didn't align onset."
-        )
+        assert (
+            100 in list(res["dur"])
+            and (50 in list(res["dur"]) or 150 in list(res["dur"]))
+            and res["dur"].isin([50, 100, 150]).all()
+        ), "Onset with align_dur and align_onset didn't align duration."
+        assert (
+            len(set([0, 50, 100, 150, 200]) - set(res["onset"])) == 1
+            and len(set(res["onset"])) == 4
+        ), "Onset with align_dur and align_onset didn't align onset."
 
         with pytest.warns(UserWarning, match=re.escape("WARNING:")):
             res = deg.onset_shift(align_df, align_dur=True, min_shift=101)
@@ -617,9 +718,12 @@ def test_onset_shift():
             res = deg.onset_shift(align_df, align_dur=True, max_duration=49)
             assert_none(res)
 
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                   " onset shift. Returning "
-                                                   "None.")):
+    with pytest.warns(
+        UserWarning,
+        match=re.escape(
+            "WARNING: No valid notes to" " onset shift. Returning " "None."
+        ),
+    ):
         res = deg.onset_shift(BASIC_DF, min_shift=300)
         assert res is None, (
             "Onset shifting with empty data min_shift greater than "
@@ -628,59 +732,67 @@ def test_onset_shift():
 
 
 def test_offset_shift():
-    def check_offset_shift_result(df, res, min_shift, max_shift,
-                                  min_duration, max_duration):
+    def check_offset_shift_result(
+        df, res, min_shift, max_shift, min_duration, max_duration
+    ):
         diff = pd.concat([res, df]).drop_duplicates(keep=False)
         new_note = pd.merge(diff, res).reset_index()
         changed_note = pd.merge(diff, df).reset_index()
         unchanged_notes = pd.merge(res, df).reset_index()
 
-        assert unchanged_notes.shape[0] == df.shape[0] - 1, (
-            "More or less than 1 note changed when shifting offset."
-        )
-        assert changed_note.shape[0] == 1, (
-            "More than 1 note changed when shifting offset."
-        )
-        assert new_note.shape[0] == 1, (
-            "More than 1 new note added when shifting offset."
-        )
-        assert min_duration <= new_note.loc[0]['dur'] <= max_duration, (
-            "Note duration not within bounds when offset shifting."
-        )
-        assert (min_shift <=
-                abs(new_note.loc[0]['dur'] - changed_note.loc[0]['dur'])
-                <= max_shift), (
-            "Note offset shifted outside of bounds when onset shifting."
-        )
-        assert new_note.loc[0]['pitch'] == changed_note.loc[0]['pitch'], (
-            "Pitch changed when offset shifting."
-        )
-        assert new_note.loc[0]['track'] == changed_note.loc[0]['track'], (
-            "Track changed when offset shifting."
-        )
-        assert changed_note.loc[0]['onset'] == new_note.loc[0]['onset'], (
-            "Onset changed when offset shifting."
-        )
-        assert (changed_note.loc[0]['onset'] + changed_note.loc[0]['dur']
-                <= df[['onset', 'dur']].sum(axis=1).max()), (
-            "Changed note offset shifted past previous last offset."
-        )
+        assert (
+            unchanged_notes.shape[0] == df.shape[0] - 1
+        ), "More or less than 1 note changed when shifting offset."
+        assert (
+            changed_note.shape[0] == 1
+        ), "More than 1 note changed when shifting offset."
+        assert (
+            new_note.shape[0] == 1
+        ), "More than 1 new note added when shifting offset."
+        assert (
+            min_duration <= new_note.loc[0]["dur"] <= max_duration
+        ), "Note duration not within bounds when offset shifting."
+        assert (
+            min_shift
+            <= abs(new_note.loc[0]["dur"] - changed_note.loc[0]["dur"])
+            <= max_shift
+        ), "Note offset shifted outside of bounds when onset shifting."
+        assert (
+            new_note.loc[0]["pitch"] == changed_note.loc[0]["pitch"]
+        ), "Pitch changed when offset shifting."
+        assert (
+            new_note.loc[0]["track"] == changed_note.loc[0]["track"]
+        ), "Track changed when offset shifting."
+        assert (
+            changed_note.loc[0]["onset"] == new_note.loc[0]["onset"]
+        ), "Onset changed when offset shifting."
+        assert (
+            changed_note.loc[0]["onset"] + changed_note.loc[0]["dur"]
+            <= df[["onset", "dur"]].sum(axis=1).max()
+        ), "Changed note offset shifted past previous last offset."
 
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                   " offset shift. Returning "
-                                                   "None.")):
-        assert deg.offset_shift(EMPTY_DF) is None, (
-            "Offset shifting with empty data frame did not return None."
-        )
+    with pytest.warns(
+        UserWarning,
+        match=re.escape(
+            "WARNING: No valid notes to" " offset shift. Returning " "None."
+        ),
+    ):
+        assert (
+            deg.offset_shift(EMPTY_DF) is None
+        ), "Offset shifting with empty data frame did not return None."
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
         # Deterministic testing
         for i in range(2):
             res = deg.offset_shift(BASIC_DF, seed=1)
-            basic_res = pd.DataFrame({'onset': [0, 100, 200, 200],
-                                      'track': [0, 1, 0, 1],
-                                      'pitch': [10, 20, 30, 40],
-                                      'dur': [100, 200, 100, 100]})
+            basic_res = pd.DataFrame(
+                {
+                    "onset": [0, 100, 200, 200],
+                    "track": [0, 1, 0, 1],
+                    "pitch": [10, 20, 30, 40],
+                    "dur": [100, 200, 100, 100],
+                }
+            )
 
             assert res.equals(basic_res), (
                 f"Offset shifting \n{BASIC_DF}\nresulted in \n{res}\n"
@@ -690,8 +802,10 @@ def test_offset_shift():
 
             with pytest.warns(UserWarning, match=re.escape("WARNING:")):
                 res = deg.offset_shift(BASIC_DF, seed=1, align_dur=True)
-                assert res is None, ("Offset shift with align_dur doesn't "
-                                     "fail on excerpt with only 1 duration.")
+                assert res is None, (
+                    "Offset shift with align_dur doesn't "
+                    "fail on excerpt with only 1 duration."
+                )
 
     # Random testing
     for i in range(10):
@@ -703,85 +817,135 @@ def test_offset_shift():
         # Cut min/max shift in half towards less shift
         min_duration = 100 - min_shift - 5
         max_duration = 100 + min_shift + 5
-        res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                               min_duration=min_duration, max_duration=max_duration)
-        check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                  max_duration)
+        res = deg.offset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_offset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Duration is too short
         min_duration = 0
         max_duration = 100 - max_shift - 1
 
-        with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                       " offset shift. Returning "
-                                                       "None.")):
-            res = deg.offset_shift(BASIC_DF, min_shift=min_shift,
-                                   max_shift=max_shift, min_duration=min_duration,
-                                   max_duration=max_duration)
-            assert res is None, (
-                "Offset shift with max_duration too short didn't return None."
+        with pytest.warns(
+            UserWarning,
+            match=re.escape(
+                "WARNING: No valid notes to" " offset shift. Returning " "None."
+            ),
+        ):
+            res = deg.offset_shift(
+                BASIC_DF,
+                min_shift=min_shift,
+                max_shift=max_shift,
+                min_duration=min_duration,
+                max_duration=max_duration,
             )
+            assert (
+                res is None
+            ), "Offset shift with max_duration too short didn't return None."
 
         # Duration is barely short enough
         min_duration = 0
         max_duration = 100 - max_shift
-        res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                               min_duration=min_duration, max_duration=max_duration)
-        check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                  max_duration)
+        res = deg.offset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_offset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Duration is too long
         min_duration = 100 + max_shift + 1
         max_duration = np.inf
 
-        with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                       " offset shift. Returning "
-                                                       "None.")):
-            res = deg.offset_shift(BASIC_DF, min_shift=min_shift,
-                                   max_shift=max_shift, min_duration=min_duration,
-                                   max_duration=max_duration)
-            assert res is None, (
-                "Offset shift with min_duration too long didn't return None."
+        with pytest.warns(
+            UserWarning,
+            match=re.escape(
+                "WARNING: No valid notes to" " offset shift. Returning " "None."
+            ),
+        ):
+            res = deg.offset_shift(
+                BASIC_DF,
+                min_shift=min_shift,
+                max_shift=max_shift,
+                min_duration=min_duration,
+                max_duration=max_duration,
             )
+            assert (
+                res is None
+            ), "Offset shift with min_duration too long didn't return None."
 
         # Duration is barely short enough
         min_duration = 100 + max_shift
         max_duration = np.inf
-        res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                               min_duration=min_duration, max_duration=max_duration)
-        check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                  max_duration)
+        res = deg.offset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_offset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Duration is shortest half of shift
         min_duration = 0
         max_duration = 100 - min_shift - 5
-        res = deg.offset_shift(BASIC_DF, min_shift=min_shift,max_shift=max_shift,
-                               min_duration=min_duration, max_duration=max_duration)
-        check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                  max_duration)
+        res = deg.offset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_offset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Duration is longest half of shift
         min_duration = 100 + min_shift + 5
         max_duration = np.inf
-        res = deg.offset_shift(BASIC_DF, min_shift=min_shift, max_shift=max_shift,
-                               min_duration=min_duration, max_duration=max_duration)
-        check_offset_shift_result(BASIC_DF, res, min_shift, max_shift, min_duration,
-                                  max_duration)
+        res = deg.offset_shift(
+            BASIC_DF,
+            min_shift=min_shift,
+            max_shift=max_shift,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
+        check_offset_shift_result(
+            BASIC_DF, res, min_shift, max_shift, min_duration, max_duration
+        )
 
         # Test align_dur
         align_df = BASIC_DF.copy()
-        align_df.iloc[0]['dur'] = 150
+        align_df.iloc[0]["dur"] = 150
 
-        if ((min_duration <= 150 and max_duration >= 100) and
-            (min_shift <= 50 <= max_shift)):
-            res = deg.offset_shift(align_df, min_shift=min_shift,
-                                   max_shift=max_shift, min_duration=min_duration,
-                                   max_duration=max_duration, align_dur=True)
-            assert ((tuple(res['dur']) in
-                     list(itertools.permutations([150, 150, 100, 100]))) or
-                    (list(res['dur']) == [100, 100, 100, 100])), (
-                "Offset shift with align_dur doesn't properly align duration."
+        if (min_duration <= 150 and max_duration >= 100) and (
+            min_shift <= 50 <= max_shift
+        ):
+            res = deg.offset_shift(
+                align_df,
+                min_shift=min_shift,
+                max_shift=max_shift,
+                min_duration=min_duration,
+                max_duration=max_duration,
+                align_dur=True,
             )
+            assert (
+                tuple(res["dur"]) in list(itertools.permutations([150, 150, 100, 100]))
+            ) or (
+                list(res["dur"]) == [100, 100, 100, 100]
+            ), "Offset shift with align_dur doesn't properly align duration."
 
         else:
             with pytest.warns(UserWarning, match=re.escape("WARNING:")):
@@ -791,9 +955,12 @@ def test_offset_shift():
                     "valid range returns something."
                 )
 
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                   " offset shift. Returning "
-                                                   "None.")):
+    with pytest.warns(
+        UserWarning,
+        match=re.escape(
+            "WARNING: No valid notes to" " offset shift. Returning " "None."
+        ),
+    ):
         res = deg.offset_shift(BASIC_DF, min_shift=300)
         assert res is None, (
             "Offset shifting with empty data min_shift greater than "
@@ -802,21 +969,26 @@ def test_offset_shift():
 
 
 def test_remove_note():
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to "
-                                                   "remove. Returning None.")):
-        assert deg.remove_note(EMPTY_DF) is None, (
-            "Remove note with empty data frame did not return None."
-        )
+    with pytest.warns(
+        UserWarning, match=re.escape("WARNING: No notes to " "remove. Returning None.")
+    ):
+        assert (
+            deg.remove_note(EMPTY_DF) is None
+        ), "Remove note with empty data frame did not return None."
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
         # Deterministic testing
         for i in range(2):
             res = deg.remove_note(BASIC_DF, seed=1)
 
-            basic_res = pd.DataFrame({'onset': [0, 200, 200],
-                                      'track': [0, 0, 1],
-                                      'pitch': [10, 30, 40],
-                                      'dur': [100, 100, 100]})
+            basic_res = pd.DataFrame(
+                {
+                    "onset": [0, 200, 200],
+                    "track": [0, 0, 1],
+                    "pitch": [10, 30, 40],
+                    "dur": [100, 100, 100],
+                }
+            )
 
             assert res.equals(basic_res), (
                 f"Removing note from \n{BASIC_DF}\n resulted in "
@@ -832,24 +1004,28 @@ def test_remove_note():
         res = deg.remove_note(BASIC_DF)
         merged = pd.merge(BASIC_DF, res)
 
-        assert merged.shape[0] == BASIC_DF.shape[0] - 1, (
-            "Remove note did not remove exactly 1 note."
-        )
+        assert (
+            merged.shape[0] == BASIC_DF.shape[0] - 1
+        ), "Remove note did not remove exactly 1 note."
 
 
 def test_add_note():
-    assert deg.add_note(EMPTY_DF) is not None, (
-        "Add note to empty data frame returned None."
-    )
+    assert (
+        deg.add_note(EMPTY_DF) is not None
+    ), "Add note to empty data frame returned None."
 
     # Deterministic testing
     for i in range(2):
         res = deg.add_note(BASIC_DF, seed=1)
 
-        basic_res = pd.DataFrame({'onset': [0, 100, 200, 200, 235],
-                                  'track': [0, 1, 0, 1, 0],
-                                  'pitch': [10, 20, 30, 40, 58],
-                                  'dur': [100, 100, 100, 100, 62]})
+        basic_res = pd.DataFrame(
+            {
+                "onset": [0, 100, 200, 200, 235],
+                "track": [0, 1, 0, 1, 0],
+                "pitch": [10, 20, 30, 40, 58],
+                "dur": [100, 100, 100, 100, 62],
+            }
+        )
 
         assert res.equals(basic_res), (
             f"Adding note to \n{BASIC_DF}\n resulted in "
@@ -867,92 +1043,119 @@ def test_add_note():
         min_duration = i * 10
         max_duration = (i + 1) * 10
 
-        res = deg.add_note(BASIC_DF, min_pitch=min_pitch, max_pitch=max_pitch,
-                           min_duration=min_duration, max_duration=max_duration)
+        res = deg.add_note(
+            BASIC_DF,
+            min_pitch=min_pitch,
+            max_pitch=max_pitch,
+            min_duration=min_duration,
+            max_duration=max_duration,
+        )
 
         diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
-        assert (diff.shape[0] == 1), (
-            "Adding a note changed an existing note, or added note is a "
-            "duplicate."
+        assert diff.shape[0] == 1, (
+            "Adding a note changed an existing note, or added note is a " "duplicate."
         )
         assert res.shape[0] == BASIC_DF.shape[0] + 1, "No note was added."
 
         note = diff.iloc[0]
-        assert min_pitch <= note['pitch'] <= max_pitch, (
+        assert min_pitch <= note["pitch"] <= max_pitch, (
             f"Added note's pitch ({note.pitch}) not within range "
             f"[{min_pitch}, {max_pitch}]."
         )
-        assert min_duration <= note['dur'] <= max_duration, (
+        assert min_duration <= note["dur"] <= max_duration, (
             f"Added note's duration ({note.dur}) not within range "
             f"[{min_duration}, {max_duration}]."
         )
-        assert (note['onset'] >= 0 and note['onset'] + note['dur'] <=
-                BASIC_DF[['onset', 'dur']].sum(axis=1).max()), (
+        assert (
+            note["onset"] >= 0
+            and note["onset"] + note["dur"]
+            <= BASIC_DF[["onset", "dur"]].sum(axis=1).max()
+        ), (
             "Added note's onset and duration do not lie within "
             "bounds of given dataframe."
         )
 
         # Test align_pitch and align_time
-        if (min_pitch > BASIC_DF['pitch'].max() or
-            max_pitch < BASIC_DF['pitch'].min() or
-            min_duration > BASIC_DF['dur'].max() or
-            max_duration < BASIC_DF['dur'].min()):
+        if (
+            min_pitch > BASIC_DF["pitch"].max()
+            or max_pitch < BASIC_DF["pitch"].min()
+            or min_duration > BASIC_DF["dur"].max()
+            or max_duration < BASIC_DF["dur"].min()
+        ):
             with pytest.warns(UserWarning, match=re.escape("WARNING:")):
-                res = deg.add_note(BASIC_DF, min_pitch=min_pitch,
-                                   max_pitch=max_pitch, min_duration=min_duration,
-                                   max_duration=max_duration, align_pitch=True,
-                                   align_time=True)
+                res = deg.add_note(
+                    BASIC_DF,
+                    min_pitch=min_pitch,
+                    max_pitch=max_pitch,
+                    min_duration=min_duration,
+                    max_duration=max_duration,
+                    align_pitch=True,
+                    align_time=True,
+                )
             continue
 
-        res = deg.add_note(BASIC_DF, min_pitch=min_pitch,
-                           max_pitch=max_pitch, min_duration=min_duration,
-                           max_duration=max_duration, align_pitch=True,
-                           align_time=True)
+        res = deg.add_note(
+            BASIC_DF,
+            min_pitch=min_pitch,
+            max_pitch=max_pitch,
+            min_duration=min_duration,
+            max_duration=max_duration,
+            align_pitch=True,
+            align_time=True,
+        )
 
         diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
-        assert (diff.shape[0] == 1), (
-            "Adding a note changed an existing note, or added note is a "
-            "duplicate." + "\n" + str(BASIC_DF) + "\n" + str(res)
+        assert (
+            diff.shape[0] == 1
+        ), "Adding a note changed an existing note, or added note is a " "duplicate." + "\n" + str(
+            BASIC_DF
+        ) + "\n" + str(
+            res
         )
         assert res.shape[0] == BASIC_DF.shape[0] + 1, "No note was added."
 
         note = diff.iloc[0]
-        assert note['pitch'] in list(BASIC_DF['pitch']), (
-            f"Added note's pitch ({note.pitch}) not aligned to \n{BASIC_DF}"
-        )
-        assert note['dur'] in list(BASIC_DF['dur']), (
-            f"Added note's duration ({note.dur}) not aligned to \n{BASIC_DF}"
-        )
-        assert note['onset'] in list(BASIC_DF['onset']), (
-            f"Added note's onset ({note.onset}) not aligned to \n{BASIC_DF}"
-        )
+        assert note["pitch"] in list(
+            BASIC_DF["pitch"]
+        ), f"Added note's pitch ({note.pitch}) not aligned to \n{BASIC_DF}"
+        assert note["dur"] in list(
+            BASIC_DF["dur"]
+        ), f"Added note's duration ({note.dur}) not aligned to \n{BASIC_DF}"
+        assert note["onset"] in list(
+            BASIC_DF["onset"]
+        ), f"Added note's onset ({note.onset}) not aligned to \n{BASIC_DF}"
 
     # Test min_duration too large
     res = deg.add_note(BASIC_DF, min_duration=500)
     diff = pd.concat([res, BASIC_DF]).drop_duplicates(keep=False)
     note = diff.iloc[0]
-    assert (note['onset'] == 0 and note['dur'] == 500), (
+    assert note["onset"] == 0 and note["dur"] == 500, (
         "Adding note with large min_duration does not set duration "
         "to full dataframe length."
     )
 
 
 def test_split_note():
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to "
-                                                   "split. Returning None.")):
-        assert deg.split_note(EMPTY_DF) is None, (
-            "Split note with empty data frame did not return None."
-        )
+    with pytest.warns(
+        UserWarning, match=re.escape("WARNING: No notes to " "split. Returning None.")
+    ):
+        assert (
+            deg.split_note(EMPTY_DF) is None
+        ), "Split note with empty data frame did not return None."
 
     if BASIC_DF.equals(BASIC_DF_FINAL):
         # Deterministic testing
         for i in range(2):
             res = deg.split_note(BASIC_DF, seed=1)
 
-            basic_res = pd.DataFrame({'onset': [0, 100, 150, 200, 200],
-                                      'track': [0, 1, 1, 0, 1],
-                                      'pitch': [10, 20, 20, 30, 40],
-                                      'dur': [100, 50, 50, 100, 100]})
+            basic_res = pd.DataFrame(
+                {
+                    "onset": [0, 100, 150, 200, 200],
+                    "track": [0, 1, 1, 0, 1],
+                    "pitch": [10, 20, 20, 30, 40],
+                    "dur": [100, 50, 50, 100, 100],
+                }
+            )
 
             assert res.equals(basic_res), (
                 f"Splitting note in \n{BASIC_DF}\n resulted in "
@@ -974,7 +1177,7 @@ def test_split_note():
         new_notes = pd.merge(diff, res).reset_index()
         changed_notes = pd.merge(diff, BASIC_DF).reset_index()
         unchanged_notes = pd.merge(res, BASIC_DF).reset_index()
-        
+
         print("READY")
         print(BASIC_DF)
         print(res)
@@ -983,101 +1186,103 @@ def test_split_note():
         print(changed_notes)
         print(unchanged_notes)
 
-        assert changed_notes.shape[0] == 1, (
-            "More than 1 note changed when splitting."
-        )
-        assert unchanged_notes.shape[0] == BASIC_DF.shape[0] - 1, (
-            "More than 1 note changed when splitting."
-        )
-        assert new_notes.shape[0] == num_notes, (
-            f"Did not split into {num_notes} notes."
-        )
+        assert changed_notes.shape[0] == 1, "More than 1 note changed when splitting."
+        assert (
+            unchanged_notes.shape[0] == BASIC_DF.shape[0] - 1
+        ), "More than 1 note changed when splitting."
+        assert new_notes.shape[0] == num_notes, f"Did not split into {num_notes} notes."
 
         # Check first new note
-        assert new_notes.loc[0]['pitch'] == changed_notes.loc[0]['pitch'], (
-            "Pitch changed when splitting."
-        )
-        assert new_notes.loc[0]['track'] == changed_notes.loc[0]['track'], (
-            "Track changed when splitting."
-        )
-        assert new_notes.loc[0]['onset'] == changed_notes.loc[0]['onset'], (
-            "Onset changed when splitting."
-        )
+        assert (
+            new_notes.loc[0]["pitch"] == changed_notes.loc[0]["pitch"]
+        ), "Pitch changed when splitting."
+        assert (
+            new_notes.loc[0]["track"] == changed_notes.loc[0]["track"]
+        ), "Track changed when splitting."
+        assert (
+            new_notes.loc[0]["onset"] == changed_notes.loc[0]["onset"]
+        ), "Onset changed when splitting."
 
         # Check duration and remainder of notes
-        total_duration = new_notes.loc[0]['dur']
+        total_duration = new_notes.loc[0]["dur"]
 
         notes = list(new_notes.iterrows())
         for prev_note, next_note in zip(notes[:-1], notes[1:]):
-            total_duration += next_note[1]['dur']
+            total_duration += next_note[1]["dur"]
 
-            assert prev_note[1]['pitch'] == next_note[1]['pitch'], (
-                "Pitch changed when splitting."
-            )
-            assert prev_note[1]['track'] == next_note[1]['track'], (
-                "Track changed when splitting."
-            )
-            assert (prev_note[1]['onset'] + prev_note[1]['dur']
-                    == next_note[1]['onset']), (
-                "Offset/onset times of split notes not aligned."
-            )
+            assert (
+                prev_note[1]["pitch"] == next_note[1]["pitch"]
+            ), "Pitch changed when splitting."
+            assert (
+                prev_note[1]["track"] == next_note[1]["track"]
+            ), "Track changed when splitting."
+            assert (
+                prev_note[1]["onset"] + prev_note[1]["dur"] == next_note[1]["onset"]
+            ), "Offset/onset times of split notes not aligned."
 
-        assert total_duration == changed_notes.loc[0]['dur'], (
-            "Duration changed when splitting."
-        )
+        assert (
+            total_duration == changed_notes.loc[0]["dur"]
+        ), "Duration changed when splitting."
 
     # Test min_duration too large for num_splits
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                   " split. Returning None.")):
-        assert deg.split_note(BASIC_DF, min_duration=10,
-                              num_splits=10) is None, (
-            "Splitting note into too many pieces didn't return None."
-        )
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("WARNING: No valid notes to" " split. Returning None."),
+    ):
+        assert (
+            deg.split_note(BASIC_DF, min_duration=10, num_splits=10) is None
+        ), "Splitting note into too many pieces didn't return None."
 
 
 def test_join_notes():
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No notes to "
-                                                   "join. Returning None.")):
-        assert deg.join_notes(EMPTY_DF) is None, (
-            "Join notes with empty data frame did not return None."
-        )
+    with pytest.warns(
+        UserWarning, match=re.escape("WARNING: No notes to " "join. Returning None.")
+    ):
+        assert (
+            deg.join_notes(EMPTY_DF) is None
+        ), "Join notes with empty data frame did not return None."
 
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                   " join. Returning None.")):
-        assert deg.join_notes(BASIC_DF) is None, (
-            "Joining notes with none back-to-back didn't return None."
-        )
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("WARNING: No valid notes to" " join. Returning None."),
+    ):
+        assert (
+            deg.join_notes(BASIC_DF) is None
+        ), "Joining notes with none back-to-back didn't return None."
 
     # Create a garbled df with indices: [0, 2, 2, 4]
-    join_df = pd.DataFrame({
-        'onset': [0, 100, 200, 200, 200],
-        'track': [0, 0, 0, 1, 1],
-        'pitch': [10, 10, 10, 40, 40],
-        'dur': [100, 100, 100, 100, 100]
-    })
-    join_df = pd.concat([join_df.iloc[[0,2]], join_df.iloc[[2,4]]])
-    join_df.iloc[1]['onset'] = 100
-    join_df.iloc[1]['track'] = 0
-    join_df.iloc[1]['pitch'] = 10
-    join_df.iloc[1]['dur'] = 100
+    join_df = pd.DataFrame(
+        {
+            "onset": [0, 100, 200, 200, 200],
+            "track": [0, 0, 0, 1, 1],
+            "pitch": [10, 10, 10, 40, 40],
+            "dur": [100, 100, 100, 100, 100],
+        }
+    )
+    join_df = pd.concat([join_df.iloc[[0, 2]], join_df.iloc[[2, 4]]])
+    join_df.iloc[1]["onset"] = 100
+    join_df.iloc[1]["track"] = 0
+    join_df.iloc[1]["pitch"] = 10
+    join_df.iloc[1]["dur"] = 100
 
     # Create an unsorted join_df
-    unsorted_join_df = join_df.iloc[[0,2,3,1]]
+    unsorted_join_df = join_df.iloc[[0, 2, 3, 1]]
 
     # Deterministic testing
     for i in range(2):
         res = deg.join_notes(join_df, seed=1)
 
-        join_res = pd.DataFrame({
-            'onset': [0, 100, 200],
-            'track': [0, 0, 1],
-            'pitch': [10, 10, 40],
-            'dur': [100, 200, 100]
-        })
+        join_res = pd.DataFrame(
+            {
+                "onset": [0, 100, 200],
+                "track": [0, 0, 1],
+                "pitch": [10, 10, 40],
+                "dur": [100, 200, 100],
+            }
+        )
 
         assert res.equals(join_res), (
-            f"Joining \n{join_df}\nresulted in \n{res}\n"
-            f"instead of \n{join_res}"
+            f"Joining \n{join_df}\nresulted in \n{res}\n" f"instead of \n{join_res}"
         )
 
         res = deg.join_notes(unsorted_join_df, seed=1)
@@ -1089,54 +1294,151 @@ def test_join_notes():
         assert not join_df.equals(res), "Note_df was not copied."
 
     # Check different pitch and track
-    join_df.iloc[1]['pitch'] = 20
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                   " join. Returning None.")):
-        assert deg.join_notes(join_df) is None, (
-            "Joining notes with different pitches didn't return None."
-        )
+    join_df.iloc[1]["pitch"] = 20
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("WARNING: No valid notes to" " join. Returning None."),
+    ):
+        assert (
+            deg.join_notes(join_df) is None
+        ), "Joining notes with different pitches didn't return None."
 
-    join_df.iloc[1]['pitch'] = 10
-    join_df.iloc[1]['track'] = 1
-    with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                   " join. Returning None.")):
-        assert deg.join_notes(join_df) is None, (
-            "Joining notes with different tracks didn't return None."
-        )
+    join_df.iloc[1]["pitch"] = 10
+    join_df.iloc[1]["track"] = 1
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("WARNING: No valid notes to" " join. Returning None."),
+    ):
+        assert (
+            deg.join_notes(join_df) is None
+        ), "Joining notes with different tracks didn't return None."
 
     # Test real example which erred (because it had multiple possible notes)
-    excerpt = pd.DataFrame({
-        'onset': [0, 250, 625, 875, 1000, 1500, 1750, 1875, 2250, 2625, 2875,
-                  3000, 3250, 3375, 3625, 3750, 3875, 4000, 4250, 4625, 4875,
-                  5000],
-        'track': [0] * 22,
-        'pitch': [47, 47, 47, 50, 43, 43, 43, 43, 50, 50, 62, 50, 50,
-                  62, 62, 48, 48, 47, 47, 47, 50, 43],
-        'dur': [83] + [125] * 10 + [83] + [125] * 5 + [83] + [125] * 4
-    })
-    correct = pd.DataFrame({
-        'onset': [0, 250, 625, 875, 1000, 1500, 1750, 1875, 2250, 2625, 2875,
-                  3000, 3250, 3375, 3625, 3750, 4000, 4250, 4625, 4875, 5000],
-        'track': [0] * 21,
-        'pitch': [47, 47, 47, 50, 43, 43, 43, 43, 50, 50, 62, 50, 50,
-                  62, 62, 48, 47, 47, 47, 50, 43],
-        'dur': [83] + [125] * 10 + [83] + [125] * 3 + [250, 83] + [125] * 4
-    })
+    excerpt = pd.DataFrame(
+        {
+            "onset": [
+                0,
+                250,
+                625,
+                875,
+                1000,
+                1500,
+                1750,
+                1875,
+                2250,
+                2625,
+                2875,
+                3000,
+                3250,
+                3375,
+                3625,
+                3750,
+                3875,
+                4000,
+                4250,
+                4625,
+                4875,
+                5000,
+            ],
+            "track": [0] * 22,
+            "pitch": [
+                47,
+                47,
+                47,
+                50,
+                43,
+                43,
+                43,
+                43,
+                50,
+                50,
+                62,
+                50,
+                50,
+                62,
+                62,
+                48,
+                48,
+                47,
+                47,
+                47,
+                50,
+                43,
+            ],
+            "dur": [83] + [125] * 10 + [83] + [125] * 5 + [83] + [125] * 4,
+        }
+    )
+    correct = pd.DataFrame(
+        {
+            "onset": [
+                0,
+                250,
+                625,
+                875,
+                1000,
+                1500,
+                1750,
+                1875,
+                2250,
+                2625,
+                2875,
+                3000,
+                3250,
+                3375,
+                3625,
+                3750,
+                4000,
+                4250,
+                4625,
+                4875,
+                5000,
+            ],
+            "track": [0] * 21,
+            "pitch": [
+                47,
+                47,
+                47,
+                50,
+                43,
+                43,
+                43,
+                43,
+                50,
+                50,
+                62,
+                50,
+                50,
+                62,
+                62,
+                48,
+                47,
+                47,
+                47,
+                50,
+                43,
+            ],
+            "dur": [83] + [125] * 10 + [83] + [125] * 3 + [250, 83] + [125] * 4,
+        }
+    )
     res = deg.join_notes(excerpt, seed=1)
-    assert res.equals(correct), ("join_notes failed on excerpt with multiple "
-                                 "pitches containing joinable notes." + f'{res}')
+    assert res.equals(correct), (
+        "join_notes failed on excerpt with multiple "
+        "pitches containing joinable notes." + f"{res}"
+    )
 
     # Check some with different max_gaps
-    join_df.iloc[1]['track'] = 0
+    join_df.iloc[1]["track"] = 0
     for i in range(10):
         np.random.seed()
 
         max_gap = i * 10
 
-        join_df.iloc[0]['dur'] = join_df.iloc[1]['onset'] - \
-            max_gap - join_df.iloc[0]['onset']
-        join_df.iloc[1]['dur'] = join_df.iloc[2]['onset'] - \
-            max_gap - join_df.iloc[1]['onset']
+        join_df.iloc[0]["dur"] = (
+            join_df.iloc[1]["onset"] - max_gap - join_df.iloc[0]["onset"]
+        )
+        join_df.iloc[1]["dur"] = (
+            join_df.iloc[2]["onset"] - max_gap - join_df.iloc[1]["onset"]
+        )
 
         res = deg.join_notes(join_df, max_notes=2, max_gap=max_gap)
 
@@ -1146,70 +1448,64 @@ def test_join_notes():
         joined_notes = pd.merge(diff, join_df).reset_index()
         unchanged_notes = pd.merge(res, join_df).reset_index()
 
-        assert unchanged_notes.shape[0] == join_df.shape[0] - 2, (
-            "Joining notes changed too many notes."
-        )
-        assert new_note.shape[0] == 1, (
-            "Joining notes resulted in more than 1 new note."
-        )
-        assert joined_notes.shape[0] == 2, (
-            "Joining notes changed too many notes."
-        )
-        assert new_note.loc[0]['onset'] == joined_notes.loc[0]['onset'], (
-            "Joined onset not equal to original onset."
-        )
-        assert new_note.loc[0]['pitch'] == joined_notes.loc[0]['pitch'], (
-            "Joined pitch not equal to original pitch."
-        )
-        assert new_note.loc[0]['track'] == joined_notes.loc[0]['track'], (
-            "Joined track not equal to original pitch."
-        )
-        assert (new_note.loc[0]['dur'] ==
-                joined_notes.iloc[-1]['onset'] +
-                joined_notes.iloc[-1]['dur'] -
-                joined_notes.loc[0]['onset']), (
-            "Joined duration not equal to original durations plus gap."
-        )
+        assert (
+            unchanged_notes.shape[0] == join_df.shape[0] - 2
+        ), "Joining notes changed too many notes."
+        assert new_note.shape[0] == 1, "Joining notes resulted in more than 1 new note."
+        assert joined_notes.shape[0] == 2, "Joining notes changed too many notes."
+        assert (
+            new_note.loc[0]["onset"] == joined_notes.loc[0]["onset"]
+        ), "Joined onset not equal to original onset."
+        assert (
+            new_note.loc[0]["pitch"] == joined_notes.loc[0]["pitch"]
+        ), "Joined pitch not equal to original pitch."
+        assert (
+            new_note.loc[0]["track"] == joined_notes.loc[0]["track"]
+        ), "Joined track not equal to original pitch."
+        assert (
+            new_note.loc[0]["dur"]
+            == joined_notes.iloc[-1]["onset"]
+            + joined_notes.iloc[-1]["dur"]
+            - joined_notes.loc[0]["onset"]
+        ), "Joined duration not equal to original durations plus gap."
 
         # Test joining multiple notes at first
         max_notes = max(2, i)
         num_joined = min(max_notes, 3)
-        res = deg.join_notes(join_df, max_notes=max_notes, only_first=True,
-                             max_gap=max_gap)
+        res = deg.join_notes(
+            join_df, max_notes=max_notes, only_first=True, max_gap=max_gap
+        )
 
         diff = pd.concat([res, join_df]).drop_duplicates(keep=False)
         new_note = pd.merge(diff, res).reset_index(drop=True)
         joined_notes = pd.merge(diff, join_df).reset_index(drop=True)
         unchanged_notes = pd.merge(res, join_df).reset_index(drop=True)
 
-        assert (unchanged_notes.shape[0] ==
-                join_df.shape[0] - num_joined), (
-            "Joining notes changed too many notes."
-        )
-        assert new_note.shape[0] == 1, (
-            "Joining notes resulted in more than 1 new note."
-        )
-        assert joined_notes.shape[0] == num_joined, (
-            "Joining notes changed too many notes."
-        )
-        assert joined_notes.loc[0].equals(join_df.loc[0]), (
-            "Joining didn't start at first."
-        )
-        assert new_note.loc[0]['onset'] == joined_notes.loc[0]['onset'], (
-            "Joined onset not equal to original onset."
-        )
-        assert new_note.loc[0]['pitch'] == joined_notes.loc[0]['pitch'], (
-            "Joined pitch not equal to original pitch."
-        )
-        assert new_note.loc[0]['track'] == joined_notes.loc[0]['track'], (
-            "Joined track not equal to original pitch."
-        )
-        assert (new_note.loc[0]['dur'] ==
-                joined_notes.iloc[-1]['onset'] +
-                joined_notes.iloc[-1]['dur'] -
-                joined_notes.loc[0]['onset']), (
-            "Joined duration not equal to original durations plus gap."
-        )
+        assert (
+            unchanged_notes.shape[0] == join_df.shape[0] - num_joined
+        ), "Joining notes changed too many notes."
+        assert new_note.shape[0] == 1, "Joining notes resulted in more than 1 new note."
+        assert (
+            joined_notes.shape[0] == num_joined
+        ), "Joining notes changed too many notes."
+        assert joined_notes.loc[0].equals(
+            join_df.loc[0]
+        ), "Joining didn't start at first."
+        assert (
+            new_note.loc[0]["onset"] == joined_notes.loc[0]["onset"]
+        ), "Joined onset not equal to original onset."
+        assert (
+            new_note.loc[0]["pitch"] == joined_notes.loc[0]["pitch"]
+        ), "Joined pitch not equal to original pitch."
+        assert (
+            new_note.loc[0]["track"] == joined_notes.loc[0]["track"]
+        ), "Joined track not equal to original pitch."
+        assert (
+            new_note.loc[0]["dur"]
+            == joined_notes.iloc[-1]["onset"]
+            + joined_notes.iloc[-1]["dur"]
+            - joined_notes.loc[0]["onset"]
+        ), "Joined duration not equal to original durations plus gap."
 
         # Test joining multiple notes not at first
         res = deg.join_notes(join_df, max_notes=max_notes, max_gap=max_gap)
@@ -1219,38 +1515,36 @@ def test_join_notes():
         joined_notes = pd.merge(diff, join_df).reset_index()
         unchanged_notes = pd.merge(res, join_df).reset_index()
 
-        assert (unchanged_notes.shape[0] >= join_df.shape[0] - max_notes and
-                unchanged_notes.shape[0] <= join_df.shape[0] - 2), (
-            "Joining notes changed too many notes."
-        )
-        assert new_note.shape[0] == 1, (
-            "Joining notes resulted in more than 1 new note."
-        )
-        assert 2 <= joined_notes.shape[0] <= 3, (
-            "Joining notes changed too many notes."
-        )
-        assert new_note.loc[0]['onset'] == joined_notes.loc[0]['onset'], (
-            "Joined onset not equal to original onset."
-        )
-        assert new_note.loc[0]['pitch'] == joined_notes.loc[0]['pitch'], (
-            "Joined pitch not equal to original pitch."
-        )
-        assert new_note.loc[0]['track'] == joined_notes.loc[0]['track'], (
-            "Joined track not equal to original pitch."
-        )
-        assert (new_note.loc[0]['dur'] ==
-                joined_notes.iloc[-1]['onset'] +
-                joined_notes.iloc[-1]['dur'] -
-                joined_notes.loc[0]['onset']), (
-            "Joined duration not equal to original durations plus gap."
-        )
+        assert (
+            unchanged_notes.shape[0] >= join_df.shape[0] - max_notes
+            and unchanged_notes.shape[0] <= join_df.shape[0] - 2
+        ), "Joining notes changed too many notes."
+        assert new_note.shape[0] == 1, "Joining notes resulted in more than 1 new note."
+        assert 2 <= joined_notes.shape[0] <= 3, "Joining notes changed too many notes."
+        assert (
+            new_note.loc[0]["onset"] == joined_notes.loc[0]["onset"]
+        ), "Joined onset not equal to original onset."
+        assert (
+            new_note.loc[0]["pitch"] == joined_notes.loc[0]["pitch"]
+        ), "Joined pitch not equal to original pitch."
+        assert (
+            new_note.loc[0]["track"] == joined_notes.loc[0]["track"]
+        ), "Joined track not equal to original pitch."
+        assert (
+            new_note.loc[0]["dur"]
+            == joined_notes.iloc[-1]["onset"]
+            + joined_notes.iloc[-1]["dur"]
+            - joined_notes.loc[0]["onset"]
+        ), "Joined duration not equal to original durations plus gap."
 
-        join_df.iloc[0]['dur'] -= 1
-        join_df.iloc[1]['dur'] -= 1
+        join_df.iloc[0]["dur"] -= 1
+        join_df.iloc[1]["dur"] -= 1
 
         # Gap too large
-        with pytest.warns(UserWarning, match=re.escape("WARNING: No valid notes to"
-                                                       " join. Returning None.")):
-            assert deg.join_notes(join_df, max_gap=max_gap) is None, (
-                "Joining notes with too large of a gap didn't return None."
-            )
+        with pytest.warns(
+            UserWarning,
+            match=re.escape("WARNING: No valid notes to" " join. Returning None."),
+        ):
+            assert (
+                deg.join_notes(join_df, max_gap=max_gap) is None
+            ), "Joining notes with too large of a gap didn't return None."

--- a/mdtk/tests/test_df_utils.py
+++ b/mdtk/tests/test_df_utils.py
@@ -2,7 +2,7 @@ import itertools
 
 import pandas as pd
 
-from mdtk.df_utils import *
+from mdtk.df_utils import clean_df, get_random_excerpt, remove_pitch_overlaps
 
 CLEAN_INPUT_DF = pd.DataFrame(
     {

--- a/mdtk/tests/test_df_utils.py
+++ b/mdtk/tests/test_df_utils.py
@@ -4,45 +4,54 @@ import pandas as pd
 
 from mdtk.df_utils import *
 
-
-CLEAN_INPUT_DF = pd.DataFrame({
-    'track': list(range(9)) + [8],
-    'dur': [50, 50, 40, 50, 50, 40, 50, 50, 40, 50],
-    'onset': [0, 0, 0, 1, 1, 1, 2, 2, 2, 3],
-    'extra': 40,
-    'pitch': [30, 20, 20, 30, 20, 20, 30, 20, 20, 20],
-})
+CLEAN_INPUT_DF = pd.DataFrame(
+    {
+        "track": list(range(9)) + [8],
+        "dur": [50, 50, 40, 50, 50, 40, 50, 50, 40, 50],
+        "onset": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3],
+        "extra": 40,
+        "pitch": [30, 20, 20, 30, 20, 20, 30, 20, 20, 20],
+    }
+)
 
 # Dict of [single_track][non_overlapping] -> result
 CLEAN_RES_DFS = {
     False: {
-        False: pd.DataFrame({
-            'onset': [0, 0, 0, 1, 1, 1, 2, 2, 2, 3],
-            'track': list(range(9)) + [8],
-            'pitch': [30, 20, 20, 30, 20, 20, 30, 20, 20, 20],
-            'dur': [50, 50, 40, 50, 50, 40, 50, 50, 40, 50]
-        }),
-        True: pd.DataFrame({
-            'onset': [0, 0, 0, 1, 1, 1, 2, 2, 2, 3],
-            'track': list(range(9)) + [8],
-            'pitch': [30, 20, 20, 30, 20, 20, 30, 20, 20, 20],
-            'dur': [50, 50, 40, 50, 50, 40, 50, 50, 1, 50]
-        })
+        False: pd.DataFrame(
+            {
+                "onset": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3],
+                "track": list(range(9)) + [8],
+                "pitch": [30, 20, 20, 30, 20, 20, 30, 20, 20, 20],
+                "dur": [50, 50, 40, 50, 50, 40, 50, 50, 40, 50],
+            }
+        ),
+        True: pd.DataFrame(
+            {
+                "onset": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3],
+                "track": list(range(9)) + [8],
+                "pitch": [30, 20, 20, 30, 20, 20, 30, 20, 20, 20],
+                "dur": [50, 50, 40, 50, 50, 40, 50, 50, 1, 50],
+            }
+        ),
     },
     True: {
-        False: pd.DataFrame({
-            'onset': [0, 0, 0, 1, 1, 1, 2, 2, 2, 3],
-            'track': 0,
-            'pitch': [20, 20, 30, 20, 20, 30, 20, 20, 30, 20],
-            'dur': [40, 50, 50, 40, 50, 50, 40, 50, 50, 50]
-        }),
-        True: pd.DataFrame({
-            'onset': [0, 0, 1, 1, 2, 2, 3],
-            'track': 0,
-            'pitch': [20, 30, 20, 30, 20, 30, 20],
-            'dur': [1, 1, 1, 1, 1, 50, 50]
-        })
-    }
+        False: pd.DataFrame(
+            {
+                "onset": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3],
+                "track": 0,
+                "pitch": [20, 20, 30, 20, 20, 30, 20, 20, 30, 20],
+                "dur": [40, 50, 50, 40, 50, 50, 40, 50, 50, 50],
+            }
+        ),
+        True: pd.DataFrame(
+            {
+                "onset": [0, 0, 1, 1, 2, 2, 3],
+                "track": 0,
+                "pitch": [20, 30, 20, 30, 20, 30, 20],
+                "dur": [1, 1, 1, 1, 1, 50, 50],
+            }
+        ),
+    },
 }
 
 
@@ -50,42 +59,43 @@ def test_clean_df():
     # Default, no arguments. multi-track, with overlaps
     # But correct sorting, columns, and index
     res = clean_df(CLEAN_INPUT_DF)
-    assert res.equals(clean_df(CLEAN_INPUT_DF, single_track=False,
-                               non_overlapping=False)), (
-        "clean_df does not default to False, False for optional args."
-    )
+    assert res.equals(
+        clean_df(CLEAN_INPUT_DF, single_track=False, non_overlapping=False)
+    ), "clean_df does not default to False, False for optional args."
 
     for track, overlap in itertools.product([True, False], repeat=2):
-        kwargs = {
-            'single_track': track,
-            'non_overlapping': overlap
-        }
+        kwargs = {"single_track": track, "non_overlapping": overlap}
         prior = CLEAN_INPUT_DF.copy()
         res = clean_df(CLEAN_INPUT_DF, **kwargs)
         assert CLEAN_INPUT_DF.equals(prior), "clean_df changed input df"
-        assert res.equals(CLEAN_RES_DFS[track][overlap]), (
-            f"clean_df result incorrect for args: {kwargs}"
-        )
+        assert res.equals(
+            CLEAN_RES_DFS[track][overlap]
+        ), f"clean_df result incorrect for args: {kwargs}"
 
 
 def test_remove_pitch_overlaps():
-    note_df_complex_overlap = pd.DataFrame({
-        'onset': [0, 50, 75, 150, 200, 200, 300, 300, 300, 300],
-        'track': [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
-        'pitch': [10, 10, 10, 20, 10, 20, 30, 30, 10, 10],
-        'dur': [50, 300, 25, 100, 125, 50, 50, 100, 100, 100]
-    })
-    note_df_complex_overlap_fixed = pd.DataFrame({
-        'onset': [0, 50, 75, 150, 200, 200, 300, 300],
-        'track': [0, 0, 0, 0, 0, 0, 0, 1],
-        'pitch': [10, 10, 10, 20, 10, 20, 30, 10],
-        'dur': [50, 25, 125, 50, 150, 50, 100, 100]
-    })
+    note_df_complex_overlap = pd.DataFrame(
+        {
+            "onset": [0, 50, 75, 150, 200, 200, 300, 300, 300, 300],
+            "track": [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
+            "pitch": [10, 10, 10, 20, 10, 20, 30, 30, 10, 10],
+            "dur": [50, 300, 25, 100, 125, 50, 50, 100, 100, 100],
+        }
+    )
+    note_df_complex_overlap_fixed = pd.DataFrame(
+        {
+            "onset": [0, 50, 75, 150, 200, 200, 300, 300],
+            "track": [0, 0, 0, 0, 0, 0, 0, 1],
+            "pitch": [10, 10, 10, 20, 10, 20, 30, 10],
+            "dur": [50, 25, 125, 50, 150, 50, 100, 100],
+        }
+    )
 
     prior = note_df_complex_overlap.copy()
     res = remove_pitch_overlaps(note_df_complex_overlap)
-    assert prior.equals(note_df_complex_overlap), ("remove_pitch_overlaps "
-                                                   "changed input df")
+    assert prior.equals(note_df_complex_overlap), (
+        "remove_pitch_overlaps " "changed input df"
+    )
     assert note_df_complex_overlap_fixed.equals(res), (
         f"Complex overlap\n{note_df_complex_overlap}\nproduced\n{res}\n"
         f"instead of\n{note_df_complex_overlap_fixed}"
@@ -95,52 +105,77 @@ def test_remove_pitch_overlaps():
 def test_get_random_excerpt():
     NUM_NOTES = 50
     NOTE_DURATION = 50
-    note_df = pd.DataFrame({
-        'onset': [NOTE_DURATION * i for i in range(NUM_NOTES)],
-        'track': 0,
-        'pitch': list(range(NUM_NOTES)),
-        'dur': NOTE_DURATION
-    })
+    note_df = pd.DataFrame(
+        {
+            "onset": [NOTE_DURATION * i for i in range(NUM_NOTES)],
+            "track": 0,
+            "pitch": list(range(NUM_NOTES)),
+            "dur": NOTE_DURATION,
+        }
+    )
 
     # Normal usage
     prior = note_df.copy()
     for _ in range(50):
         min_notes = 10
-        excerpt_length = (NUM_NOTES - 1) * NOTE_DURATION + 1 # All notes fit
+        excerpt_length = (NUM_NOTES - 1) * NOTE_DURATION + 1  # All notes fit
         start = 500
         end = 600
         excerpt = get_random_excerpt(
-            note_df, min_notes=min_notes, excerpt_length=excerpt_length,
-            first_onset_range=(start, end), iterations=1
+            note_df,
+            min_notes=min_notes,
+            excerpt_length=excerpt_length,
+            first_onset_range=(start, end),
+            iterations=1,
         )
         assert prior.equals(note_df), "get_random_excerpt changed input df"
         assert len(excerpt) >= min_notes, "Too few notes in excerpt"
-        assert excerpt.iloc[-1].pitch == NUM_NOTES - 1, ("Full excerpt_length "
-                                                         "not returned")
+        assert excerpt.iloc[-1].pitch == NUM_NOTES - 1, (
+            "Full excerpt_length " "not returned"
+        )
         excerpt_start = excerpt.iloc[0].onset
         assert start <= excerpt_start < end
-        assert all(excerpt['onset'].to_numpy() == [
-            excerpt_start + NOTE_DURATION * i for i in range(len(excerpt))
-        ]), "All note onsets did not shift correctly"
+        assert all(
+            excerpt["onset"].to_numpy()
+            == [excerpt_start + NOTE_DURATION * i for i in range(len(excerpt))]
+        ), "All note onsets did not shift correctly"
 
     # Not enough iterations
-    assert get_random_excerpt(
-        note_df, min_notes=min_notes, excerpt_length=excerpt_length,
-        first_onset_range=(start, end), iterations=0
-    ) is None, "Did not return None with iterations=0"
+    assert (
+        get_random_excerpt(
+            note_df,
+            min_notes=min_notes,
+            excerpt_length=excerpt_length,
+            first_onset_range=(start, end),
+            iterations=0,
+        )
+        is None
+    ), "Did not return None with iterations=0"
     assert prior.equals(note_df), "get_random_excerpt changed input df"
 
     # Too large min_notes
-    assert get_random_excerpt(
-        note_df, min_notes=NUM_NOTES + 1, excerpt_length=excerpt_length,
-        first_onset_range=(start, end), iterations=100
-    ) is None, "Did not return None with min_notes too large"
+    assert (
+        get_random_excerpt(
+            note_df,
+            min_notes=NUM_NOTES + 1,
+            excerpt_length=excerpt_length,
+            first_onset_range=(start, end),
+            iterations=100,
+        )
+        is None
+    ), "Did not return None with min_notes too large"
     assert prior.equals(note_df), "get_random_excerpt changed input df"
 
     # Too short excerpt_length
     excerpt_length = NOTE_DURATION * (min_notes - 1) - 1
-    assert get_random_excerpt(
-        note_df, min_notes=NUM_NOTES + 1, excerpt_length=excerpt_length,
-        first_onset_range=(start, end), iterations=100
-    ) is None, "Did not return None with excerpt_length too short"
+    assert (
+        get_random_excerpt(
+            note_df,
+            min_notes=NUM_NOTES + 1,
+            excerpt_length=excerpt_length,
+            first_onset_range=(start, end),
+            iterations=100,
+        )
+        is None
+    ), "Did not return None with excerpt_length too short"
     assert prior.equals(note_df), "get_random_excerpt changed input df"

--- a/mdtk/tests/test_downloaders.py
+++ b/mdtk/tests/test_downloaders.py
@@ -2,14 +2,16 @@ import os
 import shutil
 import urllib
 
-from mdtk.downloaders import (PPDDSep2018Monophonic, PianoMidi,
-                              PPDDSep2018Polyphonic, make_directory)
+from mdtk.downloaders import (
+    PianoMidi,
+    PPDDSep2018Monophonic,
+    PPDDSep2018Polyphonic,
+    make_directory,
+)
 
-
-DOWNLOADERS = [PPDDSep2018Monophonic, PPDDSep2018Polyphonic,
-               PianoMidi]
-USER_HOME = os.path.expanduser('~')
-TEST_CACHE_PATH = os.path.join(USER_HOME, '.mdtk_test_cache')
+DOWNLOADERS = [PPDDSep2018Monophonic, PPDDSep2018Polyphonic, PianoMidi]
+USER_HOME = os.path.expanduser("~")
+TEST_CACHE_PATH = os.path.join(USER_HOME, ".mdtk_test_cache")
 
 
 def test_make_directory():
@@ -30,27 +32,26 @@ def test_links_exist():
 
 
 def test_PPDDSep2018Monophonic_download_midi():
-    downloader = PPDDSep2018Monophonic(cache_path=TEST_CACHE_PATH,
-                                        sizes=['small', 'medium'])
-    output_path = os.path.join(TEST_CACHE_PATH, downloader.dataset_name,
-                               'midi')
+    downloader = PPDDSep2018Monophonic(
+        cache_path=TEST_CACHE_PATH, sizes=["small", "medium"]
+    )
+    output_path = os.path.join(TEST_CACHE_PATH, downloader.dataset_name, "midi")
     downloader.download_midi(output_path)
     assert len(os.listdir(output_path)) == 1100
 
 
 def test_PPDDSep2018Polyphonic_download_midi():
-    downloader = PPDDSep2018Polyphonic(cache_path=TEST_CACHE_PATH,
-                                        sizes=['small', 'medium'])
-    output_path = os.path.join(TEST_CACHE_PATH, downloader.dataset_name,
-                               'midi')
+    downloader = PPDDSep2018Polyphonic(
+        cache_path=TEST_CACHE_PATH, sizes=["small", "medium"]
+    )
+    output_path = os.path.join(TEST_CACHE_PATH, downloader.dataset_name, "midi")
     downloader.download_midi(output_path)
     assert len(os.listdir(output_path)) == 1100
 
 
 def test_PianoMidi_download_midi():
     downloader = PianoMidi(cache_path=TEST_CACHE_PATH)
-    output_path = os.path.join(TEST_CACHE_PATH, downloader.dataset_name,
-                               'midi')
+    output_path = os.path.join(TEST_CACHE_PATH, downloader.dataset_name, "midi")
     downloader.download_midi(output_path)
     assert len(os.listdir(output_path)) == 328
 
@@ -65,17 +66,19 @@ def test_cleanup():
     assert os.path.exists(TEST_CACHE_PATH)
     assert len(os.listdir(TEST_CACHE_PATH)) == 0
     shutil.rmtree(TEST_CACHE_PATH)
-#    
-    
-    
-#def test_working_dir():
+
+
+#
+
+
+# def test_working_dir():
 #    cwd = os.getcwd()
 #    assert (os.path.basename(cwd) == 'melody_gen' and
 #            os.path.exists(os.path.join(cwd, 'LICENSE'))), ("Please run tests "
 #            f"from the project root directory. Currently running from {cwd}")
 
 
-#def get_random_csv_filepath(seed=None, size=None, part=None):
+# def get_random_csv_filepath(seed=None, size=None, part=None):
 #    if seed:
 #        np.random.seed(seed)
 #    if size is None:
@@ -87,7 +90,7 @@ def test_cleanup():
 #    return np.random.choice(glob(f"{csv_dir}/*.csv"))
 #
 #
-#class RandomFilepath:
+# class RandomFilepath:
 #    """Convenience class such that you can create a 'variable' which returns
 #    a random file path every time it is called e.g.
 #        random_path = RandomFilepath()
@@ -103,17 +106,17 @@ def test_cleanup():
 #        return get_random_csv_filepath()
 
 
-#random_path = RandomFilepath()
+# random_path = RandomFilepath()
 
 
-#def get_random_compositions(nr_comps=1, **kwargs):
+# def get_random_compositions(nr_comps=1, **kwargs):
 #    if nr_comps == 1:
 #        return Composition(csv_path=str(random_path), **kwargs)
 #    return [Composition(csv_path=str(random_path), **kwargs)
 #            for ii in range(nr_comps)]
 
 
-#def test_data_has_been_downloaded():
+# def test_data_has_been_downloaded():
 #    print(os.path.dirname(os.path.realpath(__file__)))
 #    sizes = ['small', 'medium', 'large']
 #    parts = ['prime', 'cont_foil', 'cont_true']
@@ -125,14 +128,14 @@ def test_cleanup():
 #                (f"Could not find data at {path}. Please consult "
 #                 "README.md.")
 
-#def test_monophonic():
+# def test_monophonic():
 #    compositions = [comp for comp in
 #                    get_random_compositions(10, monophonic=True)]
 #    for comp in compositions:
 #        assert np.sum(comp.pianoroll[:, :, 0]) == comp.pianoroll.shape[1]
 
 
-#def test_all_composition_methods_and_attributes_with_random_files():
+# def test_all_composition_methods_and_attributes_with_random_files():
 #    compositions = [comp for comp in get_random_compositions(10)]
 #    for comp in compositions:
 #        comp.csv_path

--- a/mdtk/tests/test_fileio.py
+++ b/mdtk/tests/test_fileio.py
@@ -1,15 +1,16 @@
-import pandas as pd
-import os
-import pretty_midi
-import shutil
 import itertools
+import os
+import shutil
+
+import pandas as pd
+import pretty_midi
 
 import mdtk.fileio as fileio
 from mdtk.df_utils import clean_df
 from mdtk.tests.test_df_utils import CLEAN_INPUT_DF, CLEAN_RES_DFS
 
-USER_HOME = os.path.expanduser('~')
-TEST_CACHE_PATH = os.path.join(USER_HOME, '.mdtk_test_cache')
+USER_HOME = os.path.expanduser("~")
+TEST_CACHE_PATH = os.path.join(USER_HOME, ".mdtk_test_cache")
 MIDI_PATH = f"mdtk{os.path.sep}tests"
 
 TEST_MID = f"{MIDI_PATH}{os.path.sep}test.mid"
@@ -21,42 +22,28 @@ def test_midi_rounding():
 
 
 def test_csv_to_df():
-    csv_path = os.path.join(TEST_CACHE_PATH, 'test.csv')
+    csv_path = os.path.join(TEST_CACHE_PATH, "test.csv")
     fileio.df_to_csv(CLEAN_INPUT_DF, csv_path)
 
     # Check clean_df args
     for (track, overlap) in itertools.product([False, True], repeat=2):
-        kwargs = {
-            'single_track': track,
-            'non_overlapping': overlap
-        }
+        kwargs = {"single_track": track, "non_overlapping": overlap}
 
         correct = CLEAN_RES_DFS[track][overlap]
         res = fileio.csv_to_df(csv_path, **kwargs)
 
-        assert res.equals(correct), (
-            f"csv_to_df result incorrect with args={kwargs}"
-        )
+        assert res.equals(correct), f"csv_to_df result incorrect with args={kwargs}"
 
 
 def test_df_to_csv():
     notes = []
-    notes.append({'onset': 0,
-                  'track': 1,
-                  'pitch': 42,
-                  'dur': 1})
-    notes.append({'onset': 0,
-                  'track': 1,
-                  'pitch': 40,
-                  'dur': 1})
-    notes.append({'onset': 1,
-                  'track': 2,
-                  'pitch': 56,
-                  'dur': 5})
+    notes.append({"onset": 0, "track": 1, "pitch": 42, "dur": 1})
+    notes.append({"onset": 0, "track": 1, "pitch": 40, "dur": 1})
+    notes.append({"onset": 1, "track": 2, "pitch": 56, "dur": 5})
 
     df = pd.DataFrame(notes)
 
-    csv_name = os.path.join(TEST_CACHE_PATH, 'tmp_dir', 'test.csv')
+    csv_name = os.path.join(TEST_CACHE_PATH, "tmp_dir", "test.csv")
     try:
         os.removedirs(csv_name)
     except:
@@ -64,31 +51,39 @@ def test_df_to_csv():
 
     fileio.df_to_csv(df, csv_name)
 
-    assert os.path.exists(csv_name), ('No csv created.')
+    assert os.path.exists(csv_name), "No csv created."
 
     # Check that notes were written correctly
-    with open(csv_name, 'r') as csv_file:
+    with open(csv_name, "r") as csv_file:
         for i, line in enumerate(csv_file):
-            split = line.split(',')
-            assert int(split[0]) == notes[i]['onset'], ("Onset time of "
-                   f"note {i} ({notes[i]}) not equal to csv's written onset "
-                   f"time of {int(split[0])}")
+            split = line.split(",")
+            assert int(split[0]) == notes[i]["onset"], (
+                "Onset time of "
+                f"note {i} ({notes[i]}) not equal to csv's written onset "
+                f"time of {int(split[0])}"
+            )
             assert split[1].isdigit(), f"Track {split[1]} is not an int."
-            assert int(split[1]) == notes[i]['track'], ("Track of "
-                   f"note {i} ({notes[i]}) not equal to csv's written track "
-                   f"of {int(split[1])}")
+            assert int(split[1]) == notes[i]["track"], (
+                "Track of "
+                f"note {i} ({notes[i]}) not equal to csv's written track "
+                f"of {int(split[1])}"
+            )
             assert split[2].isdigit(), f"Pitch {split[2]} is not an int."
-            assert int(split[2]) == notes[i]['pitch'], ("Pitch of "
-                   f"note {i} ({notes[i]}) not equal to csv's written pitch "
-                   f"of {int(split[2])}")
-            assert int(split[3]) == notes[i]['dur'], ("Duration of "
-                   f"note {i} ({notes[i]}) not equal to csv's written "
-                   f"duration of {int(split[3])}")
+            assert int(split[2]) == notes[i]["pitch"], (
+                "Pitch of "
+                f"note {i} ({notes[i]}) not equal to csv's written pitch "
+                f"of {int(split[2])}"
+            )
+            assert int(split[3]) == notes[i]["dur"], (
+                "Duration of "
+                f"note {i} ({notes[i]}) not equal to csv's written "
+                f"duration of {int(split[3])}"
+            )
 
     # Check writing without any directory
-    fileio.df_to_csv(df, 'test.csv')
+    fileio.df_to_csv(df, "test.csv")
     try:
-        os.remove('test.csv')
+        os.remove("test.csv")
     except:
         pass
 
@@ -106,44 +101,48 @@ def test_midi_to_df():
     midi_notes = []
     for i, instrument in enumerate(m.instruments):
         for note in instrument.notes:
-            midi_notes.append({'onset': int(round(note.start * 1000)),
-                               'track': i,
-                               'pitch': note.pitch,
-                               'dur': int(round(note.end * 1000) -
-                                          round(note.start * 1000))})
+            midi_notes.append(
+                {
+                    "onset": int(round(note.start * 1000)),
+                    "track": i,
+                    "pitch": note.pitch,
+                    "dur": int(round(note.end * 1000) - round(note.start * 1000)),
+                }
+            )
     midi_df = pd.DataFrame(midi_notes)
 
-    df_notes = df.to_dict('records')
+    df_notes = df.to_dict("records")
 
     # Test that all notes df notes are in the MIDI
     for df_note in df_notes:
-        assert df_note in midi_notes, (f"DataFrame note {df_note} not in " +
-                                       "list of MIDI notes from pretty_midi " +
-                                       "(or was duplicated).")
+        assert df_note in midi_notes, (
+            f"DataFrame note {df_note} not in "
+            + "list of MIDI notes from pretty_midi "
+            + "(or was duplicated)."
+        )
         midi_notes.remove(df_note)
 
     # Test that all MIDI notes were in the df
-    assert len(midi_notes) == 0, ("Some MIDI notes (from pretty_midi) were " +
-                                  f"not found in the DataFrame: {midi_notes}")
+    assert len(midi_notes) == 0, (
+        "Some MIDI notes (from pretty_midi) were "
+        + f"not found in the DataFrame: {midi_notes}"
+    )
 
     # Check clean_df (args, sorting)
     for (track, overlap) in itertools.product([False, True], repeat=2):
-        kwargs = {
-            'single_track': track,
-            'non_overlapping': overlap
-        }
+        kwargs = {"single_track": track, "non_overlapping": overlap}
 
         correct = clean_df(midi_df, **kwargs)
         res = fileio.midi_to_df(TEST_MID, **kwargs)
 
-        assert res.equals(correct), (
-            f"csv_to_midi not using args correctly with args={kwargs}"
-        )
+        assert res.equals(
+            correct
+        ), f"csv_to_midi not using args correctly with args={kwargs}"
 
 
 def test_midi_to_csv():
     # This method is just calls to midi_to_df and df_to_csv
-    csv_path = TEST_CACHE_PATH + os.path.sep + 'test.csv'
+    csv_path = TEST_CACHE_PATH + os.path.sep + "test.csv"
 
     try:
         os.remove(csv_path)
@@ -157,58 +156,64 @@ def test_midi_to_csv():
     midi_notes = []
     for i, instrument in enumerate(m.instruments):
         for note in instrument.notes:
-            midi_notes.append({'onset': int(round(note.start * 1000)),
-                               'track': i,
-                               'pitch': note.pitch,
-                               'dur': int(round(note.end * 1000) -
-                                          round(note.start * 1000))})
+            midi_notes.append(
+                {
+                    "onset": int(round(note.start * 1000)),
+                    "track": i,
+                    "pitch": note.pitch,
+                    "dur": int(round(note.end * 1000) - round(note.start * 1000)),
+                }
+            )
 
     # Check that notes were written correctly
-    with open(csv_path, 'r') as file:
+    with open(csv_path, "r") as file:
         for i, line in enumerate(file):
-            split = line.split(',')
-            note = {'onset': int(split[0]),
-                    'track': int(split[1]),
-                    'pitch': int(split[2]),
-                    'dur': int(split[3])}
-            assert note in midi_notes, (f"csv note {note} not in list " +
-                                        "of MIDI notes from pretty_midi " +
-                                        "(or was duplicated).")
+            split = line.split(",")
+            note = {
+                "onset": int(split[0]),
+                "track": int(split[1]),
+                "pitch": int(split[2]),
+                "dur": int(split[3]),
+            }
+            assert note in midi_notes, (
+                f"csv note {note} not in list "
+                + "of MIDI notes from pretty_midi "
+                + "(or was duplicated)."
+            )
             midi_notes.remove(note)
 
     # Test that all MIDI notes were in the df
-    assert len(midi_notes) == 0, ("Some MIDI notes (from pretty_midi) were "
-                                  f"not found in the DataFrame: {midi_notes}")
+    assert len(midi_notes) == 0, (
+        "Some MIDI notes (from pretty_midi) were "
+        f"not found in the DataFrame: {midi_notes}"
+    )
 
     # Some less robust tests regarding single_track and non_overlapping
     # (Robust versions will be in the *_to_df and df_to_* functions)
     midi_path = TEST_MID
-    csv_path = 'test.csv'
+    csv_path = "test.csv"
     for (track, overlap) in itertools.product([True, False], repeat=2):
-        kwargs = {
-            'single_track': track,
-            'non_overlapping': overlap
-        }
+        kwargs = {"single_track": track, "non_overlapping": overlap}
         fileio.midi_to_csv(midi_path, csv_path, **kwargs)
         df = fileio.csv_to_df(csv_path, **kwargs)
-        assert df.equals(fileio.midi_to_df(midi_path, **kwargs)), (
-            "midi_to_csv not using single_track and non_overlapping correctly."
-        )
+        assert df.equals(
+            fileio.midi_to_df(midi_path, **kwargs)
+        ), "midi_to_csv not using single_track and non_overlapping correctly."
 
     # Check writing without any directory
-    fileio.midi_to_csv(TEST_MID, 'test.csv')
+    fileio.midi_to_csv(TEST_MID, "test.csv")
     try:
-        os.remove('test.csv')
+        os.remove("test.csv")
     except:
         pass
 
 
 def test_midi_dir_to_csv():
-    basenames = ['test', 'test2', 'alb_se2']
+    basenames = ["test", "test2", "alb_se2"]
     midi_dir = os.path.dirname(TEST_MID)
-    midi_paths = [os.path.join(midi_dir, f'{name}.mid') for name in basenames]
+    midi_paths = [os.path.join(midi_dir, f"{name}.mid") for name in basenames]
     csv_dir = TEST_CACHE_PATH
-    csv_paths = [os.path.join(csv_dir, f'{name}.csv') for name in basenames]
+    csv_paths = [os.path.join(csv_dir, f"{name}.csv") for name in basenames]
 
     for csv_path in csv_paths:
         try:
@@ -216,7 +221,7 @@ def test_midi_dir_to_csv():
         except:
             pass
 
-    midi2_path = os.path.dirname(TEST_MID) + os.path.sep + 'test2.mid'
+    midi2_path = os.path.dirname(TEST_MID) + os.path.sep + "test2.mid"
     shutil.copyfile(TEST_MID, midi2_path)
 
     fileio.midi_dir_to_csv(midi_dir, csv_dir)
@@ -230,39 +235,45 @@ def test_midi_dir_to_csv():
     midi_notes2 = []
     for i, instrument in enumerate(m.instruments):
         for note in instrument.notes:
-            midi_notes.append({'onset': int(round(note.start * 1000)),
-                               'track': i,
-                               'pitch': note.pitch,
-                               'dur': int(round(note.end * 1000) -
-                                          round(note.start * 1000))})
+            midi_notes.append(
+                {
+                    "onset": int(round(note.start * 1000)),
+                    "track": i,
+                    "pitch": note.pitch,
+                    "dur": int(round(note.end * 1000) - round(note.start * 1000)),
+                }
+            )
             midi_notes2.append(midi_notes[-1])
 
     # Check that notes were written correctly
     for csv_path, notes in zip(csv_paths, [midi_notes, midi_notes2]):
-        with open(csv_path, 'r') as file:
+        with open(csv_path, "r") as file:
             for i, line in enumerate(file):
-                split = line.split(',')
-                note = {'onset': int(split[0]),
-                        'track': int(split[1]),
-                        'pitch': int(split[2]),
-                        'dur': int(split[3])}
-                assert note in notes, (f"csv note {note} not in list " +
-                                       "of MIDI notes from pretty_midi " +
-                                       "(or was duplicated).")
+                split = line.split(",")
+                note = {
+                    "onset": int(split[0]),
+                    "track": int(split[1]),
+                    "pitch": int(split[2]),
+                    "dur": int(split[3]),
+                }
+                assert note in notes, (
+                    f"csv note {note} not in list "
+                    + "of MIDI notes from pretty_midi "
+                    + "(or was duplicated)."
+                )
                 notes.remove(note)
 
     # Test that all MIDI notes were in the df
     for notes in [midi_notes, midi_notes2]:
-        assert len(notes) == 0, ("Some MIDI notes (from pretty_midi) were " +
-                                 f"not found in the DataFrame: {notes}")
+        assert len(notes) == 0, (
+            "Some MIDI notes (from pretty_midi) were "
+            + f"not found in the DataFrame: {notes}"
+        )
 
     # Some less robust tests regarding single_track and non_overlapping
     # (Robust versions will be in the *_to_df and df_to_* functions)
     for (track, overlap) in itertools.product([True, False], repeat=2):
-        kwargs = {
-            'single_track': track,
-            'non_overlapping': overlap
-        }
+        kwargs = {"single_track": track, "non_overlapping": overlap}
         fileio.midi_dir_to_csv(midi_dir, csv_dir, **kwargs)
         for midi_path, csv_path in zip(midi_paths, csv_paths):
             df = fileio.csv_to_df(csv_path, **kwargs)
@@ -275,102 +286,106 @@ def test_midi_dir_to_csv():
 
 
 def test_df_to_midi():
-    df = pd.DataFrame({
-        'onset': 0,
-        'track': [0, 0, 1],
-        'pitch': [10, 20, 30],
-        'dur': 1000
-    })
+    df = pd.DataFrame(
+        {"onset": 0, "track": [0, 0, 1], "pitch": [10, 20, 30], "dur": 1000}
+    )
 
     # Test basic writing
-    fileio.df_to_midi(df, 'test.mid')
-    assert fileio.midi_to_df('test.mid').equals(df), (
-        "Writing df to MIDI and reading changes df."
-    )
+    fileio.df_to_midi(df, "test.mid")
+    assert fileio.midi_to_df("test.mid").equals(
+        df
+    ), "Writing df to MIDI and reading changes df."
 
     # Test that writing should overwrite existing notes
     df.pitch += 10
-    fileio.df_to_midi(df, 'test2.mid', existing_midi_path='test.mid')
-    assert fileio.midi_to_df('test2.mid').equals(df), (
-        "Writing df to MIDI with existing MIDI does not overwrite notes."
-    )
+    fileio.df_to_midi(df, "test2.mid", existing_midi_path="test.mid")
+    assert fileio.midi_to_df("test2.mid").equals(
+        df
+    ), "Writing df to MIDI with existing MIDI does not overwrite notes."
 
     # Test that writing skips non-overwritten notes
-    fileio.df_to_midi(df, 'test2.mid', existing_midi_path='test.mid',
-                    excerpt_start=1000)
-    expected = pd.DataFrame({
-        'onset': [0, 0, 0, 1000, 1000, 1000],
-        'track': [0, 0, 1, 0, 0, 1],
-        'pitch': [10, 20, 30, 20, 30, 40],
-        'dur': 1000
-    })
-    assert fileio.midi_to_df('test2.mid').equals(expected), (
-        "Writing to MIDI doesn't copy notes before excerpt_start"
+    fileio.df_to_midi(
+        df, "test2.mid", existing_midi_path="test.mid", excerpt_start=1000
     )
+    expected = pd.DataFrame(
+        {
+            "onset": [0, 0, 0, 1000, 1000, 1000],
+            "track": [0, 0, 1, 0, 0, 1],
+            "pitch": [10, 20, 30, 20, 30, 40],
+            "dur": 1000,
+        }
+    )
+    assert fileio.midi_to_df("test2.mid").equals(
+        expected
+    ), "Writing to MIDI doesn't copy notes before excerpt_start"
 
     # Test that writing skips non-overwritten notes past end
-    fileio.df_to_midi(df, 'test.mid', existing_midi_path='test2.mid',
-                    excerpt_length=1000)
-    expected = pd.DataFrame({
-        'onset': [0, 0, 0, 1000, 1000, 1000],
-        'track': [0, 0, 1, 0, 0, 1],
-        'pitch': [20, 30, 40, 20, 30, 40],
-        'dur': 1000
-    })
-    assert fileio.midi_to_df('test.mid').equals(expected), (
-        "Writing to MIDI doesn't copy notes after excerpt_length"
+    fileio.df_to_midi(
+        df, "test.mid", existing_midi_path="test2.mid", excerpt_length=1000
     )
+    expected = pd.DataFrame(
+        {
+            "onset": [0, 0, 0, 1000, 1000, 1000],
+            "track": [0, 0, 1, 0, 0, 1],
+            "pitch": [20, 30, 40, 20, 30, 40],
+            "dur": 1000,
+        }
+    )
+    assert fileio.midi_to_df("test.mid").equals(
+        expected
+    ), "Writing to MIDI doesn't copy notes after excerpt_length"
 
     df.track = 2
-    fileio.df_to_midi(df, 'test.mid', existing_midi_path='test2.mid',
-                    excerpt_length=1000)
-    expected = pd.DataFrame({
-        'onset': [0, 0, 0, 1000, 1000, 1000],
-        'track': [2, 2, 2, 0, 0, 1],
-        'pitch': [20, 30, 40, 20, 30, 40],
-        'dur': 1000
-    })
-    assert fileio.midi_to_df('test.mid').equals(expected), (
-        "Writing to MIDI with extra track breaks"
+    fileio.df_to_midi(
+        df, "test.mid", existing_midi_path="test2.mid", excerpt_length=1000
     )
+    expected = pd.DataFrame(
+        {
+            "onset": [0, 0, 0, 1000, 1000, 1000],
+            "track": [2, 2, 2, 0, 0, 1],
+            "pitch": [20, 30, 40, 20, 30, 40],
+            "dur": 1000,
+        }
+    )
+    assert fileio.midi_to_df("test.mid").equals(
+        expected
+    ), "Writing to MIDI with extra track breaks"
 
     # Check all non-note events
-    midi_obj = pretty_midi.PrettyMIDI('test.mid')
-    midi_obj.instruments[0].name = 'test'
+    midi_obj = pretty_midi.PrettyMIDI("test.mid")
+    midi_obj.instruments[0].name = "test"
     midi_obj.instruments[0].program = 100
     midi_obj.instruments[0].is_drum = True
     midi_obj.instruments[0].pitch_bends.append(pretty_midi.PitchBend(10, 0))
-    midi_obj.instruments[0].control_changes.append(
-        pretty_midi.ControlChange(10, 10, 0)
-    )
+    midi_obj.instruments[0].control_changes.append(pretty_midi.ControlChange(10, 10, 0))
     midi_obj.lyrics.append(pretty_midi.Lyric("test", 0))
     midi_obj.time_signature_changes.append(pretty_midi.TimeSignature(2, 4, 1))
     midi_obj.key_signature_changes.append(pretty_midi.KeySignature(5, 1))
-    midi_obj.write('test.mid')
+    midi_obj.write("test.mid")
 
-    fileio.df_to_midi(expected, 'test2.mid', existing_midi_path='test.mid')
-    assert fileio.midi_to_df('test2.mid').equals(expected)
+    fileio.df_to_midi(expected, "test2.mid", existing_midi_path="test.mid")
+    assert fileio.midi_to_df("test2.mid").equals(expected)
 
     # Check non-note events and data here
-    new_midi = pretty_midi.PrettyMIDI('test2.mid')
+    new_midi = pretty_midi.PrettyMIDI("test2.mid")
 
-    for instrument, new_instrument in zip(midi_obj.instruments,
-                                          new_midi.instruments):
+    for instrument, new_instrument in zip(midi_obj.instruments, new_midi.instruments):
         assert instrument.name == new_instrument.name
         assert instrument.program == new_instrument.program
         assert instrument.is_drum == new_instrument.is_drum
-        for pb, new_pb in zip(instrument.pitch_bends,
-                              new_instrument.pitch_bends):
+        for pb, new_pb in zip(instrument.pitch_bends, new_instrument.pitch_bends):
             assert pb.pitch == new_pb.pitch
             assert pb.time == new_pb.time
-        for cc, new_cc in zip(instrument.control_changes,
-                              new_instrument.control_changes):
+        for cc, new_cc in zip(
+            instrument.control_changes, new_instrument.control_changes
+        ):
             assert cc.number == new_cc.number
             assert cc.value == new_cc.value
             assert cc.time == new_cc.time
 
-    for ks, new_ks in zip(midi_obj.key_signature_changes,
-                          new_midi.key_signature_changes):
+    for ks, new_ks in zip(
+        midi_obj.key_signature_changes, new_midi.key_signature_changes
+    ):
         assert ks.key_number == new_ks.key_number
         assert ks.time == new_ks.time
 
@@ -378,13 +393,14 @@ def test_df_to_midi():
         assert lyric.text == new_lyric.text
         assert lyric.time == new_lyric.time
 
-    for ts, new_ts in zip(midi_obj.time_signature_changes,
-                          new_midi.time_signature_changes):
+    for ts, new_ts in zip(
+        midi_obj.time_signature_changes, new_midi.time_signature_changes
+    ):
         assert ts.numerator == new_ts.numerator
         assert ts.denominator == new_ts.denominator
         assert ts.time == new_ts.time
 
-    for filename in ['test.mid', 'test2.mid']:
+    for filename in ["test.mid", "test2.mid"]:
         try:
             os.remove(filename)
         except:
@@ -392,78 +408,81 @@ def test_df_to_midi():
 
 
 def test_csv_to_midi():
-    df = pd.DataFrame({
-        'onset': 0,
-        'track': [0, 0, 1],
-        'pitch': [10, 20, 30],
-        'dur': 1000
-    })
-    fileio.df_to_csv(df, 'test.csv')
+    df = pd.DataFrame(
+        {"onset": 0, "track": [0, 0, 1], "pitch": [10, 20, 30], "dur": 1000}
+    )
+    fileio.df_to_csv(df, "test.csv")
 
     # Test basic writing
-    fileio.csv_to_midi('test.csv', 'test.mid')
-    assert fileio.midi_to_df('test.mid').equals(df), (
-        "Writing df to MIDI and reading changes df."
-    )
+    fileio.csv_to_midi("test.csv", "test.mid")
+    assert fileio.midi_to_df("test.mid").equals(
+        df
+    ), "Writing df to MIDI and reading changes df."
 
     # Test that writing should overwrite existing notes
     df.pitch += 10
-    fileio.df_to_csv(df, 'test.csv')
-    fileio.csv_to_midi('test.csv', 'test2.mid', existing_midi_path='test.mid')
-    assert fileio.midi_to_df('test2.mid').equals(df), (
-        "Writing df to MIDI with existing MIDI does not overwrite notes."
-    )
+    fileio.df_to_csv(df, "test.csv")
+    fileio.csv_to_midi("test.csv", "test2.mid", existing_midi_path="test.mid")
+    assert fileio.midi_to_df("test2.mid").equals(
+        df
+    ), "Writing df to MIDI with existing MIDI does not overwrite notes."
 
     # Test that writing skips non-overwritten notes
-    fileio.csv_to_midi('test.csv', 'test2.mid', existing_midi_path='test.mid',
-                     excerpt_start=1000)
-    expected = pd.DataFrame({
-        'onset': [0, 0, 0, 1000, 1000, 1000],
-        'track': [0, 0, 1, 0, 0, 1],
-        'pitch': [10, 20, 30, 20, 30, 40],
-        'dur': 1000
-    })
-    assert fileio.midi_to_df('test2.mid').equals(expected), (
-        "Writing to MIDI doesn't copy notes before excerpt_start"
+    fileio.csv_to_midi(
+        "test.csv", "test2.mid", existing_midi_path="test.mid", excerpt_start=1000
     )
+    expected = pd.DataFrame(
+        {
+            "onset": [0, 0, 0, 1000, 1000, 1000],
+            "track": [0, 0, 1, 0, 0, 1],
+            "pitch": [10, 20, 30, 20, 30, 40],
+            "dur": 1000,
+        }
+    )
+    assert fileio.midi_to_df("test2.mid").equals(
+        expected
+    ), "Writing to MIDI doesn't copy notes before excerpt_start"
 
     # Test that writing skips non-overwritten notes past end
-    fileio.csv_to_midi('test.csv', 'test.mid', existing_midi_path='test2.mid',
-                    excerpt_length=1000)
-    expected = pd.DataFrame({
-        'onset': [0, 0, 0, 1000, 1000, 1000],
-        'track': [0, 0, 1, 0, 0, 1],
-        'pitch': [20, 30, 40, 20, 30, 40],
-        'dur': 1000
-    })
-    assert fileio.midi_to_df('test.mid').equals(expected), (
-        "Writing to MIDI doesn't copy notes after excerpt_length"
+    fileio.csv_to_midi(
+        "test.csv", "test.mid", existing_midi_path="test2.mid", excerpt_length=1000
     )
+    expected = pd.DataFrame(
+        {
+            "onset": [0, 0, 0, 1000, 1000, 1000],
+            "track": [0, 0, 1, 0, 0, 1],
+            "pitch": [20, 30, 40, 20, 30, 40],
+            "dur": 1000,
+        }
+    )
+    assert fileio.midi_to_df("test.mid").equals(
+        expected
+    ), "Writing to MIDI doesn't copy notes after excerpt_length"
 
     df.track = 2
-    fileio.df_to_csv(df, 'test.csv')
-    fileio.csv_to_midi('test.csv', 'test.mid', existing_midi_path='test2.mid',
-                     excerpt_length=1000)
-    expected = pd.DataFrame({
-        'onset': [0, 0, 0, 1000, 1000, 1000],
-        'track': [2, 2, 2, 0, 0, 1],
-        'pitch': [20, 30, 40, 20, 30, 40],
-        'dur': 1000
-    })
-    assert fileio.midi_to_df('test.mid').equals(expected), (
-        "Writing to MIDI with extra track breaks"
+    fileio.df_to_csv(df, "test.csv")
+    fileio.csv_to_midi(
+        "test.csv", "test.mid", existing_midi_path="test2.mid", excerpt_length=1000
     )
+    expected = pd.DataFrame(
+        {
+            "onset": [0, 0, 0, 1000, 1000, 1000],
+            "track": [2, 2, 2, 0, 0, 1],
+            "pitch": [20, 30, 40, 20, 30, 40],
+            "dur": 1000,
+        }
+    )
+    assert fileio.midi_to_df("test.mid").equals(
+        expected
+    ), "Writing to MIDI with extra track breaks"
 
-    csv_path = 'test.csv'
-    midi_path = 'test.mid'
+    csv_path = "test.csv"
+    midi_path = "test.mid"
     fileio.df_to_csv(CLEAN_INPUT_DF, csv_path)
     # Some less robust tests regarding single_track and non_overlapping
     # (Robust versions will be in the *_to_df and df_to_* functions)
     for (track, overlap) in itertools.product([False, True], repeat=2):
-        kwargs = {
-            'single_track': track,
-            'non_overlapping': overlap
-        }
+        kwargs = {"single_track": track, "non_overlapping": overlap}
 
         df = fileio.csv_to_df(csv_path, **kwargs)
         fileio.df_to_midi(df, midi_path)
@@ -472,11 +491,11 @@ def test_csv_to_midi():
         fileio.csv_to_midi(csv_path, midi_path, **kwargs)
         res = fileio.midi_to_df(midi_path)
 
-        assert res.equals(correct), (
-            f"csv_to_midi not using args correctly with args={kwargs}"
-        )
+        assert res.equals(
+            correct
+        ), f"csv_to_midi not using args correctly with args={kwargs}"
 
-    for filename in ['test.mid', 'test2.mid', 'test.csv']:
+    for filename in ["test.mid", "test2.mid", "test.csv"]:
         try:
             os.remove(filename)
         except:

--- a/mdtk/tests/test_fileio.py
+++ b/mdtk/tests/test_fileio.py
@@ -18,7 +18,7 @@ ALB_MID = f"{MIDI_PATH}{os.path.sep}alb_se2.mid"
 
 
 def test_midi_rounding():
-    df = fileio.midi_to_df(ALB_MID)
+    _ = fileio.midi_to_df(ALB_MID)
 
 
 def test_csv_to_df():
@@ -46,7 +46,7 @@ def test_df_to_csv():
     csv_name = os.path.join(TEST_CACHE_PATH, "tmp_dir", "test.csv")
     try:
         os.removedirs(csv_name)
-    except:
+    except Exception:
         pass
 
     fileio.df_to_csv(df, csv_name)
@@ -84,12 +84,12 @@ def test_df_to_csv():
     fileio.df_to_csv(df, "test.csv")
     try:
         os.remove("test.csv")
-    except:
+    except Exception:
         pass
 
     try:
         os.removedirs(csv_name)
-    except:
+    except Exception:
         pass
 
 
@@ -146,7 +146,7 @@ def test_midi_to_csv():
 
     try:
         os.remove(csv_path)
-    except:
+    except Exception:
         pass
 
     fileio.midi_to_csv(TEST_MID, csv_path)
@@ -204,7 +204,7 @@ def test_midi_to_csv():
     fileio.midi_to_csv(TEST_MID, "test.csv")
     try:
         os.remove("test.csv")
-    except:
+    except Exception:
         pass
 
 
@@ -218,7 +218,7 @@ def test_midi_dir_to_csv():
     for csv_path in csv_paths:
         try:
             os.remove(csv_path)
-        except:
+        except Exception:
             pass
 
     midi2_path = os.path.dirname(TEST_MID) + os.path.sep + "test2.mid"
@@ -403,7 +403,7 @@ def test_df_to_midi():
     for filename in ["test.mid", "test2.mid"]:
         try:
             os.remove(filename)
-        except:
+        except Exception:
             pass
 
 
@@ -498,5 +498,5 @@ def test_csv_to_midi():
     for filename in ["test.mid", "test2.mid", "test.csv"]:
         try:
             os.remove(filename)
-        except:
+        except Exception:
             pass

--- a/measure_errors.py
+++ b/measure_errors.py
@@ -3,23 +3,26 @@
 a degraded MIDI dataset with the given proportions of degradations."""
 import argparse
 import glob
-import os
-import pandas as pd
-import pickle
-import numpy as np
-import warnings
 import json
+import os
+import pickle
+import warnings
 
+import numpy as np
+import pandas as pd
 import pretty_midi
 from tqdm import tqdm
 
 from mdtk import degradations, fileio, formatters
-from mdtk.degradations import (MAX_GAP_DEFAULT, MIN_SHIFT_DEFAULT,
-                               MIN_PITCH_DEFAULT, MAX_PITCH_DEFAULT,
-                               DEGRADATIONS)
+from mdtk.degradations import (
+    DEGRADATIONS,
+    MAX_GAP_DEFAULT,
+    MAX_PITCH_DEFAULT,
+    MIN_PITCH_DEFAULT,
+    MIN_SHIFT_DEFAULT,
+)
 
-FILE_TYPES = ['mid', 'pkl', 'csv']
-
+FILE_TYPES = ["mid", "pkl", "csv"]
 
 
 def get_df_excerpt(note_df, start_time, end_time):
@@ -54,18 +57,20 @@ def get_df_excerpt(note_df, start_time, end_time):
     note_df = note_df.copy()
 
     # Move onsets of notes which lie before start (and finish after start)
-    need_to_shift = ((note_df.onset < start_time) &
-                     (note_df.onset + note_df.dur > start_time))
-    shift_amt = start_time - note_df.loc[need_to_shift, 'onset']
-    note_df.loc[need_to_shift, 'onset'] = start_time
-    note_df.loc[need_to_shift, 'dur'] -= shift_amt
+    need_to_shift = (note_df.onset < start_time) & (
+        note_df.onset + note_df.dur > start_time
+    )
+    shift_amt = start_time - note_df.loc[need_to_shift, "onset"]
+    note_df.loc[need_to_shift, "onset"] = start_time
+    note_df.loc[need_to_shift, "dur"] -= shift_amt
 
     # Shorten notes which go past end time
     if end_time is not None:
-        need_to_shorten = ((note_df.onset < end_time) &
-                           (note_df.onset + note_df.dur > end_time))
-        note_df.loc[need_to_shorten, 'dur'] = (
-            end_time - note_df.loc[need_to_shorten, 'onset']
+        need_to_shorten = (note_df.onset < end_time) & (
+            note_df.onset + note_df.dur > end_time
+        )
+        note_df.loc[need_to_shorten, "dur"] = (
+            end_time - note_df.loc[need_to_shorten, "onset"]
         )
 
     # Drop notes which lie outside of bounds
@@ -76,8 +81,12 @@ def get_df_excerpt(note_df, start_time, end_time):
     return note_df
 
 
-def load_file(filename, pr_min_pitch=MIN_PITCH_DEFAULT,
-              pr_max_pitch=MAX_PITCH_DEFAULT, pr_time_increment=40):
+def load_file(
+    filename,
+    pr_min_pitch=MIN_PITCH_DEFAULT,
+    pr_max_pitch=MAX_PITCH_DEFAULT,
+    pr_time_increment=40,
+):
     """
     Load the given filename into a pandas dataframe.
 
@@ -102,43 +111,48 @@ def load_file(filename, pr_min_pitch=MIN_PITCH_DEFAULT,
     """
     ext = os.path.splitext(os.path.basename(filename))[1]
 
-    if ext == '.mid':
+    if ext == ".mid":
         return fileio.midi_to_df(filename)
 
-    if ext == '.csv':
+    if ext == ".csv":
         return fileio.csv_to_df(filename)
 
-    if ext == '.pkl':
-        with open(filename, 'rb') as file:
+    if ext == ".pkl":
+        with open(filename, "rb") as file:
             pkl = pickle.load(file)
 
-        piano_roll = pkl['piano_roll']
+        piano_roll = pkl["piano_roll"]
 
         if piano_roll.shape[1] == (pr_min_pitch - pr_max_pitch + 1):
             # Normal piano roll only -- no onsets
             note_pr = piano_roll.astype(int)
-            onset_pr = ((np.roll(note_pr, 1, axis=0) - note_pr) == -1)
+            onset_pr = (np.roll(note_pr, 1, axis=0) - note_pr) == -1
             onset_pr[0] = note_pr[0]
             onset_pr = onset_pr.astype(int)
 
         elif piano_roll.shape[1] == 2 * (pr_min_pitch - pr_max_pitch + 1):
             # Piano roll with onsets
-            note_pr = piano_roll[:, :piano_roll.shape[1] / 2].astype(int)
-            onset_pr = piano_roll[:, piano_roll.shape[1] / 2:].astype(int)
+            note_pr = piano_roll[:, : piano_roll.shape[1] / 2].astype(int)
+            onset_pr = piano_roll[:, piano_roll.shape[1] / 2 :].astype(int)
 
         else:
-            raise ValueError("Piano roll dimension 2 size ("
-                             f"{piano_roll.shape[1]}) must be equal to 1 or 2"
-                             f" times the given pitch range [{pr_min_pitch} - "
-                             f"{pr_max_pitch}] = "
-                             f"{pr_min_pitch - pr_max_pitch + 1}")
+            raise ValueError(
+                "Piano roll dimension 2 size ("
+                f"{piano_roll.shape[1]}) must be equal to 1 or 2"
+                f" times the given pitch range [{pr_min_pitch} - "
+                f"{pr_max_pitch}] = "
+                f"{pr_min_pitch - pr_max_pitch + 1}"
+            )
 
         piano_roll = np.vstack((note_pr, onset_pr))
         return formatters.double_pianoroll_to_df(
-            piano_roll, min_pitch=pr_min_pitch, max_pitch=pr_max_pitch,
-            time_increment=pr_time_increment)
+            piano_roll,
+            min_pitch=pr_min_pitch,
+            max_pitch=pr_max_pitch,
+            time_increment=pr_time_increment,
+        )
 
-    raise NotImplementedError(f'Extension {ext} not supported.')
+    raise NotImplementedError(f"Extension {ext} not supported.")
 
 
 def merge_on_pitch(gt_df, trans_df, offset=True):
@@ -172,16 +186,18 @@ def merge_on_pitch(gt_df, trans_df, offset=True):
 
     # Pre-calculate offset time once
     if offset:
-        gt_df['offset'] = gt_df.onset + gt_df.dur
-        trans_df['offset'] = trans_df.onset + trans_df.dur
+        gt_df["offset"] = gt_df.onset + gt_df.dur
+        trans_df["offset"] = trans_df.onset + trans_df.dur
 
     # Merge notes with equal pitch -- keep all pairs
-    return trans_df.reset_index().merge(gt_df.reset_index(), on='pitch',
-                                        suffixes=('_trans', '_gt'))
+    return trans_df.reset_index().merge(
+        gt_df.reset_index(), on="pitch", suffixes=("_trans", "_gt")
+    )
 
 
-def get_correct_notes(gt_df, trans_df, max_onset_err=MIN_SHIFT_DEFAULT,
-                      max_offset_err=MIN_SHIFT_DEFAULT):
+def get_correct_notes(
+    gt_df, trans_df, max_onset_err=MIN_SHIFT_DEFAULT, max_offset_err=MIN_SHIFT_DEFAULT
+):
     """
     Get lists of the correctly transcribed notes' indices.
 
@@ -216,23 +232,21 @@ def get_correct_notes(gt_df, trans_df, max_onset_err=MIN_SHIFT_DEFAULT,
     merged_df = merge_on_pitch(gt_df, trans_df, offset=True)
 
     # Keep only notes close enough at onset and offset
-    merged_df['onset_diff'] = (
-        (merged_df.onset_trans - merged_df.onset_gt).abs()
-    )
+    merged_df["onset_diff"] = (merged_df.onset_trans - merged_df.onset_gt).abs()
     onset_close = merged_df.onset_diff < max_onset_err
     offset_close = (
-        (merged_df.offset_trans - merged_df.offset_gt).abs() <= max_offset_err
-    )
+        merged_df.offset_trans - merged_df.offset_gt
+    ).abs() <= max_offset_err
     merged_df = merged_df.loc[onset_close & offset_close]
 
     while len(merged_df) > 0:
         # Keep only match closest to correct onset
-        matched_notes = merged_df.loc[merged_df.groupby('index_gt')
-                                      ['onset_diff'].idxmin()]
+        matched_notes = merged_df.loc[
+            merged_df.groupby("index_gt")["onset_diff"].idxmin()
+        ]
 
         # Remove duplicate trans note matches
-        matched_notes = matched_notes.loc[~matched_notes.index_trans
-                                          .duplicated()]
+        matched_notes = matched_notes.loc[~matched_notes.index_trans.duplicated()]
 
         # Save matches
         correct_gt.extend(list(matched_notes.index_gt))
@@ -246,10 +260,13 @@ def get_correct_notes(gt_df, trans_df, max_onset_err=MIN_SHIFT_DEFAULT,
     return correct_gt, correct_trans
 
 
-
-def get_shifts(gt_df, trans_df, max_onset_err=MIN_SHIFT_DEFAULT,
-               max_offset_err=MIN_SHIFT_DEFAULT,
-               max_dur_err=MIN_SHIFT_DEFAULT):
+def get_shifts(
+    gt_df,
+    trans_df,
+    max_onset_err=MIN_SHIFT_DEFAULT,
+    max_offset_err=MIN_SHIFT_DEFAULT,
+    max_dur_err=MIN_SHIFT_DEFAULT,
+):
     """
     Get the shift degradations (onset, offset, time, pitch) of the
     given ground truth and transcription.
@@ -300,31 +317,26 @@ def get_shifts(gt_df, trans_df, max_onset_err=MIN_SHIFT_DEFAULT,
 
     # Save fully merged df
     merged_df = merge_on_pitch(gt_df, trans_df, offset=True)
-    merged_df['onset_diff'] = (
-        (merged_df.onset_trans - merged_df.onset_gt).abs()
-    )
-    merged_df['offset_diff'] = (
-        (merged_df.offset_trans - merged_df.offset_gt).abs()
-    )
-    merged_df['dur_diff'] = (
-        (merged_df.dur_trans - merged_df.dur_gt).abs()
-    )
+    merged_df["onset_diff"] = (merged_df.onset_trans - merged_df.onset_gt).abs()
+    merged_df["offset_diff"] = (merged_df.offset_trans - merged_df.offset_gt).abs()
+    merged_df["dur_diff"] = (merged_df.dur_trans - merged_df.dur_gt).abs()
 
     # First, check for time offset shifts
     # Onset is close enough
     match_df = merged_df.loc[merged_df.onset_diff <= max_onset_err]
     # Keep only match closest to correct onset
     match_df = match_df.loc[
-        match_df.index == match_df.groupby('index_gt')['onset_diff'].idxmin()[
-            match_df.index_gt
-        ]
+        match_df.index
+        == match_df.groupby("index_gt")["onset_diff"].idxmin()[match_df.index_gt]
     ]
     offset = dict(zip(match_df.index_gt, match_df.index_trans))
 
     # Filter offset shifts out of base dfs
     merged_df = merged_df.loc[
-        ~(merged_df.index_trans.isin(match_df.index_trans) |
-          merged_df.index_gt.isin(match_df.index_gt))
+        ~(
+            merged_df.index_trans.isin(match_df.index_trans)
+            | merged_df.index_gt.isin(match_df.index_gt)
+        )
     ].copy()
     gt_df = gt_df.drop(index=match_df.index_gt)
     trans_df = trans_df.drop(index=match_df.index_trans)
@@ -334,16 +346,17 @@ def get_shifts(gt_df, trans_df, max_onset_err=MIN_SHIFT_DEFAULT,
     match_df = merged_df.loc[merged_df.offset_diff <= max_offset_err]
     # Keep only match closest to correct offset
     match_df = match_df.loc[
-        match_df.index == match_df.groupby('index_gt')['offset_diff'].idxmin()[
-            match_df.index_gt
-        ]
+        match_df.index
+        == match_df.groupby("index_gt")["offset_diff"].idxmin()[match_df.index_gt]
     ]
     onset = dict(zip(match_df.index_gt, match_df.index_trans))
 
     # Filter onset shifts out of base dfs
     merged_df = merged_df.loc[
-        ~(merged_df.index_trans.isin(match_df.index_trans) |
-          merged_df.index_gt.isin(match_df.index_gt))
+        ~(
+            merged_df.index_trans.isin(match_df.index_trans)
+            | merged_df.index_gt.isin(match_df.index_gt)
+        )
     ].copy()
     gt_df = gt_df.drop(index=match_df.index_gt)
     trans_df = trans_df.drop(index=match_df.index_trans)
@@ -355,9 +368,8 @@ def get_shifts(gt_df, trans_df, max_onset_err=MIN_SHIFT_DEFAULT,
     match_df = match_df.loc[match_df.onset_diff <= match_df.dur_gt]
     # Keep only match shortest shift
     match_df = match_df.loc[
-        match_df.index == match_df.groupby('index_gt')['onset_diff'].idxmin()[
-            match_df.index_gt
-        ]
+        match_df.index
+        == match_df.groupby("index_gt")["onset_diff"].idxmin()[match_df.index_gt]
     ]
     time = dict(zip(match_df.index_gt, match_df.index_trans))
 
@@ -366,36 +378,33 @@ def get_shifts(gt_df, trans_df, max_onset_err=MIN_SHIFT_DEFAULT,
     trans_df = trans_df.drop(index=match_df.index_trans)
 
     # Fourth, check for pitch shifts
-    gt_df['offset'] = gt_df.onset + gt_df.dur
-    trans_df['offset'] = trans_df.onset + trans_df.dur
+    gt_df["offset"] = gt_df.onset + gt_df.dur
+    trans_df["offset"] = trans_df.onset + trans_df.dur
 
     # Looping is necesary because we only get 1 gt_note per trans note,
     # Although, each trans_note may be associated with multiple gt notes
     # at each iteration.
     while len(gt_df) and len(trans_df) > 0:
         # Find onset time closest to each gt note
-        gt_df['closest_onset_idx'] = gt_df.apply(
-            lambda x: (trans_df.onset - x.onset).abs().idxmin(),
-            axis=1
+        gt_df["closest_onset_idx"] = gt_df.apply(
+            lambda x: (trans_df.onset - x.onset).abs().idxmin(), axis=1
         )
-        gt_df['closest_onset'] = (
-            (trans_df.loc[gt_df.closest_onset_idx, 'onset'].to_numpy() -
-             gt_df.onset).abs()
-        )
+        gt_df["closest_onset"] = (
+            trans_df.loc[gt_df.closest_onset_idx, "onset"].to_numpy() - gt_df.onset
+        ).abs()
         # Here, gt_df will eventually become empty (to exit while loop)
         gt_df = gt_df.loc[gt_df.closest_onset <= max_onset_err]
 
         # Sort by closest onset, and then only take first of each trans_idx
-        gt_df = gt_df.sort_values(by='closest_onset')
-        pitch_df = gt_df.drop_duplicates(subset='closest_onset_idx')
+        gt_df = gt_df.sort_values(by="closest_onset")
+        pitch_df = gt_df.drop_duplicates(subset="closest_onset_idx")
 
         # Add to pitch shifts and also_offset
         pitch.update(zip(pitch_df.index, pitch_df.closest_onset_idx))
         offset_diff = (
-            pitch_df.offset - trans_df.loc[pitch_df.closest_onset_idx, 'offset']
+            pitch_df.offset - trans_df.loc[pitch_df.closest_onset_idx, "offset"]
         )
-        also_offset.extend(pitch_df.loc[offset_diff.abs() > max_offset_err]
-                           .index)
+        also_offset.extend(pitch_df.loc[offset_diff.abs() > max_offset_err].index)
 
         # Remove matches from gt_df and trans_df
         gt_df = gt_df.drop(index=pitch_df.index)
@@ -449,11 +458,12 @@ def get_joins(gt_df, trans_df, max_gap=MAX_GAP_DEFAULT):
 
     # Save only rows where notes overlap enough
     # Must overlap at least half of min(max gap, gt_duration)
-    overlap_start = merged_df[['onset_trans', 'onset_gt']].max(axis=1)
-    overlap_end = merged_df[['offset_trans', 'offset_gt']].min(axis=1)
-    merged_df['overlap_length'] = overlap_end - overlap_start
-    merged_df = merged_df.loc[merged_df.overlap_length >=
-                              0.5 * merged_df.dur_gt.clip(upper=max_gap)]
+    overlap_start = merged_df[["onset_trans", "onset_gt"]].max(axis=1)
+    overlap_end = merged_df[["offset_trans", "offset_gt"]].min(axis=1)
+    merged_df["overlap_length"] = overlap_end - overlap_start
+    merged_df = merged_df.loc[
+        merged_df.overlap_length >= 0.5 * merged_df.dur_gt.clip(upper=max_gap)
+    ]
 
     # Keep only trans notes with multiple overlapping gt notes
     merged_df = merged_df.loc[merged_df.index_trans.duplicated(keep=False)].copy()
@@ -468,39 +478,39 @@ def get_joins(gt_df, trans_df, max_gap=MAX_GAP_DEFAULT):
     # This allows us to find consecutive Trues based on having the same value here
     # Note that the last False before a True will be included in the cumsum group
     # The second line filters the Falses out, leaving only the Trues
-    merged_df['invalid_count'] = (~valid_note).cumsum()
+    merged_df["invalid_count"] = (~valid_note).cumsum()
     merged_df = merged_df.loc[valid_note].copy()
 
     # Now, group by trans note, and find each one's largest chunk of True
-    merged_df['largest_group_invalid_count'] = (
-        merged_df.groupby('index_trans')['invalid_count']
-            .transform(lambda x: x.value_counts().idxmax())
-    )
-    merged_df['largest_group_size'] = (
-        merged_df.groupby('index_trans')['invalid_count']
-            .transform(lambda x: x.value_counts().max())
-    )
+    merged_df["largest_group_invalid_count"] = merged_df.groupby("index_trans")[
+        "invalid_count"
+    ].transform(lambda x: x.value_counts().idxmax())
+    merged_df["largest_group_size"] = merged_df.groupby("index_trans")[
+        "invalid_count"
+    ].transform(lambda x: x.value_counts().max())
 
     # Select each one's largest group, if of size > 1
-    merged_df = merged_df.loc[(merged_df.invalid_count ==
-                               merged_df.largest_group_invalid_count) &
-                              (merged_df.largest_group_size > 1)].copy()
+    merged_df = merged_df.loc[
+        (merged_df.invalid_count == merged_df.largest_group_invalid_count)
+        & (merged_df.largest_group_size > 1)
+    ].copy()
 
     # Check for onset/offset shifts
-    merged_df['onset_close'] = ((merged_df.onset_trans - merged_df.onset_gt).abs()
-                                <= max_gap)
-    merged_df['offset_close'] = ((merged_df.offset_trans - merged_df.offset_gt).abs()
-                                 <= max_gap)
+    merged_df["onset_close"] = (
+        merged_df.onset_trans - merged_df.onset_gt
+    ).abs() <= max_gap
+    merged_df["offset_close"] = (
+        merged_df.offset_trans - merged_df.offset_gt
+    ).abs() <= max_gap
 
     # Generate output lists
-    for trans_id, trans_note_df in merged_df.groupby('index_trans'):
+    for trans_id, trans_note_df in merged_df.groupby("index_trans"):
         pre_joined_notes.append(list(trans_note_df.index_gt))
         post_joined_notes.append(trans_id)
         shift_onset.append(not trans_note_df.iloc[0].onset_close)
         shift_offset.append(not trans_note_df.iloc[-1].offset_close)
 
     return pre_joined_notes, post_joined_notes, shift_onset, shift_offset
-
 
 
 def get_splits(gt_df, trans_df, max_gap=MAX_GAP_DEFAULT):
@@ -542,12 +552,11 @@ def get_splits(gt_df, trans_df, max_gap=MAX_GAP_DEFAULT):
         join has been shifted (in addition to the split).
     """
     # Split is exactly reverse of a join
-    post_split_notes, pre_split_notes, shift_onset, shift_offset = (
-        get_joins(trans_df, gt_df, max_gap=max_gap)
+    post_split_notes, pre_split_notes, shift_onset, shift_offset = get_joins(
+        trans_df, gt_df, max_gap=max_gap
     )
 
     return pre_split_notes, post_split_notes, shift_onset, shift_offset
-
 
 
 def get_excerpt_degs(gt_excerpt, trans_excerpt):
@@ -577,52 +586,50 @@ def get_excerpt_degs(gt_excerpt, trans_excerpt):
     trans_excerpt = trans_excerpt.drop(index=correct_trans)
 
     # Check for joins
-    pre_joined_notes, post_joined_notes, shift_onset, shift_offset = (
-        get_joins(gt_excerpt, trans_excerpt)
+    pre_joined_notes, post_joined_notes, shift_onset, shift_offset = get_joins(
+        gt_excerpt, trans_excerpt
     )
-    deg_counts[list(DEGRADATIONS).index('join_notes')] = len(pre_joined_notes)
-    deg_counts[list(DEGRADATIONS).index('onset_shift')] = sum(shift_onset)
-    deg_counts[list(DEGRADATIONS).index('offset_shift')] = sum(shift_offset)
-    gt_excerpt = gt_excerpt.drop(index=[idx for join in pre_joined_notes
-                                        for idx in join])
+    deg_counts[list(DEGRADATIONS).index("join_notes")] = len(pre_joined_notes)
+    deg_counts[list(DEGRADATIONS).index("onset_shift")] = sum(shift_onset)
+    deg_counts[list(DEGRADATIONS).index("offset_shift")] = sum(shift_offset)
+    gt_excerpt = gt_excerpt.drop(
+        index=[idx for join in pre_joined_notes for idx in join]
+    )
     trans_excerpt = trans_excerpt.drop(index=post_joined_notes)
 
     # Check for splits
-    pre_split_notes, post_split_notes, shift_onset, shift_offset = (
-        get_splits(gt_excerpt, trans_excerpt)
+    pre_split_notes, post_split_notes, shift_onset, shift_offset = get_splits(
+        gt_excerpt, trans_excerpt
     )
-    deg_counts[list(DEGRADATIONS).index('split_note')] = len(pre_split_notes)
-    deg_counts[list(DEGRADATIONS).index('onset_shift')] += sum(shift_onset)
-    deg_counts[list(DEGRADATIONS).index('offset_shift')] += sum(shift_offset)
+    deg_counts[list(DEGRADATIONS).index("split_note")] = len(pre_split_notes)
+    deg_counts[list(DEGRADATIONS).index("onset_shift")] += sum(shift_onset)
+    deg_counts[list(DEGRADATIONS).index("offset_shift")] += sum(shift_offset)
     gt_excerpt = gt_excerpt.drop(index=pre_split_notes)
-    trans_excerpt = trans_excerpt.drop(index=[idx for split in post_split_notes
-                                              for idx in split])
+    trans_excerpt = trans_excerpt.drop(
+        index=[idx for split in post_split_notes for idx in split]
+    )
 
     # Shift degredation estimation (onset, offset, time, pitch)
-    onset, offset, time, pitch, also_offset = get_shifts(gt_excerpt,
-                                                         trans_excerpt)
-    deg_counts[list(DEGRADATIONS).index('onset_shift')] += len(onset)
-    deg_counts[list(DEGRADATIONS).index('offset_shift')] += (len(offset) +
-                                                             len(also_offset))
-    deg_counts[list(DEGRADATIONS).index('time_shift')] = len(time)
-    deg_counts[list(DEGRADATIONS).index('pitch_shift')] = len(pitch)
+    onset, offset, time, pitch, also_offset = get_shifts(gt_excerpt, trans_excerpt)
+    deg_counts[list(DEGRADATIONS).index("onset_shift")] += len(onset)
+    deg_counts[list(DEGRADATIONS).index("offset_shift")] += len(offset) + len(
+        also_offset
+    )
+    deg_counts[list(DEGRADATIONS).index("time_shift")] = len(time)
+    deg_counts[list(DEGRADATIONS).index("pitch_shift")] = len(pitch)
 
     total_shifts = len(onset) + len(offset) + len(time) + len(pitch)
 
     # Remainder are all adds and removes
-    deg_counts[list(DEGRADATIONS).index('add_note')] = (
-        len(trans_excerpt) - total_shifts
-    )
-    deg_counts[list(DEGRADATIONS).index('remove_note')] = (
-        len(gt_excerpt) - total_shifts
-    )
+    deg_counts[list(DEGRADATIONS).index("add_note")] = len(trans_excerpt) - total_shifts
+    deg_counts[list(DEGRADATIONS).index("remove_note")] = len(gt_excerpt) - total_shifts
 
     return deg_counts
 
 
-
-def get_proportions(gt, trans, trans_start=0, trans_end=None, length=5000,
-                    min_notes=10):
+def get_proportions(
+    gt, trans, trans_start=0, trans_end=None, length=5000, min_notes=10
+):
     """
     Get the proportion of each degradation given a ground truth file and
     its transcription.
@@ -680,8 +687,9 @@ def get_proportions(gt, trans, trans_start=0, trans_end=None, length=5000,
     elif len(trans_df) == 0:
         end_time = (gt_df.onset + gt_df.dur).max()
     else:
-        end_time = max((gt_df.onset + gt_df.dur).max(),
-                       (trans_df.onset + trans_df.dur).max())
+        end_time = max(
+            (gt_df.onset + gt_df.dur).max(), (trans_df.onset + trans_df.dur).max()
+        )
     # Take each excerpt from time 0 until the end
     for excerpt_start in range(0, end_time, length):
         excerpt_end = min(excerpt_start + length, end_time)
@@ -690,13 +698,15 @@ def get_proportions(gt, trans, trans_start=0, trans_end=None, length=5000,
 
         # Check for validity
         if len(gt_excerpt) < min_notes and len(trans_excerpt) < min_notes:
-            warnings.warn(f'Skipping excerpt {gt} for too few notes. '
-                          f'Time range = [{excerpt_start}, {excerpt_end}). '
-                          f'Try lowering the minimum note count --min-notes '
-                          f'(currently {min_notes}), or '
-                          'ignore this if it is just due to a song length '
-                          'not being divisible by the --excerpt-length '
-                          f'(currently {length}).')
+            warnings.warn(
+                f"Skipping excerpt {gt} for too few notes. "
+                f"Time range = [{excerpt_start}, {excerpt_end}). "
+                f"Try lowering the minimum note count --min-notes "
+                f"(currently {min_notes}), or "
+                "ignore this if it is just due to a song length "
+                "not being divisible by the --excerpt-length "
+                f"(currently {length})."
+            )
             continue
 
         num_excerpts += 1
@@ -714,61 +724,105 @@ def get_proportions(gt, trans, trans_start=0, trans_end=None, length=5000,
     return proportions, clean
 
 
-
 def parse_args(args_input=None):
-    parser = argparse.ArgumentParser(description="Measure errors from a "
-                                     "transcription error in order to make "
-                                     "a degraded MIDI dataset with the measure"
-                                     " proportion of each degration.")
+    parser = argparse.ArgumentParser(
+        description="Measure errors from a "
+        "transcription error in order to make "
+        "a degraded MIDI dataset with the measure"
+        " proportion of each degration."
+    )
 
-    parser.add_argument("--json", help="The file to write the degradation config"
-                        " json data out to.", default="config.json")
-    parser.add_argument("-r", "--recursive", help="Search the given --gt and "
-                        "--trans directories recursively. The directory structures"
-                        " in each don't have to be identical, but corresponding "
-                        "files must still be uniquely named.", action="store_true")
+    parser.add_argument(
+        "--json",
+        help="The file to write the degradation config" " json data out to.",
+        default="config.json",
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        help="Search the given --gt and "
+        "--trans directories recursively. The directory structures"
+        " in each don't have to be identical, but corresponding "
+        "files must still be uniquely named.",
+        action="store_true",
+    )
 
-    parser.add_argument("--gt", help="The directory which contains the ground "
-                        "truth musical scores or piano rolls.", required=True)
-    parser.add_argument("--gt_ext", choices=FILE_TYPES, default=None,
-                        help="Restrict the file type for the ground truths.")
+    parser.add_argument(
+        "--gt",
+        help="The directory which contains the ground "
+        "truth musical scores or piano rolls.",
+        required=True,
+    )
+    parser.add_argument(
+        "--gt_ext",
+        choices=FILE_TYPES,
+        default=None,
+        help="Restrict the file type for the ground truths.",
+    )
 
-    parser.add_argument("--trans", help="The directory which contains the "
-                        "transcriptions.", required=True)
-    parser.add_argument("--trans_ext", choices=FILE_TYPES, default=None,
-                        help="Restrict the file type for the transcriptions.")
+    parser.add_argument(
+        "--trans",
+        help="The directory which contains the " "transcriptions.",
+        required=True,
+    )
+    parser.add_argument(
+        "--trans_ext",
+        choices=FILE_TYPES,
+        default=None,
+        help="Restrict the file type for the transcriptions.",
+    )
 
     # Pianoroll specific args
-    parser.add_argument("--pr-min-pitch", type=int, default=21,
-                        help="Minimum pianoroll pitch.")
-    parser.add_argument("--pr-max-pitch", type=int, default=108,
-                        help="Maximum pianoroll pitch.")
+    parser.add_argument(
+        "--pr-min-pitch", type=int, default=21, help="Minimum pianoroll pitch."
+    )
+    parser.add_argument(
+        "--pr-max-pitch", type=int, default=108, help="Maximum pianoroll pitch."
+    )
 
     # Transcription doesn't have same time basis as ground truth
-    parser.add_argument("--trans_start", type=int, default=0, help="What time"
-                        " the transcription starts, in ms. Notes before this "
-                        "in the gt will be ignored, and all transcribed notes "
-                        "will be shifted forward by this amount.")
-    parser.add_argument("--trans_end", type=int, default=None, help="What time"
-                        "the transcription ends, in ms (if any). Notes after "
-                        "this in the gt will be ignored, and notes still on "
-                        "will be cut at this time.")
+    parser.add_argument(
+        "--trans_start",
+        type=int,
+        default=0,
+        help="What time"
+        " the transcription starts, in ms. Notes before this "
+        "in the gt will be ignored, and all transcribed notes "
+        "will be shifted forward by this amount.",
+    )
+    parser.add_argument(
+        "--trans_end",
+        type=int,
+        default=None,
+        help="What time"
+        "the transcription ends, in ms (if any). Notes after "
+        "this in the gt will be ignored, and notes still on "
+        "will be cut at this time.",
+    )
 
     # Excerpt arguments
-    parser.add_argument('--excerpt-length', metavar='ms', type=int,
-                        help='The length of the excerpt (in ms) to take from '
-                        'each piece. The excerpt will start on a note onset '
-                        'and include all notes whose onset lies within this '
-                        'number of ms after the first note.', default=5000)
-    parser.add_argument('--min-notes', metavar='N', type=int, default=10,
-                        help='The minimum number of notes required for an '
-                        'excerpt to be valid.')
+    parser.add_argument(
+        "--excerpt-length",
+        metavar="ms",
+        type=int,
+        help="The length of the excerpt (in ms) to take from "
+        "each piece. The excerpt will start on a note onset "
+        "and include all notes whose onset lies within this "
+        "number of ms after the first note.",
+        default=5000,
+    )
+    parser.add_argument(
+        "--min-notes",
+        metavar="N",
+        type=int,
+        default=10,
+        help="The minimum number of notes required for an " "excerpt to be valid.",
+    )
     args = parser.parse_args(args=args_input)
     return args
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parse_args()
 
     # Get allowed file extensions
@@ -776,13 +830,14 @@ if __name__ == '__main__':
     gt_ext = [args.gt_ext] if args.gt_ext is not None else FILE_TYPES
 
     if args.recursive:
-        args.trans = os.path.join(args.trans, '**')
-        args.gt = os.path.join(args.gt, '**')
+        args.trans = os.path.join(args.trans, "**")
+        args.gt = os.path.join(args.gt, "**")
 
     trans = []
     for ext in trans_ext:
-        trans.extend(glob.glob(os.path.join(args.trans, '*.' + ext),
-                               recursive=args.recursive))
+        trans.extend(
+            glob.glob(os.path.join(args.trans, "*." + ext), recursive=args.recursive)
+        )
 
     proportion = []
     clean_prop = []
@@ -793,25 +848,37 @@ if __name__ == '__main__':
         # Find gt file
         gt_list = []
         for ext in gt_ext:
-            gt_list.extend(glob.glob(os.path.join(args.gt, basename + '.' + ext),
-                                     recursive=args.recursive))
+            gt_list.extend(
+                glob.glob(
+                    os.path.join(args.gt, basename + "." + ext),
+                    recursive=args.recursive,
+                )
+            )
 
         if len(gt_list) == 0:
-            warnings.warn(f'No ground truth found for transcription {file}. Check'
-                          ' that the file extension --gt_ext is correct (or not '
-                          'given), and the dir --gt is correct. Searched for file'
-                          f' {basename}.{gt_ext} in dir {args.gt}.')
+            warnings.warn(
+                f"No ground truth found for transcription {file}. Check"
+                " that the file extension --gt_ext is correct (or not "
+                "given), and the dir --gt is correct. Searched for file"
+                f" {basename}.{gt_ext} in dir {args.gt}."
+            )
             continue
         elif len(gt_list) > 1:
-            warnings.warn(f'Multiple ground truths found for transcription {file}:'
-                          f'{gt_list}. Defaulting to the first one. Try narrowing '
-                          'down extensions with --gt_ext.')
+            warnings.warn(
+                f"Multiple ground truths found for transcription {file}:"
+                f"{gt_list}. Defaulting to the first one. Try narrowing "
+                "down extensions with --gt_ext."
+            )
         gt = gt_list[0]
 
-        prop, clean = get_proportions(gt, file, trans_start=args.trans_start,
-                                      trans_end=args.trans_end,
-                                      length=args.excerpt_length,
-                                      min_notes=args.min_notes)
+        prop, clean = get_proportions(
+            gt,
+            file,
+            trans_start=args.trans_start,
+            trans_end=args.trans_end,
+            length=args.excerpt_length,
+            min_notes=args.min_notes,
+        )
         if sum(prop) > 0:
             proportion.append(prop)
         if sum(prop) + clean > 0:
@@ -821,10 +888,9 @@ if __name__ == '__main__':
     proportion = np.mean(proportion, axis=0)
     clean = np.mean(clean_prop)
 
-    with open(args.json, 'w') as file:
+    with open(args.json, "w") as file:
         json.dump(
-            {
-                'degradation_dist': proportion.tolist(),
-                'clean_prop': clean
-            }, file, indent=4)
-
+            {"degradation_dist": proportion.tolist(), "clean_prop": clean},
+            file,
+            indent=4,
+        )

--- a/measure_errors.py
+++ b/measure_errors.py
@@ -9,11 +9,9 @@ import pickle
 import warnings
 
 import numpy as np
-import pandas as pd
-import pretty_midi
 from tqdm import tqdm
 
-from mdtk import degradations, fileio, formatters
+from mdtk import fileio, formatters
 from mdtk.degradations import (
     DEGRADATIONS,
     MAX_GAP_DEFAULT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,3 @@ exclude = '''
   | dist
 )/
 '''
-
-[flake8]
-max-line-length=88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+target_version = ['py37']
+line-length = 88
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
+[flake8]
+max-line-length=88

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,3 +65,4 @@ index_url = https://pypi.org/simple/
 
 [flake8]
 max-line-length = 88
+ignore = E203,W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,67 @@
+[metadata]
+name = mdtk
+version = 2019.06rc1
+licence = MIT
+url = https://github.com/JamesOwers/midi_degradation_toolkit
+author = James Owers
+author_email = james.f.owers@gmail.com
+keywords = MIDI ACME melody music dataset
+description = A toolkit for making Altered and Corrupted MIDI Excerpts (ACME datasets)
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    License :: MIT
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+
+[options]
+zip_safe = False
+include_package_data = True
+# please keep package list sorted
+# TODO: move matplotlib, mir_eval etc. into an eval option
+install_requires =
+    matplotlib
+    mir_eval
+    numpy
+    pandas
+    pretty_midi
+    seaborn
+    torch
+    tqdm
+python_requires =
+    ~=3.7
+packages = find:
+dependency_links =
+    https://github.com/craffel/pretty-midi/tarball/master#egg=0.2.8'
+
+[options.extras_require]
+# please keep package lists sorted
+dev =
+    %(docs)s
+    black
+    flake8
+    isort
+    ipykernel
+    jupyter_contrib_nbextensions
+    mypy
+    nodejs
+    pre-commit
+    pylint
+    pytest
+docs =
+    jupyterlab
+
+[bdist_wheel]
+universal = 0
+
 [aliases]
-test=pytest
+test = pytest
+
+[tool:pytest]
+testpaths = tests
+
+[easy_install]
+index_url = https://pypi.org/simple/
+
+[flake8]
+max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ universal = 0
 test = pytest
 
 [tool:pytest]
-testpaths = tests
+testpaths = mdtk/tests
 
 [easy_install]
 index_url = https://pypi.org/simple/

--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,4 @@
-"""Script for setuptools"""
+"""Script for setuptools."""
 import setuptools
 
-with open("README.md", "r") as fh:
-    LONG_DESCRIPTION = fh.read()
-
-setuptools.setup(
-    name="mdtk",
-    version="2019.06rc1",
-    author="James Owers",
-    author_email="james.f.owers@gmail.com",
-    description="A toolkit for creating datasets of Altered and Corrupted "
-                "MIDI Excerpts (ACME datasets)",
-    long_description=LONG_DESCRIPTION,
-    long_description_content_type="text/markdown",
-    keywords='MIDI ACME melody music dataset',
-    url="https://github.com/JamesOwers/midi_degradation_toolkit",
-    packages=setuptools.find_packages(),
-    install_requires=[
-        'numpy',
-        'pandas',
-        'matplotlib',
-        'tqdm',
-        'mir_eval',
-        'pretty_midi',
-        'torch',
-        'seaborn'
-    ],
-    python_requires='~=3.7',
-    classifiers=[
-        "Development Status :: 1 - Planning",
-        "Programming Language :: Python :: 3 :: Only",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Topic :: Multimedia :: Sound/Audio :: MIDI"
-    ],
-    dependency_links=['https://github.com/craffel/pretty-midi/tarball/'
-                      'master#egg=0.2.8'],
-    zip_safe=False,
-    setup_requires=["pytest-runner"],
-    tests_require=["pytest"]
-)
+setuptools.setup()


### PR DESCRIPTION
pre-commit hooks (if installed) are run every time you try to commit they check:
* the ordering of imports at the top of the file (`isort` configured in `.isort.cfg`)
* coding style conventions are followed (`black` configured in `pyproject.toml`)
* some pylint rules are adhered to (`flake8` configured in `setup.cfg`) e.g. no unused imports
* the process is configured in `.pre-commit-config.yaml` 

The black coding style is rigid, and I quite like that. If you really hate it then let me know! Basically, it insists on:
* Strings with double quotes
* A specific kind of line continuation within brackets
* spaces between shit

To check this change hasn't broken stuff, please may you:

1. Check the install instructions for both the standard install and with the `dev` option pass all tests
1. With the dev environment, try and commit things which are invalid to see how pre-commit hooks work.
