### PR TITLE
Fixes call to codecov after_success

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches:               # branch names that can post comment
+    - "master"

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,9 +2,9 @@
 source=mdtk
 [report]
 exclude_lines =
-    pragma: no cover
-    raise
-    except
-    register_parameter
-    warn
-    pass
+  pragma: no cover
+  raise
+  except
+  register_parameter
+  warn
+  pass

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -8,5 +8,5 @@ force_grid_wrap = 0
 use_parentheses = True
 ensure_newline_before_comments = True
 line_length = 88
-known_third_party = IPython,matplotlib,mir_eval,numpy,pandas,pretty_midi,seaborn,torch,tqdm
+known_third_party = IPython,matplotlib,mir_eval,numpy,pandas,pretty_midi,pytest,seaborn,torch,tqdm
 extend-ignore = E203, W503

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
 # command to install dependencies
 before_install:
   - python --version
+  - pip install codecov  # for the after_success command
 install:
   - pip install .
 # command to run tests - the required packages, pytest-runner, pytest, and pytest-cov


### PR DESCRIPTION
Currently, the call to `codecov` at the end of the continuous integration fails because codecov is not installed. This change ensures that travis installs codecov. 

Additional changes: formatting, and added .codecov.yml to configure the codecov comments on prs.