### PR TITLE
Params

### DIFF
--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -564,6 +564,42 @@ def test_pitch_shift(caplog):
     )
     assert res is not None
 
+    # Test align_pitch
+    for _ in range(10):
+        res = deg.pitch_shift(BASIC_DF, align_pitch=True)
+        assert len(res["pitch"].unique()) == len(BASIC_DF["pitch"].unique()) - 1
+
+        max_pitch = BASIC_DF["pitch"].max()
+        res = deg.pitch_shift(
+            BASIC_DF,
+            align_pitch=True,
+            min_pitch=max_pitch,
+        )
+        assert (
+            len(res.loc[res["pitch"] == max_pitch])
+            == len(BASIC_DF.loc[BASIC_DF["pitch"] == max_pitch]) + 1
+        )
+
+        min_pitch = BASIC_DF["pitch"].min()
+        res = deg.pitch_shift(
+            BASIC_DF, align_pitch=True, min_pitch=0, max_pitch=min_pitch
+        )
+        assert (
+            len(res.loc[res["pitch"] == min_pitch])
+            == len(BASIC_DF.loc[BASIC_DF["pitch"] == min_pitch]) + 1
+        )
+
+        distribution = np.zeros(21)
+        distribution[1] = 1
+        res = deg.pitch_shift(BASIC_DF, align_pitch=True, distribution=distribution)
+        assert_none(res, msg="pitch_shift with align_pitch and distribution wrong")
+        assert_warned(caplog)
+
+        distribution[0] = 1
+        distribution[-1] = 1
+        res = deg.pitch_shift(BASIC_DF, align_pitch=True, distribution=distribution)
+        assert len(res["pitch"].unique()) == len(BASIC_DF["pitch"].unique()) - 1
+
 
 def test_time_shift(caplog):
     assert_none(

--- a/mdtk/tests/test_degradations.py
+++ b/mdtk/tests/test_degradations.py
@@ -1466,6 +1466,36 @@ def test_add_note(caplog):
         "to full dataframe length."
     )
 
+    # Test pitch_distribution
+    for _ in range(10):
+        dist = np.zeros(500)
+        dist[1] = 1
+        dist[499] = 1
+        res = deg.add_note(BASIC_DF, pitch_distribution=dist)
+        assert_none(res)
+        assert_warned(caplog)
+
+        res = deg.add_note(BASIC_DF, min_pitch=1, pitch_distribution=dist)
+        assert res["pitch"].min() == 1
+
+        res = deg.add_note(BASIC_DF, max_pitch=499, pitch_distribution=dist)
+        assert res["pitch"].max() == 499
+
+        dist[45] = 1
+        res = deg.add_note(BASIC_DF, pitch_distribution=dist)
+        assert len(res.loc[res["pitch"] == 45]) == 1
+
+        res = deg.add_note(BASIC_DF, pitch_distribution=dist, align_pitch=True)
+        assert_none(res)
+        assert_warned(caplog)
+
+        dist[40] = 1
+        res = deg.add_note(BASIC_DF, pitch_distribution=dist, align_pitch=True)
+        assert (
+            len(res.loc[res["pitch"] == 40])
+            == len(BASIC_DF.loc[BASIC_DF["pitch"] == 40]) + 1
+        )
+
 
 def test_split_note(caplog):
     assert_none(


### PR DESCRIPTION
Fixes #164 

Specifically, adds (and tests) 3 parameters:
- `pitch_shift(abs_distribution)`, which can be used to give a distribution over all pitches, regardless of the chosen pitch. This value is multiplied by the corresponding relative distribution pitch and then re-normalized if both are given.
- `pitch_shift(align_pitch)`, which can be used to force the shifted pitch to align with an existing pitch.
- `add_note(pitch_distribution)`, which can be used to define a sample distribution over pitches for add_note.